### PR TITLE
[plugin.video.vox-now.de] 3.0.1

### DIFF
--- a/plugin.video.vox-now.de/addon.xml
+++ b/plugin.video.vox-now.de/addon.xml
@@ -7,6 +7,8 @@
 		<provides>video</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
+        <broken lang="en">Development discontinued - Please use the successor NOW TV</broken>
+        <broken lang="de">Entwicklung eingestellt - Bitte nutzt den Nachfolger NOW TV</broken>
         <summary lang="en">VOX NOW media library</summary>
 		<summary lang="de">Mediathek für VOX NOW</summary>
 		<description lang="en">With VOX NOW many series, shows, documentaries and magazines can be seen from the program of VOX.</description>


### PR DESCRIPTION
Can be removed. The successor is NOW TV. After years the provider decided finally to merge all 6 channels to one big platform.