### PR TITLE
[plugin.video.currenttime.tv] 1.0.3

### DIFF
--- a/plugin.video.currenttime.tv/addon.xml
+++ b/plugin.video.currenttime.tv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.currenttime.tv" name="CurrentTime.TV" version="1.0.2" provider-name="dicoka@ukr.net">
+<addon id="plugin.video.currenttime.tv" name="CurrentTime.TV" version="1.0.3" provider-name="dicoka@ukr.net">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
   </requires>
@@ -16,8 +16,8 @@
     <platform>all</platform>
 	<language></language>
 	<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-	<news lang="en">Fixed video archive playback with selected quality</news>
-	<news lang="ru">Исправлено воспроизведение видео архива с заданным качеством</news>
+	<news lang="en">Added "TV Listing" with schedule for today</news>
+	<news lang="ru">Добавлена "Телепрограмма" на текущие сутки</news>
 	<assets>
         <icon>icon.png</icon>
         <fanart>fanart.jpg</fanart>

--- a/plugin.video.currenttime.tv/changelog.txt
+++ b/plugin.video.currenttime.tv/changelog.txt
@@ -1,3 +1,7 @@
+v1.0.3 (2017-01-23)
+- Added "TV Listing" with schedule for today
+- Добавлена "Телепрограмма" на текущие сутки
+
 v1.0.2 (2016-12-23)
 - Fixed video archive playback with selected quality (due to provider api changes)
 - Исправлено воспроизведение видео архива с заданным качеством (в связи с изменениями api провайдера)

--- a/plugin.video.currenttime.tv/resources/language/English/strings.po
+++ b/plugin.video.currenttime.tv/resources/language/English/strings.po
@@ -73,6 +73,13 @@ msgctxt "#30014"
 msgid "Opinions"
 msgstr ""
 
+msgctxt "#30015"
+msgid "TV Listing"
+msgstr ""
+
+msgctxt "#30016"
+msgid "TV listing - schedule for today"
+msgstr ""
 
 
 msgctxt "#30031"

--- a/plugin.video.currenttime.tv/resources/language/Russian/strings.po
+++ b/plugin.video.currenttime.tv/resources/language/Russian/strings.po
@@ -73,6 +73,13 @@ msgctxt "#30014"
 msgid "Opinions"
 msgstr "Мнения"
 
+msgctxt "#30015"
+msgid "TV Listing"
+msgstr "Телепрограмма"
+
+msgctxt "#30016"
+msgid "TV listing - schedule for today"
+msgstr "Телевизионная программа на сегодня"
 
 
 msgctxt "#30031"


### PR DESCRIPTION
### Description
TV listing with schedule for today added
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
