### PR TITLE
[plugin.video.mediathek] v0.8.0

### DIFF
--- a/plugin.video.mediathek/addon.xml
+++ b/plugin.video.mediathek/addon.xml
@@ -2,7 +2,7 @@
 <addon
   id="plugin.video.mediathek"
   name="Mediathek"
-  version="0.7.5"
+  version="0.8.0"
   provider-name="Raptor 2101">
   <requires>
    <import addon="xbmc.python" version="2.25.0"/>

--- a/plugin.video.mediathek/changelog.txt
+++ b/plugin.video.mediathek/changelog.txt
@@ -1,3 +1,4 @@
+0.8.0 - CHG: Version pump to seperate pre-krypton version and krypton version
 0.7.5 - CHG: reimplement ZDF Mediathak (important: ZDF enforces TLSv1 with SNI enabled, what is only supported by python 2.7.9.)
         Temporaily fix ARTE
 0.7.4 - CHG: Repearing NDR und 3SAT


### PR DESCRIPTION
### Description
This is only a version pump to seperate pre-krypton version from krypton version of this plugin. (as requested here: https://github.com/xbmc/repo-plugins/pull/757)
### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
