### PR TITLE
[plugin.video.mediathek] 0.7.5

### DIFF
--- a/plugin.video.mediathek/default.py
+++ b/plugin.video.mediathek/default.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 
-import urllib,xbmc,os
+import urllib,xbmc,os,xbmcaddon
 from simplexbmc import SimpleXbmcGui
 from mediathek.factory import MediathekFactory
 __plugin__ = "mediathek"
 
-gui = SimpleXbmcGui();
+settings = xbmcaddon.Addon(id='plugin.video.mediathek');
+
+gui = SimpleXbmcGui(settings);
 
 def get_params():
   paramDict = {}
@@ -41,6 +43,10 @@ def get_params():
 params = get_params();
 mediathekName = params.get("type", "")
 action=params.get("action", "")
+
+DIR_HOME = xbmc.translatePath(settings.getAddonInfo("profile"))
+if not os.path.exists(DIR_HOME):
+  os.mkdir(DIR_HOME);
 
 gui.log("Quality: %s"%gui.quality);
 gui.log("argv[0]: %s"%sys.argv[0]);
@@ -89,6 +95,13 @@ else:
       mediathek.searchVideo(searchText);
     else:
       gui.back();
+  elif(action == "openJsonPath"):
+    path = params.get("path", "0");
+    callhash = params.get("callhash", "0");
+    mediathek.buildJsonMenu(path,callhash,0)
+  elif(action == "openJsonLink"):
+    link = urllib.unquote_plus(params.get("link", ""));
+    mediathek.playVideoFromJsonLink(link);
   else:
     if(mediathek.isSearchable()):
       gui.addSearchButton(mediathek);

--- a/plugin.video.mediathek/mediathek/__init__.py
+++ b/plugin.video.mediathek/mediathek/__init__.py
@@ -120,3 +120,16 @@ class Mediathek(object):
         self.gui.buildMenuLink(treeNode,self,len(self.menuTree)) 
     else:
       self.buildPageMenu(self.menuTree[0].link, 0);
+      
+  def walkJson(self, path, jsonObject):
+    path = path.split('.');
+    i = 0
+    while(i < len(path)):
+      if(type(jsonObject) is list):
+        index = int(path.pop(0));
+      else:
+        index = path.pop(0);
+      jsonObject = jsonObject[index];
+      
+    return jsonObject;
+      

--- a/plugin.video.mediathek/mediathek/arte.py
+++ b/plugin.video.mediathek/mediathek/arte.py
@@ -69,7 +69,7 @@ class ARTEMediathek(Mediathek):
     self.regex_VideoPageLinksHTML = re.compile("href=[\"'](http:\\\\/\\\\/www\\.arte\\.tv\\\\/guide\\\\/de\\\\/\d{6}-\d{3}/.+?)[\"']");
     self.regex_VideoPageLinksJSON = re.compile("\"url\":\"((http:\\\\/\\\\/www\\.arte\\.tv){0,1}\\\\/guide\\\\/de\\\\/\d{6}-\d{3}\\\\/.+?)\"");
     
-    self.regex_findVideoIds = re.compile("\"id\":\"(\d{6}-\d{3})(-A)\"");
+    self.regex_findVideoIds = re.compile("(\d{6}-\d{3})(-A)");
     
     self.regex_JSONPageLink = re.compile("http://arte.tv/papi/tvguide/videos/stream/player/D/\d{6}-\d{3}.+?/ALL/ALL.json");
     self.regex_JSON_VideoLink = re.compile("\"HTTP_MP4_.+?\":{.*?\"bitrate\":(\d+),.*?\"url\":\"(http://.*?.mp4)\".*?\"versionShortLibelle\":\"([a-zA-Z]{2})\".*?}");

--- a/plugin.video.mediathek/mediathek/zdf.py
+++ b/plugin.video.mediathek/mediathek/zdf.py
@@ -17,313 +17,146 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>. 
 import re,math,traceback,time
 from mediathek import *
-from xml.dom import minidom
-from xml.dom import Node;
+from datetime import datetime,timedelta
+import json
     
 class ZDFMediathek(Mediathek):
   def __init__(self, simpleXbmcGui):
     self.gui = simpleXbmcGui;
-    if(self.gui.preferedStreamTyp == 0):
-      self.baseType = "http_na_na";
-    elif (self.gui.preferedStreamTyp == 1):  
-      self.baseType = "rtmp_smil_http"
-    elif (self.gui.preferedStreamTyp == 2):
-      self.baseType ="mms_asx_http";
-    else:
-      self.baseType ="rtsp_mov_http";
+    
+    today = datetime.today();
     
     self.menuTree = (
-      TreeNode("0","Startseite","http://www.zdf.de/ZDFmediathek/hauptnavigation/startseite?flash=off",True,
-        (
-          TreeNode("0.0","Tipps","http://www.zdf.de/ZDFmediathek/hauptnavigation/startseite/tipps?flash=off",True),
-          TreeNode("0.1","Ganze Sendungen","http://www.zdf.de/ZDFmediathek/hauptnavigation/nachrichten/ganze-sendungen?flash=off",True),
-          TreeNode("0.2","Meist Gesehen","http://www.zdf.de/ZDFmediathek/hauptnavigation/nachrichten/meist-gesehen?flash=off",True)
-        )
-      ),
-      TreeNode("1","Nachrichten","http://www.zdf.de/ZDFmediathek/hauptnavigation/nachrichten?flash=off",True),
-      TreeNode("2","Sendung verpasst?","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst?flash=off",False,(
-          TreeNode("2.0","Heute","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day0?flash=off",True),
-          TreeNode("2.1","Gestern","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day1?flash=off",True),
-          TreeNode("2.2","vor 2 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day2?flash=off",True),
-          TreeNode("2.3","vor 3 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day3?flash=off",True),
-          TreeNode("2.4","vor 4 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day4?flash=off",True),
-          TreeNode("2.5","vor 5 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day5?flash=off",True),
-          TreeNode("2.6","vor 6 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day6?flash=off",True),
-          TreeNode("2.7","vor 7 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-verpasst/day7?flash=off",True),
-        )
-      ),
-      TreeNode("3","LIVE","http://www.zdf.de/ZDFmediathek/hauptnavigation/live?flash=off",False,(
-          TreeNode("3.0","Heute","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day0?flash=off",True),
-          TreeNode("3.1","Gestern","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day1?flash=off",True),
-          TreeNode("3.2","vor 2 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day2?flash=off",True),
-          TreeNode("3.3","vor 3 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day3?flash=off",True),
-          TreeNode("3.4","vor 4 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day4?flash=off",True),
-          TreeNode("3.5","vor 5 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day5?flash=off",True),
-          TreeNode("3.6","vor 6 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day6?flash=off",True),
-          TreeNode("3.7","vor 7 Tagen","http://www.zdf.de/ZDFmediathek/hauptnavigation/live/day7?flash=off",True),
-        )
-      ),
-      TreeNode("4","Sendungen A-Z","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z?flash=off",False,
-        (
-          TreeNode("4.0","ABC","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz0?flash=off",True),
-          TreeNode("4.1","DEF","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz1?flash=off",True),
-          TreeNode("4.2","GHI","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz2?flash=off",True),
-          TreeNode("4.3","JKL","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz3?flash=off",True),
-          TreeNode("4.4","MNO","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz4?flash=off",True),
-          TreeNode("4.5","PQRS","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz5?flash=off",True),
-          TreeNode("4.6","TUV","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz6?flash=off",True),
-          TreeNode("4.7","WXYZ","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz7?flash=off",True),
-          TreeNode("4.8","0-9","http://www.zdf.de/ZDFmediathek/hauptnavigation/sendung-a-bis-z/saz8?flash=off",True),
-        )
-      ),
-      TreeNode("5","Rubriken","http://www.zdf.de/ZDFmediathek/hauptnavigation/rubriken?flash=off",True),
-      TreeNode("6","Themen","http://www.zdf.de/ZDFmediathek/hauptnavigation/themen?flash=off",True),
+      TreeNode("0","Startseite","https://zdf-cdn.live.cellular.de/mediathekV2/start-page",True),
+      TreeNode("1","Kategorien","https://zdf-cdn.live.cellular.de/mediathekV2/categories",True),
+      TreeNode("2","Sendungen von A-Z","https://zdf-cdn.live.cellular.de/mediathekV2/brands-alphabetical",True),
+      TreeNode("3","Sendung verpasst?","",False,(
+        TreeNode("3.0","Heute","https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%(today.strftime("%Y-%m-%d")),True),
+        TreeNode("3.1","Gestern","https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=1)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.2","Vorgestern","https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=2)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.3",(today-timedelta(days=3)).strftime("%A"),"https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=3)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.4",(today-timedelta(days=4)).strftime("%A"),"https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=4)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.5",(today-timedelta(days=5)).strftime("%A"),"https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=5)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.6",(today-timedelta(days=6)).strftime("%A"),"https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=6)).strftime("%Y-%m-%d")),True),
+        TreeNode("3.7",(today-timedelta(days=7)).strftime("%A"),"https://zdf-cdn.live.cellular.de/mediathekV2/broadcast-missed/%s"%((today-timedelta(days=7)).strftime("%Y-%m-%d")),True),
+        )),
+      TreeNode("4","Live TV","https://zdf-cdn.live.cellular.de/mediathekV2/live-tv/%s"%(today.strftime("%Y-%m-%d")),True)
       );
-    regex_imageLink = "/ZDFmediathek/contentblob/\\d+/timg\\d+x\\d+blob/\\d+";
-    #ZDFmediathek/beitrag/live/
-    self.regex_videoPageLink = "/ZDFmediathek/beitrag/((video)|(live))/\\d+?/.*flash=off";
-    self.regex_topicPageLink = "/ZDFmediathek/((kanaluebersicht/aktuellste/\\d+.*)|(hauptnavigation/nachrichten/ganze-sendungen.*))flash=off";
-    
-    self._regex_extractTopicObject = re.compile("<li.*\\s*<div class=\"image\">\\s*<a href=\""+self.regex_topicPageLink+"\">\\s*<img src=\""+regex_imageLink+"\" title=\".*\" alt=\".*\"/>\\s*</a>\\s*</div>\\s*<div class=\"text\">\\s*<p( class=\".*\"){0,1}>\\s*<a href=\""+self.regex_topicPageLink+"\"( class=\"orangeUpper\"){0,1}>.*</a>\\s*</p>\\s*<p>\\s*<b>\\s*<a href=\""+self.regex_topicPageLink+"\">\\s*.*</a>");
-    self._regex_extractPageNavigation = re.compile("<a href=\""+self.regex_topicPageLink+"\" .*>.*?</a>");
-    
-    
-    self._regex_extractPictureLink = re.compile(regex_imageLink);
-    self._regex_extractPicSize = re.compile("\\d{2,4}x\\d{2,4}");
-    
-    self._regex_extractTopicPageLink = re.compile(self.regex_topicPageLink);    
-    self._regex_extractTopicTitle = re.compile("<a href=\"/ZDFmediathek/.*flash=off\".*>[^<].*</a>");
-    
-    self._regex_extractVideoPageLink = re.compile(self.regex_videoPageLink);
-    self._regex_extractVideoID = re.compile("/\\d+/");
-    self._regex_extractVideoLink = re.compile("");
-    self.replace_html = re.compile("<.*?>");
-    
-    self.rootLink = "http://www.zdf.de";
-    self.searchSite = "http://www.zdf.de/ZDFmediathek/suche?flash=off"
-    self.xmlService = "http://www.zdf.de/ZDFmediathek/xmlservice/web/beitragsDetails?id=%s&ak=web";
   @classmethod
   def name(self):
     return "ZDF";
     
   def isSearchable(self):
-    return True;
+    return False;
   
   def searchVideo(self, searchText):
-    self.gui.log("searchVideo: "+searchText);
-    values ={'sucheBtn.x':'25',
-             'sucheBtn.y':'8',
-             'sucheText': searchText}
-    mainPage = self.loadPage(self.searchSite,values);
-    videoPageLinks = list(self._regex_extractVideoPageLink.finditer(mainPage));
-    
-    self.initCount = 0;
-    self.countTopic = 0;
-    self.countVideo = len(videoPageLinks);
-    
-    self.extractVideoObjects(videoPageLinks);
+    return;
     
   def buildPageMenu(self, link, initCount):
     self.gui.log("buildPageMenu: "+link);
-    mainPage = self.loadPage(link);
+    jsonObject = json.loads(self.loadPage(link));
+    callhash = self.gui.storeJsonFile(jsonObject);
     
-    topicPageLinks = list(self._regex_extractTopicObject.finditer(mainPage));
-    videoPageLinks = list(self._regex_extractVideoPageLink.finditer(mainPage));
-    pageNavigation = list(self._regex_extractPageNavigation.finditer(mainPage));
-        
-    self.initCount = initCount;
-    self.countTopic = len(topicPageLinks)+len(pageNavigation);
-    self.countVideo = len(videoPageLinks);
+    if("stage" in jsonObject):
+      for stageObject in jsonObject["stage"]:
+        if(stageObject["type"]=="video"):
+          self.buildVideoLink(stageObject,initCount);
     
-    self.extractTopicObjects(topicPageLinks);
-    self.extractVideoObjects(videoPageLinks);
-    self.extractPageNavigation(pageNavigation);
-  
-  def extractPageNavigation(self, links):
-    for element in links:
-      element = element.group()
-      
-      title = self._regex_extractTopicTitle.search(element).group();
-      title = unicode(title,'UTF-8');
-      title = self.replace_html.sub("", title); #outerhtml wegschneiden
-      title = title.replace("&nbsp;", ""); #sinnlose "steuerzeichen wegschneiden"
-      
-      videoPageLink = self.rootLink+self._regex_extractTopicPageLink.search(element).group();
-      self.gui.buildVideoLink(DisplayObject(title,"","","",videoPageLink,False),self,self.getItemCount());
-  
-  def getItemCount(self):
-    return self.initCount + self.countTopic + self.countVideo;
+    if("cluster" in jsonObject):
+      for counter, clusterObject in enumerate(jsonObject["cluster"]):
+        if "teaser" in clusterObject and "name" in clusterObject:
+          path = "cluster.%d.teaser"%(counter)
+          self.gui.buildJsonLink(self,clusterObject["name"],path,callhash,initCount)
+    if("broadcastCluster" in jsonObject):
+      for counter, clusterObject in enumerate(jsonObject["broadcastCluster"]):
+        if clusterObject["type"].startswith("teaser") and "name" in clusterObject:
+          path = "broadcastCluster.%d.teaser"%(counter)
+          self.gui.buildJsonLink(self,clusterObject["name"],path,callhash,initCount)
+    if("epgCluster" in jsonObject):
+      for epgObject in jsonObject["epgCluster"]:
+        if("liveStream" in epgObject and len(epgObject["liveStream"])>0):
+          self.buildVideoLink(epgObject["liveStream"], initCount);
     
-  def extractVideoObjects(self,videoPageLinks):
-    lastID = -1;
-    videos = []
-    for pageLink in videoPageLinks:
-      self.gui.log("pageLink: "+pageLink.group());
-      videoID = self._regex_extractVideoID.search(pageLink.group()).group();
-      videoID = videoID.replace("/","");
-      if(not lastID == videoID):
-        self.gui.log("append VideoID: %s len: %d"%(videoID,len(videos)));
-        videos.append(videoID);
-        lastID = videoID;
-    
-    self.countVideo = len(videos);
-    self.gui.log("len %d"%(len(videos)));
-    for videoID in videos:
-      self.gui.log("decode VideoID: %s"%(videoID));
-      self.loadConfigXml(videoID);
-  
-  def loadConfigXml(self, videoID):
-    link = self.xmlService%(videoID);
-    self.gui.log("load:"+link)
-    xmlPage = self.loadPage(link);
-    if(not xmlPage.startswith("<?xml")):
-      return;
-    try:  
-      configXml = minidom.parseString(xmlPage);
-      
-      title = configXml.getElementsByTagName("title")[0].childNodes[0].data
-      detail = configXml.getElementsByTagName("detail")[0].childNodes[0].data
-      dateString = configXml.getElementsByTagName("airtime")[0].childNodes[0].data
-      date = time.strptime(dateString,"%d.%m.%Y %H:%M");
-      size = 0;
-      picture = "";
-      for picElement in configXml.getElementsByTagName("teaserimage"):
-        picSizeString = picElement.getAttribute('key')
-        picSizes = picSizeString.split("x");
-        width = int(picSizes[0]);
-        height = int(picSizes[0]);
-        diag = math.sqrt(height*height+width*width);
-        if(diag > size):
-          size = diag;
-          self.gui.log("%d %s"%(diag,picElement.childNodes[0].data));
-          picture = picElement.childNodes[0].data;
-      links = {};
-      
-      for streamObject in configXml.getElementsByTagName("formitaet"):
-        baseType = streamObject.getAttribute("basetype")
-        if(baseType.find(self.baseType)>-1):
           
-          url = streamObject.getElementsByTagName("url")[0].childNodes[0].data;
-          try:
-            size = int(streamObject.getElementsByTagName("filesize")[0].childNodes[0].data);
-          except:
-            size = 0;
-          if("rtmp_smil_http" in self.baseType):
-            links = self.getRtmpLinks(url, size);
-            break;
-          else:
-            quality = streamObject.getElementsByTagName("quality")[0].childNodes[0].data;
-            url = streamObject.getElementsByTagName("url")[0].childNodes[0].data;
-            
-            if url.find(".mp3") > -1:
-              continue;
-
-            if(quality == "low"):
-              links[0] = SimpleLink(url, size);
-            elif(quality == "high"):
-              links[1] = SimpleLink(url, size);
-            elif(quality == "veryhigh"):
-              links[2] = SimpleLink(url, size);
-            elif(quality == "hd"):
-              links[3] = SimpleLink(url, size);
-      if(len(links) == 0):
-        links = {};
-        for streamObject in configXml.getElementsByTagName("formitaet"):
-          baseType = streamObject.getAttribute("basetype")
-          if(baseType.find("asx_http")>-1):
-            quality = streamObject.getElementsByTagName("quality")[0].childNodes[0].data;
-            url = streamObject.getElementsByTagName("url")[0].childNodes[0].data;
-            
-            if(quality == "low"):
-              links[0] = SimpleLink(url, size);
-            elif(quality == "high"):
-              links[1] = SimpleLink(url, size);
-            elif(quality == "veryhigh"):
-              links[2] = SimpleLink(url, size);
-            elif(quality == "hd"):
-              links[3] = SimpleLink(url, size); 
-            break;
-      configXml.unlink();
-      if(len(links) > 0):
-        self.gui.buildVideoLink(DisplayObject(title,"",picture,detail,links,True, date),self,self.getItemCount());
-    except:
-      self.gui.log("Error while processing the xml-file: %s"%link);
-      print xmlPage;
-      self.gui.log("Exception: ");
-      traceback.print_exc();
-      self.gui.log("Stacktrace: ");
-      traceback.print_stack();
-      #sys.exit();
-  
-  def getRtmpLinks(self, url, size):
-    self.gui.log("decoding smil page")
-    links = {};
-    hostConfig = {};
-    smilPage = self.loadPage(url);
-    if(not smilPage.startswith("<?xml")):
-      return None;
-    
-    xmlDocument = minidom.parseString(smilPage);
-    
-    self.cleanupNodes(xmlDocument.documentElement);
-    xmlDocument.documentElement.normalize() 
-    
-    #extract hostData
-    for paramGroup in xmlDocument.getElementsByTagName("paramGroup"):
-      groupName = paramGroup.getAttribute("xml:id");
-      
-      host = "";
-      app = ""
-      for param in paramGroup.childNodes:
         
-        paramName = param.getAttribute("name");
-        if(paramName == "app"): app = param.getAttribute("value");
-        if(paramName == "host"): host = param.getAttribute("value");
-      self.gui.log("%s rtmp://%s/%s/"%(groupName,host,app))
-      hostConfig[groupName] = "rtmp://%s/%s/"%(host,app);
-      
-    
-    videoNodes = xmlDocument.getElementsByTagName("video");
+  def buildJsonMenu(self, path,callhash, initCount):
+    jsonObject=self.gui.loadJsonFile(callhash);
+    jsonObject=self.walkJson(path,jsonObject);
    
-    for videoNode in videoNodes:
-      quality = videoNode.getElementsByTagName("param")[0].getAttribute("value");
-      paramGroupName = videoNode.getAttribute("paramGroup");
+    categoriePages=[];
+    videoObjects=[];
+    
+    for entry in jsonObject:
+      if entry["type"] == "brand":
+        categoriePages.append(entry);
+      if entry["type"] == "video" and len(videoObjects) < 50:
+        videoObjects.append(entry);  
+    
+    self.gui.log("CategoriePages: %d"%len(categoriePages));
+    self.gui.log("VideoPages: %d"%len(videoObjects));  
+    for categoriePage in categoriePages:
+      title=categoriePage["titel"];
+      subTitle=categoriePage["beschreibung"];
+      imageLink="";
+      for width,imageObject in categoriePage["teaserBild"].iteritems():
+        if int(width)<=840:
+          imageLink=imageObject["url"];
+      url = categoriePage["url"];
+      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,"",url,False),self,initCount);
+    
+    
+    
+    for videoObject in videoObjects:
+      self.buildVideoLink(videoObject,initCount);
       
-      hostString = hostConfig[paramGroupName];
-      urlString = videoNode.getAttribute("src");
-      link = "%s playPath=%s"%(hostString,urlString)
-      self.gui.log(link)
-      link = SimpleLink(link,size);
-      if(quality == "low"):
-        links[0] = link
-      elif(quality == "high"):
-        links[1] = link
-      elif(quality == "veryhigh"):
-        links[2] = link
-      elif(quality == "hd"):
-        links[3] = link
-    xmlDocument.unlink();
+      
+  def buildVideoLink(self,videoObject,counter):
+    title=videoObject["headline"];
+    subTitle=videoObject["titel"];
+    
+    if(len(title)==0):
+      title = subTitle;
+      subTitle = "";
+    description=videoObject["beschreibung"];
+    imageLink="";
+    for width,imageObject in videoObject["teaserBild"].iteritems():
+      if int(width)<=840:
+        imageLink=imageObject["url"];
+    if("formitaeten" in videoObject):
+      links = self.extractLinks(videoObject);
+      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,links,True,None,videoObject.get('length')),self,counter);
+    else:
+      link = videoObject["url"];
+      self.gui.buildVideoLink(DisplayObject(title,subTitle,imageLink,description,link,"JsonLink",None,videoObject.get('length')),self,counter);
+    
+  def playVideoFromJsonLink(self,link):
+    jsonObject = json.loads(self.loadPage(link));
+    links = self.extractLinks(jsonObject["document"]);
+    self.gui.play(links);
+  def extractLinks(self,jsonObject):
+    links={};
+    for formitaete in jsonObject["formitaeten"]:
+      url = formitaete["url"];
+      quality = formitaete["quality"];
+      hd = formitaete["hd"];
+      self.gui.log("quality:%s hd:%s url:%s"%(quality,hd,url));
+      if hd == True:
+        links[4] = SimpleLink(url, -1); 
+      else:
+        if quality == "low":
+          links[0] = SimpleLink(url, -1); 
+        if quality == "med":
+          links[1] = SimpleLink(url, -1); 
+        if quality == "high":
+          links[2] = SimpleLink(url, -1); 
+        if quality == "veryhigh":
+          links[3] = SimpleLink(url, -1);
+        if quality == "auto":
+          links[3] = SimpleLink(url, -1);
     return links;
     
+      
     
-  def extractTopicObjects(self,pageLinks):
-    for element in pageLinks:
-      element = element.group()
-      pictureLink = self.rootLink + self._regex_extractPictureLink.search(element).group();
-      videoPageLink = self.rootLink + self._regex_extractTopicPageLink.search(element).group();
-      titles = [];
-      for title in self._regex_extractTopicTitle.findall(element):
-        title = unicode(title,'UTF-8');
-        title = self.replace_html.sub("", title); #outerhtml wegschneiden
-        title = title.replace("&nbsp;", ""); #sinnlose "steuerzeichen wegschneiden"
-        titles.append(title);
-      while len(titles) < 2:
-        titles.append("");
-      self.gui.buildVideoLink(DisplayObject(titles[0],titles[1],pictureLink,"",videoPageLink,False),self,self.getItemCount());
-  
-  def cleanupNodes(self, rootNode):
-    for node in rootNode.childNodes:
-      if node.nodeType == Node.TEXT_NODE:
-        node.data = node.data.strip()
-      else:
-        self.cleanupNodes(node);
+
+    
+    

--- a/plugin.video.mediathek/resources/language/English/strings.xml
+++ b/plugin.video.mediathek/resources/language/English/strings.xml
@@ -4,7 +4,8 @@
     <string id="30002">Low</string>
     <string id="30003">Medium</string>
     <string id="30004">High</string>
-    <string id="30005">HD</string>
+    <string id="30005">Very High</string>
+    <string id="30006">HD</string>
     
     <string id="30010">Access Method</string>
     <string id="30011">Online</string>

--- a/plugin.video.mediathek/resources/language/German/strings.xml
+++ b/plugin.video.mediathek/resources/language/German/strings.xml
@@ -4,7 +4,8 @@
     <string id="30002">Niedrig</string>
     <string id="30003">Normal</string>
     <string id="30004">Hoch</string>
-    <string id="30005">HD</string>
+    <string id="30005">Very High</string>
+    <string id="30006">HD</string>
     
     <string id="30010">Zugriffsmethode</string>
     <string id="30011">Online</string>

--- a/plugin.video.mediathek/resources/language/Italian/strings.xml
+++ b/plugin.video.mediathek/resources/language/Italian/strings.xml
@@ -4,7 +4,8 @@
     <string id="30002">Bassa</string>
     <string id="30003">Media</string>
     <string id="30004">Alta</string>
-    <string id="30005">HD</string>
+    <string id="30005">altissima</string>
+    <string id="30006">HD</string>
     
     <string id="30010">Metodo d'accesso</string>
     <string id="30011">Online</string>

--- a/plugin.video.mediathek/resources/settings.xml
+++ b/plugin.video.mediathek/resources/settings.xml
@@ -3,7 +3,7 @@
 
   <!-- General -->
   <category label="General">
-    <setting id="quality" type="enum" label="30001" lvalues="30002|30003|30004|30005" default="2" />    
+    <setting id="quality" type="enum" label="30001" lvalues="30002|30003|30004|30005|30006" default="2" />    
     <setting id="preferedStreamType" type="enum" label="30020" lvalues="30021|30022|30023|30024" default="1" />
   </category>
 </settings>


### PR DESCRIPTION
### Description
ZDF Completly changes its WebInterface so the plugin is rewriten to adopt that (now using JSON API, hopefully more stable)
Important: ZDF enforces TLSv1 with SNI enabled. Support for this is added in Pyhton 2.7.9. (See here https://github.com/raptor2101/Mediathek/issues/85). I'am unsure how to handle that via Kodi dependency. On Linux based platforms, this should be no problem, even with old Kodi version, on Windows this enforces Kodi 17.
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

### Additional information :
I'am aware that the code provided by this PullRequest pusches 129 CodeIssues (regarding to codacy). I  was unaware of that until now and will solve these issues with the next PR.

