### PR TITLE
[plugin.video.southpark_unofficial] 0.4.5

### DIFF
--- a/plugin.video.southpark_unofficial/addon.xml
+++ b/plugin.video.southpark_unofficial/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.4.4" provider-name="Deroad">
+<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.4.5" provider-name="Deroad">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
     </requires>

--- a/plugin.video.southpark_unofficial/changelog.txt
+++ b/plugin.video.southpark_unofficial/changelog.txt
@@ -1,51 +1,53 @@
-0.1.0
-- Initial release
-0.1.3
-- added langs and fixed geolocation
-0.2.1
-- added support to southpark.de
-0.2.2
-- fixed bug on 'de' lang (season 18 is in english)
-0.2.3
-- added CC and Added warning on Banned Episodes (ep 200/201 - season 14)
-0.2.4
-- fixed new mediagen url
-0.2.5
-- better loading time.
-0.2.6
-- re-added playlist. now works with SUBS! next/back now works and perma cc can be enabled via options.
-0.2.7
-- FireTV fix
-0.3.0
-- adding pre Python 2.7 support.
-0.3.1
-- removed old mediagen method, and added German translation.
-0.3.2
-- added spanish language. it looks like it's easy to add it, less work for me! some episodes will still be in english for de/es languages. not my fault. they have errors on their DB.
-0.3.3
-- Fixed stop on slow connections
-0.3.4
-- Pseudo-fix for missing cc
-0.3.5
-- Added Search and new links.
-0.3.6
-- Added Season 19.
-0.3.7
-- Fixed german support.
-0.3.8
-- Fixed premiere episodes
-- Added [Banned]/[Premiere] tags
-0.3.9
-- Added a timer before release on premiere episodes on the description.
-- Added seasons covers.
+0.4.5
+- Fixed EN/ES streams due RTMPE bad behaviour.
+0.4.4
+- Fixed EN/DE/ES streams.
+0.4.3
+- Added Season 20
+0.4.2
+- Fixed DE language (thanks to JinJin @kodi forums)
+0.4.1
+- Fixed DE/EN/ES and carousel
 0.4.0
 - Fixed again DE support
 - Added DE descriptions/titles on seasons and random episodes.
-0.4.1
-- Fixed DE/EN/ES and carousel
-0.4.2
-- Fixed DE language (thanks to JinJin @kodi forums)
-0.4.3
-- Added Season 20
-0.4.4
-- Fixed EN/DE/ES streams.
+0.3.9
+- Added a timer before release on premiere episodes on the description.
+- Added seasons covers.
+0.3.8
+- Fixed premiere episodes
+- Added [Banned]/[Premiere] tags
+0.3.7
+- Fixed german support.
+0.3.6
+- Added Season 19.
+0.3.5
+- Added Search and new links.
+0.3.4
+- Pseudo-fix for missing cc
+0.3.3
+- Fixed stop on slow connections
+0.3.2
+- added spanish language. it looks like it's easy to add it, less work for me! some episodes will still be in english for de/es languages. not my fault. they have errors on their DB.
+0.3.1
+- removed old mediagen method, and added German translation.
+0.3.0
+- adding pre Python 2.7 support.
+0.2.7
+- FireTV fix
+0.2.6
+- re-added playlist. now works with SUBS! next/back now works and perma cc can be enabled via options.
+0.2.5
+- better loading time.
+0.2.4
+- fixed new mediagen url
+0.2.3
+- added CC and Added warning on Banned Episodes (ep 200/201 - season 14)
+0.2.2
+- fixed bug on 'de' lang (season 18 is in english)
+0.2.1
+- added support to southpark.de
+0.1.3
+- added langs and fixed geolocation
+0.1.0
+- Initial release

--- a/plugin.video.southpark_unofficial/default.py
+++ b/plugin.video.southpark_unofficial/default.py
@@ -135,9 +135,9 @@ def list(url):
     xbmc.executebuiltin('Container.SetViewMode('+viewMode+')')
 
 def playEpisode(url, title, thumbnail):
-	xbmc.log("sp.addon: " + url, xbmc.LOGFATAL)
-	xbmc.log("sp.addon: " + title, xbmc.LOGFATAL)
-	xbmc.log("sp.addon: " + thumbnail, xbmc.LOGFATAL)
+	xbmc.log("sp.addon: " + url, xbmc.LOGDEBUG)
+	xbmc.log("sp.addon: " + title, xbmc.LOGDEBUG)
+	xbmc.log("sp.addon: " + thumbnail, xbmc.LOGDEBUG)
 	if url == "banned":
 		notifyText(translation(30011), 7000)
 		return

--- a/plugin.video.southpark_unofficial/default.py
+++ b/plugin.video.southpark_unofficial/default.py
@@ -135,7 +135,9 @@ def list(url):
     xbmc.executebuiltin('Container.SetViewMode('+viewMode+')')
 
 def playEpisode(url, title, thumbnail):
-	print url, title, thumbnail
+	xbmc.log("sp.addon: " + url, xbmc.LOGFATAL)
+	xbmc.log("sp.addon: " + title, xbmc.LOGFATAL)
+	xbmc.log("sp.addon: " + thumbnail, xbmc.LOGFATAL)
 	if url == "banned":
 		notifyText(translation(30011), 7000)
 		return
@@ -176,22 +178,24 @@ def playEpisode(url, title, thumbnail):
 			rtmpgeo = 0
 		playpath = ""
 		rtmp = rtmpe[best]
-		if "viacomccstrm" in rtmpe[best]:
-			playpath = "mp4:"+rtmpe[best].split('viacomccstrm/')[1]
-			rtmp = rtmp_geo[0]#rtmpe[best].split('viacomccstrm/')[0]+'viacomccstrm/'
-		elif "cp9950.edgefcs.net" in rtmpe[best]:
-			playpath = "mp4:"+rtmpe[best].split('mtvnorigin/')[1]
-			rtmp = rtmp_geo[0]#rtmpe[best].split('viacomccstrm/')[0]+'viacomccstrm/'
+		xbmc.log("sp.addon: " + rtmp, xbmc.LOGDEBUG)
 		videoname = title + " (" + str(i+1) + " of " + parts +")"
 		li = xbmcgui.ListItem(videoname, iconImage=thumbnail, thumbnailImage=thumbnail)
 		li.setInfo('video', {'Title': videoname})
 		li.setProperty('conn', "B:0")
-		if playpath != "":
-			li.setProperty('PlayPath', playpath)
-		li.setProperty('flashVer', "WIN 19,0,0,185")
-		li.setProperty('pageUrl', pageUrl)
-		li.setProperty('SWFPlayer', "http://media.mtvnservices.com/player/prime/mediaplayerprime.2.12.5.swf")
-		li.setProperty("SWFVerify", "true")
+		if not "http" in rtmp:
+			if "viacomccstrm" in rtmpe[best]:
+				playpath = "mp4:"+rtmpe[best].split('viacomccstrm/')[1]
+				rtmp = rtmp_geo[0]#rtmpe[best].split('viacomccstrm/')[0]+'viacomccstrm/'
+			elif "cp9950.edgefcs.net" in rtmpe[best]:
+				playpath = "mp4:"+rtmpe[best].split('mtvnorigin/')[1]
+				rtmp = rtmp_geo[1]#rtmpe[best].split('viacomccstrm/')[0]+'viacomccstrm/'
+			if playpath != "":
+				li.setProperty('PlayPath', playpath)
+			li.setProperty('flashVer', "WIN 24,0,0,186")
+			li.setProperty('pageUrl', pageUrl)
+			li.setProperty('SWFPlayer', "http://media.mtvnservices.com/player/prime/mediaplayerprime.2.12.5.swf")
+			li.setProperty("SWFVerify", "true")
 		if cc != "" and cc_settings:
 			fname = os.path.join(addonpath, "subtitle_"+str(i)+"_"+str(parts)+".vtt")
 			subname = saveSubs(fname, cc)
@@ -214,7 +218,7 @@ def playEpisode(url, title, thumbnail):
 			player.setSubtitles(ccs[pos])
 			player.showSubtitles(cc_settings)
 		else:
-			print "["+addonID+"] missing some vtt subs..."
+			xbmc.log("sp.addon: " + "["+addonID+"] missing some vtt subs...", xbmc.LOGERROR)
 
 	while pos < playlist.size() and player.isPlaying():
 		while player.isPlaying():
@@ -225,7 +229,7 @@ def playEpisode(url, title, thumbnail):
 					player.setSubtitles(ccs[pos])
 					player.showSubtitles(cc_settings)
 				else:
-					print "["+addonID+"] missing some vtt subs..."
+					xbmc.log("sp.addon: " + "["+addonID+"] missing some vtt subs...", xbmc.LOGERROR)
 		time.sleep(10)
 	return
 
@@ -242,7 +246,7 @@ def notifyText(text, time=5000):
 
 def getUrl(url):
 	link = ""
-	print url
+	xbmc.log("sp.addon: " + url, xbmc.LOGDEBUG)
 	try:
 		req = urllib2.Request(url)
 		req.add_header('User-Agent', 'Mozilla/5.0 (Windows NT 6.1; rv:25.0) Gecko/20100101 Firefox/25.0')
@@ -296,8 +300,9 @@ def getCarousel():
 
 def getMediagen(id):
 	feed = ""
-	print "http://"+mainweb_geo[audio_pos]+"/feeds/video-player/mrss/mgid:arc:episode:"+pageurl_geo[audio_pos]+":"+id+"?lang="+audio
-	feed = getUrl("http://"+mainweb_geo[audio_pos]+"/feeds/video-player/mrss/mgid:arc:episode:"+pageurl_geo[audio_pos]+":"+id+"?lang="+audio)
+	comp = "http://"+mainweb_geo[audio_pos]+"/feeds/video-player/mrss/mgid:arc:episode:"+pageurl_geo[audio_pos]+":"+id+"?lang="+audio
+	xbmc.log("sp.addon: " + comp, xbmc.LOGDEBUG)
+	feed = getUrl(comp)
 	root = ET.fromstring(feed)
 	mediagen = []
 	if sys.version_info >=  (2, 7):
@@ -312,10 +317,9 @@ def getMediagen(id):
 
 def getVideoData(mediagen):
 	xml = ""
-	if audio == "de":
-		mediagen += "&deviceOsVersion=4.4.4&acceptMethods=hls";
-		mediagen = mediagen.replace('{device}', 'Android')
-	print "MEDIAGEN: " + mediagen
+	mediagen += "&deviceOsVersion=4.4.4&acceptMethods=hls";
+	mediagen = mediagen.replace('{device}', 'Android')
+	xbmc.log("sp.addon: " + mediagen, xbmc.LOGDEBUG)
 	xml = getUrl(mediagen)
 	root = ET.fromstring(xml)
 	rtmpe = []


### PR DESCRIPTION
### Description
0.4.5 - Fixed EN/ES streams due RTMPE bad behaviour.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] 1.0.0
