### PR TITLE
[plugin.video.rts] 1.1.4

### DIFF
--- a/plugin.video.rts/addon.py
+++ b/plugin.video.rts/addon.py
@@ -7,7 +7,7 @@ import xbmcgui
 import urllib, urllib2
 from resources.lib import rtsProvider
 
-__addon__       = xbmcaddon.Addon(id='plugin.video.rts-video')
+__addon__       = xbmcaddon.Addon(id='plugin.video.rts')
 __addonname__   = __addon__.getAddonInfo('name')
 __icon__        = __addon__.getAddonInfo('icon')
  

--- a/plugin.video.rts/addon.xml
+++ b/plugin.video.rts/addon.xml
@@ -2,7 +2,7 @@
 <addon
    id="plugin.video.rts"
    name="RTS - Emissions TV"
-   version="1.1.3"
+   version="1.1.4"
    provider-name="Yttrium">
   <requires>
     <import addon="xbmc.python"                 version="2.1.0"/>

--- a/plugin.video.rts/changelog.txt
+++ b/plugin.video.rts/changelog.txt
@@ -1,3 +1,7 @@
+v1.1.4:
+- Fix xbmcaddon.Addon() call
+- Fix rss parsing on channel/item/description content when there is no img tag in
+
 v1.0:
 Première version stable.
 v0.3:

--- a/plugin.video.rts/resources/lib/rtsProvider.py
+++ b/plugin.video.rts/resources/lib/rtsProvider.py
@@ -6,6 +6,7 @@ import httplib
 from urlparse import urlparse
 from xml.dom.minidom import parse
 from bs4 import BeautifulSoup
+import bs4
 import re
 
 
@@ -45,9 +46,12 @@ class tvShow:
                 '',
                 item.getElementsByTagName('itunes:summary')[0].childNodes[0].data
             )
-            epImage = BeautifulSoup(
+            bsImg = BeautifulSoup(
                 item.getElementsByTagName('description')[0].childNodes[0].nodeValue
-            ).img[u'src'].replace('w=80&h=57','w=260&h=227')
+            ).img
+            ebImage = ''
+            if type(bsImg) is bs4.element.Tag:
+                epImage = bsImg[u'src'].replace('w=80&h=57','w=260&h=227')
             epPubDate = item.getElementsByTagName('pubDate')[0].childNodes[0].data
             epVidUrl = item.getElementsByTagName('enclosure')[0].attributes['url'].childNodes[0].data
             self.listOfEpisodes.append(


### PR DESCRIPTION
- Fix xbmcaddon.Addon() call (was preventing plugin run at least from 13.2)
- Fix rss parsing on channel/item/description content when there is no img tag in

PS: the source repository referenced in the add-on page http://kodi.wiki/view/Add-on:RTS_-_Emissions_TV was deleted so I started a new one at https://github.com/trepmag/plugin.video.rts.