### PR TITLE
[plugin.video.rtl-now.de] 3.0.1

### DIFF
--- a/plugin.video.rtl-now.de/addon.xml
+++ b/plugin.video.rtl-now.de/addon.xml
@@ -7,6 +7,8 @@
 		<provides>video</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
+        <broken lang="en">Development discontinued - Please use the successor NOW TV</broken>
+        <broken lang="de">Entwicklung eingestellt - Bitte nutzt den Nachfolger NOW TV</broken>
 		<summary lang="en">RTL NOW media library</summary>
 		<summary lang="de">Mediathek für RTL NOW</summary>
 		<description lang="en">With RTL NOW many series, shows, documentaries and magazines can be seen from the program of RTL.</description>

--- a/plugin.video.rtl-now.de/resources/lib/test/test_client.py
+++ b/plugin.video.rtl-now.de/resources/lib/test/test_client.py
@@ -24,8 +24,29 @@ class TestClient(unittest.TestCase):
 
     def test_get_films(self):
         client = rtlinteractive.Client(rtlinteractive.Client.CONFIG_RTL_NOW)
-        json_data = client.get_films(format_id=1061, page=1)
+        json_data = client.get_films(format_id=7956, page=1)
         self.assertTrue(json_data['success'])
+        pass
+
+    def test_get_formats_channel(self):
+        for i in range(899, 1000):
+            print '=== Testing "%d" ===' % i
+            config = rtlinteractive.Client.CONFIG_RTL_NOW
+            config['id'] = str(i)
+            client = rtlinteractive.Client(config)
+            json_data = client.get_formats()
+            result = json_data.get('result', {})
+            content = result.get('content', {})
+            format_list = content.get('formatlist', {})
+            for key in format_list:
+                format = format_list[key]
+                format_long = format.get('formatlong', '')
+                if format_long:
+                    print 'Format "%s"' % format_long
+                    pass
+                pass
+            print '=== Finished "%d" ===' % i
+            pass
         pass
 
     def test_get_formats(self):


### PR DESCRIPTION
Can be removed. The successor is NOW TV. After years the provider decided finally to merge all 6 channels to one big platform.