### PR TITLE
[plugin.video.putiov2] deprecate

### DIFF
--- a/plugin.video.putiov2/addon.xml
+++ b/plugin.video.putiov2/addon.xml
@@ -18,6 +18,6 @@
         <description lang="en">Put.io is a service that combines cloud storage and bittorrent. You need an account to use this plug-in. Get one from https://put.io</description>
         <language></language>
         <license>GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007</license>
-        <broken>Add-on does not function properly</broken>
+        <broken>deprecated</broken>
     </extension>
 </addon>


### PR DESCRIPTION
This plugin is broken and deprecated. plugin.video.putio can be used instead.