### PR TITLE
[plugin.audio.rne] 1.0.6

### DIFF
--- a/plugin.audio.rne/.gitignore
+++ b/plugin.audio.rne/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+*.mosquis
+*.new
+*.org

--- a/plugin.audio.rne/addon.xml
+++ b/plugin.audio.rne/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.audio.rne" name="RNE Podcasts" version="1.0.5" provider-name="Jose Antonio Montes (jamontes)">
+<addon id="plugin.audio.rne" name="RNE Podcasts" version="1.0.6" provider-name="Jose Antonio Montes (jamontes)">
     <requires>
         <import addon="xbmc.python" version="2.19.0"/>
     </requires>

--- a/plugin.audio.rne/changelog.txt
+++ b/plugin.audio.rne/changelog.txt
@@ -1,3 +1,5 @@
+1.0.6 (2016.04.11)
+- Got the direct channels back to their original source (credits: vicglez).
 1.0.5 (2016.02.14)
 - Quick fix for direct channels due to website changes.
 1.0.4 (2016.01.21)

--- a/plugin.audio.rne/resources/lib/rne_api.py
+++ b/plugin.audio.rne/resources/lib/rne_api.py
@@ -318,9 +318,9 @@ def get_audio_list(program_url, localized=lambda x: x):
 def get_direct_channels():
     """This function makes the direct channels menu."""
 
-    direct_url    = 'u3m.3pm.s%/evtr/moc.noitomulf.maerts.evtr.emf-s%//:ptth'[::-1]
+    direct_url    = 'u3m.s%/se.evtr.eviloidar//:ptth'[::-1]
     channel_list  = (
-            ( 'Radio Nacional',   'radio1'),
+            ( 'Radio Nacional',   'rne'),
             ( 'Radio Clásica',    'radioclasica'),
             ( 'Radio 3',          'radio3'),
             ( 'Ràdio 4',          'radio4'),
@@ -333,7 +333,7 @@ def get_direct_channels():
         menu_item = {
                 'action' : 'play_audio',
                 'title'  : channel,
-                'url'    : direct_url % (playlist, playlist),
+                'url'    : direct_url % playlist,
         }
         menu_entries.append(menu_item)
 
@@ -343,7 +343,7 @@ def get_direct_channels():
 def get_playable_url(url):
     """This function gets the stream url for direct channels."""
 
-    playable_url_pattern = ')3pm?*.ptth('[::-1]
+    playable_url_pattern = ')oidua.tsaceci?*.ptth('[::-1]
 
     buffer_url           = l.carga_web(url)
     stream_url           = l.find_first(buffer_url, playable_url_pattern)


### PR DESCRIPTION
Hi,
This is a new update for plugin.audio.rne over Helix branch.

Changelog:
1.0.6 (2016.04.11)
- Got the direct channels back to their original source (credits: vicglez).

Many thanks in advance and best regards,
jamontes.