### PR TITLE
[plugin.video.snnow] 1.0.12

### DIFF
--- a/plugin.video.snnow/addon.xml
+++ b/plugin.video.snnow/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.snnow" name="Sportsnet Now" version="1.0.11" provider-name="Micah Galizia">
+<addon id="plugin.video.snnow" name="Sportsnet Now" version="1.0.12" provider-name="Micah Galizia">
   <requires>
     <import addon="xbmc.python"   version="2.20.0"/>
   </requires>

--- a/plugin.video.snnow/changelog.txt
+++ b/plugin.video.snnow/changelog.txt
@@ -1,3 +1,8 @@
+[B]Version 1.0.12[/B]
+
+- Update for Krypton broken HLS
+- Add stream bitrate selection
+
 [B]Version 1.0.11[/B]
 
 - Fix Cogeco authentication (github.com/graterje)

--- a/plugin.video.snnow/default.py
+++ b/plugin.video.snnow/default.py
@@ -111,7 +111,20 @@ def createLiveMenu(values):
 
 def playChannel(values):
     mso = __settings__.getSetting("mso")
-    stream = getChannelStream(values['id'][0], values['abbr'][0], mso)
+    streams = getChannelStream(values['id'][0], values['abbr'][0], mso)
+
+    # here get the streams
+    bitrates = [int(x) for x in streams.keys()]
+    bitrates = [str(x) for x in reversed(sorted(bitrates)) ]
+
+    index = xbmcgui.Dialog().select("Select Bitrate", bitrates)
+
+    if index < 0:
+        dialog = xbmcgui.Dialog()
+        dialog.ok(__language__(30004), __language__(30005))
+        return
+
+    stream = streams[bitrates[index]]
 
     if not stream:
         dialog = xbmcgui.Dialog()
@@ -140,8 +153,7 @@ def getChannelStream(channelId, channelName, msoName):
         creds = getAuthCredentials()
         if sn.authorize(creds['u'], creds['p'], creds['m']):
             return sn.getChannel(channelId, channelName, msoName)
-    return stream
-
+    return sn.parsePlaylist(stream)
 
 if len(sys.argv[2]) == 0:
 

--- a/plugin.video.snnow/test.py
+++ b/plugin.video.snnow/test.py
@@ -45,8 +45,11 @@ if abbr:
         sys.exit(1)
     print "Authorization Complete."
     stream = sn.getChannel(options.id, abbr, options.mso)
-    if stream:
-        print stream
-    else:
+    if not stream:
         print "Unable to get stream"
-    
+        sys.exit(0)
+
+    streams = sn.parsePlaylist(stream)
+    bitrates = [int(x) for x in streams.keys()]
+    for bitrate in reversed(sorted(bitrates)):
+        print str(bitrate) + ':' + streams[str(bitrate)]


### PR DESCRIPTION
### Description

Neulion HLS doesn't work with the default ffmpeg probing behaviour added into Krypton (eg: probe each substream) because it sends an HTTP 403 in response to repeated key requests. To work around this, I'm forcing the user to select which bitrate they would like to watch.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0