### PR TITLE
[plugin.video.odeon] 1.2.0

### DIFF
--- a/plugin.video.odeon/README.md
+++ b/plugin.video.odeon/README.md
@@ -18,5 +18,5 @@ Odeón es la plataforma de video a demanda del Cine Argentino donde encontrarás
 ### Addtional information
 - https://www.odeon.com.ar
 - https://arsat.github.io/odeon-kodi/
+- http://forum.kodi.tv/showthread.php?tid=296742
 - Contact: dev@odeon.com.ar
-

--- a/plugin.video.odeon/addon.xml
+++ b/plugin.video.odeon/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.odeon"
-       name="Odeon" version="0.0.8"
+       name="Odeon" version="1.2.0"
        provider-name="ARSAT">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
@@ -21,7 +21,7 @@ Odeón es la plataforma de video a demanda del Cine Argentino donde encontrarás
         <platform>all</platform>
         <license>GNU General Public License, Version 3</license>
         <source>https://github.com/arsat/odeon-kodi</source>
-        <forum>https://www.facebook.com/OdeonVOD</forum>
+        <forum>http://forum.kodi.tv/showthread.php?tid=296742</forum>
         <website>https://www.odeon.com.ar</website>
         <email>consultas@odeon.com.ar</email>
     </extension>

--- a/plugin.video.odeon/changelog.txt
+++ b/plugin.video.odeon/changelog.txt
@@ -1,32 +1,13 @@
 ﻿# Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2016-11-16
+### Changed
+- Use of zlib instead of gzip.
+- Better cache for short max-age responses.
+- Replacement for /home API call.
+
 ## [0.0.8] - 2016-11-11
 ### Added
-- Nueva versión del backend
-- Internacionalización
-- Bug fixes
-
-## [0.0.5] - 2016-10-28
-### Added
-- Agregado de licencia
-- Compresión gzip en http.
-- Metadata y optimización del Player.
-- Control de progreso de la reproducción.
-
-## [0.0.2] - 2016-10-06
-### Added
-- Login con usuario y contraseña.
-- Verificación de aceptación de Términos y Condiciones.
-- Selección de perfil e ingreso de pin.
-- Navegación de la página de inicio de ODEON.
-- Selección por género, y tipo de producción.
-- Búsquedas por título, director, actor.
-- Ordenamiento de búsquedas.
-- Detalle de producción (para series y compilados).
-- Agregar a mi sala, marcar como vista y calificar.
-
-## [0.0.1] - 2016-09-30
-### Added
-- Versión inicial.
+- Initial version.
 

--- a/plugin.video.odeon/resources/lib/simplerequests.py
+++ b/plugin.video.odeon/resources/lib/simplerequests.py
@@ -20,7 +20,7 @@
 
 import json as jsonr
 import urllib2
-import utils
+import zlib
 
 class response():
 
@@ -36,10 +36,12 @@ class response():
             self.headers = info.dict.copy()
             self.status_code = self.r.code
 
-            if info.get('Content-Encoding') == 'gzip':
-                self.content = utils.unzip(self.r.read())
-            else:
+            try:
                 self.content = self.r.read()
+                if info.get('Content-Encoding') == 'gzip':
+                    self.content = zlib.decompress(self.content, zlib.MAX_WBITS + 16)
+            except:
+                pass
 
         elif self.e:
             self.status_code = self.e.code

--- a/plugin.video.odeon/resources/lib/utils.py
+++ b/plugin.video.odeon/resources/lib/utils.py
@@ -18,37 +18,27 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import gzip
-import StringIO
 import base64
 import json
+import zlib
 import hashlib
 
 
-def comp(data):
-    out = StringIO.StringIO()
-    f = gzip.GzipFile(fileobj=out, mode='w', compresslevel=5)
-    js = json.dumps(data, ensure_ascii=True, encoding='utf-8')
-    f.write(js)
-    f.close()
-    return base64.b64encode(out.getvalue())
+def comp(js):
+    data = json.dumps(js, ensure_ascii=True, encoding='utf-8')
+    deflated = zlib.compress(data)
+    return base64.b64encode(deflated)
 
 
 def decomp(b64):
-    gzipData = base64.b64decode(b64)
-    stream = StringIO.StringIO(gzipData)
-    f = gzip.GzipFile(fileobj=stream, mode='r')
-    txt = f.read()
-    f.close()
-    return json.loads(txt, encoding='utf-8')
+    try:
+        deflated = base64.b64decode(b64)
+        data = zlib.decompress(deflated)
+        return json.loads(data, encoding='utf-8')
+    except:
+        return None
 
 
 def digest(data):
     digest = hashlib.md5(data).digest()
     return base64.b64encode(digest)
-
-
-def unzip(zipped):
-    stream = StringIO.StringIO(zipped)
-    f = gzip.GzipFile(fileobj=stream, mode='r')
-    return f.read()


### PR DESCRIPTION
### Description
- use of zlib instead of gzip library
- optimize cache for short max-age responses
- change in api call
- renumbered version

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

