### PR TITLE
[plugin.video.eitb] 1.0.5

### DIFF
--- a/plugin.video.eitb/addon.xml
+++ b/plugin.video.eitb/addon.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.eitb-master" name="EITB Nahieran (unofficial)" version="1.0.4" provider-name="Mikel Larreategi">
-<!-- note the id has -master in it because then the github repo download is then an installable zip -->
+<addon id="plugin.video.eitb" name="EITB Nahieran (unofficial)" version="1.0.5" provider-name="Mikel Larreategi">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
         <import addon="script.module.requests" version="2.9.1"/>

--- a/plugin.video.eitb/changelog.txt
+++ b/plugin.video.eitb/changelog.txt
@@ -1,3 +1,9 @@
+[B]1.0.5[/B]
+- Fix plugin id on addon.xml
+[B]1.0.4[/B]
+- First version published on Kodi repository
+[B]1.0.3[/B]
+- Test version
 [B]1.0.2[/B]
 - Nothing changed yet.
 


### PR DESCRIPTION
### Description
Minor update of the plugin. The plugin id in addon.xml is fixed to be _plugin.video.eitb_ instead of the previous _plugin.video.eitb-master_, which created install errors when installing from repository.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
