### PR TITLE
[plugin.video.vox-now.de] 2.2.3

### DIFF
--- a/plugin.video.vox-now.de/addon.xml
+++ b/plugin.video.vox-now.de/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vox-now.de" name="VOX NOW" version="2.2.2" provider-name="bromix">
+<addon id="plugin.video.vox-now.de" name="VOX NOW" version="2.2.3" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.14.0"/>
 	</requires>
@@ -7,6 +7,7 @@
 		<provides>video</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
+        <broken>discontinued because of DRM protection</broken>
 		<summary lang="en">VOX NOW media library</summary>
 		<summary lang="de">Mediathek für VOX NOW</summary>
 		<description lang="en">With VOX NOW many series, shows, documentaries and magazines can be seen from the program of VOX.</description>


### PR DESCRIPTION
# discontinued because of DRM protection

I added only the broken tag because of no support of **Adobe Access**. The addon can be removed later.