### PR TITLE
[plugin.video.rtl2-now.de] 2.1.3

### DIFF
--- a/plugin.video.rtl2-now.de/addon.xml
+++ b/plugin.video.rtl2-now.de/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtl2-now.de" name="RTL II NOW" version="2.1.2" provider-name="bromix">
+<addon id="plugin.video.rtl2-now.de" name="RTL II NOW" version="2.1.3" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 	</requires>

--- a/plugin.video.rtl2-now.de/changelog.txt
+++ b/plugin.video.rtl2-now.de/changelog.txt
@@ -1,3 +1,6 @@
+2.1.3 (2015-03-22)
+UPD: skip DRM protected videos (HDS + Manifest +f4m)
+
 2.1.2 (2015-03-03)
 FIX: playback based on web-page changes
 

--- a/plugin.video.rtl2-now.de/resources/lib/rtlinteractive/client.py
+++ b/plugin.video.rtl2-now.de/resources/lib/rtlinteractive/client.py
@@ -231,6 +231,10 @@ class Client(object):
                 if metadaten and headerdaten:
                     raise UnsupportedStreamException
 
+                # No support for HDS MANIFEST
+                if re.search(r'http://.+/hds/.+/\d+/manifest-hds.f4m', filename.text):
+                    raise UnsupportedStreamException
+
                 rtmpe_match = re.search(r'(?P<url>rtmpe://(?:[^/]+/){2})(?P<play_path>.+)', filename.text)
                 hds_match = re.search(r'http://hds.+/(?P<play_path>\d+/.+)', filename.text)
                 if rtmpe_match:


### PR DESCRIPTION
UPD: skip DRM protected videos (HDS + Manifest +f4m)