### PR TITLE
[plugin.video.cbsn] 1.0.5 mark as broken

### DIFF
--- a/plugin.video.cbsn/addon.xml
+++ b/plugin.video.cbsn/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cbsn"
        name="CBSN News Live"
-       version="1.0.4"
+       version="1.0.5"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
@@ -21,5 +21,6 @@
     <website>www.cbsn.com</website>
     <email></email>
     <source>https://github.com/learningit/plugin.video.cbsn</source>
+    <broken>To continue using the CBSN News addon, please upgrade your version of Kodi to Isengard or above</broken>
   </extension>
 </addon>


### PR DESCRIPTION
Mark CBSN addon 1.0.x as broken.