### PR TITLE
[plugin.video.ntv-now.de] 2.2.2

### DIFF
--- a/plugin.video.ntv-now.de/addon.xml
+++ b/plugin.video.ntv-now.de/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.ntv-now.de" name="N-TV NOW" version="2.2.1" provider-name="bromix">
+<addon id="plugin.video.ntv-now.de" name="N-TV NOW" version="2.2.2" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 	</requires>
@@ -7,6 +7,7 @@
 		<provides>video</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
+        <broken>discontinued because of DRM protection</broken>
 		<summary lang="en">N-TV NOW media library</summary>
 		<summary lang="de">Mediathek für N-TV NOW</summary>
 		<description lang="en">With N-TV NOW many series, shows, documentaries and magazines can be seen from the program of N-TV.</description>

--- a/plugin.video.ntv-now.de/changelog.txt
+++ b/plugin.video.ntv-now.de/changelog.txt
@@ -1,3 +1,6 @@
+2.2.2 (2015-04-14)
+FIX: playback (based on DRM protection)
+
 2.2.1 (2015-04-03)
 UPD: new icons
 FIX: playback (based on DRM protection)

--- a/plugin.video.ntv-now.de/resources/lib/rtlinteractive/client.py
+++ b/plugin.video.ntv-now.de/resources/lib/rtlinteractive/client.py
@@ -129,13 +129,8 @@ class Client(object):
 
     @staticmethod
     def get_server_id():
-        """
-        For HDS streams we need a valid server id ('fms-fraXX'). We use the show 'n-tv Dokumentation' of
-        http://www.n-tvnow.de/ for all other NOW services (because the use all the same server).
-        :return:
-        """
-        client = Client(Client.CONFIG_NTV_NOW)
-        json_data = client.get_films(2033)
+        client = Client(Client.CONFIG_RTL_NOW)
+        json_data = client.get_films(2)
         film_list = json_data.get('result', {}).get('content', {}).get('filmlist', {})
         film_id = None
         for key in film_list:


### PR DESCRIPTION
# discontinued because of DRM protection

I added only the broken tag. I don't know if it's possible to support **Adobe Access** in the future...but for now this addon won't work. Maybe remove it completely from the gotham repo? (I would be okay with me)