### PR TITLE
Updated add-on.xml as broken

### DIFF
--- a/plugin.video.redbull.tv/addon.xml
+++ b/plugin.video.redbull.tv/addon.xml
@@ -19,5 +19,6 @@
 		<website>http://www.redbull.tv/</website>
 		<email>bromix at gmx dot net</email>
 		<source>https://github.com/bromix/plugin.video.redbull.tv/</source>
+		<broken>When launched, throws a Exception in ContentProvider, Unknown response type 'MediaBaseClient::UnAuthorized Error'</broken>
 	</extension>
 </addon>


### PR DESCRIPTION
Marking the add-on as broken, updated with the error it throws. Does not do anything after this.
