### PR TITLE
[plugin.video.wabc] 3.0.9

### DIFF
--- a/plugin.video.wabc/addon.xml
+++ b/plugin.video.wabc/addon.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.wabc"
        name="WABC Programs"
-       version="3.0.8"
+       version="3.0.9"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.20.0"/>
-    <import addon="script.module.t1mlib" version="1.0.15"/>
+    <import addon="script.module.t1mlib" version="1.0.18"/>
   </requires>
   <extension point="xbmc.python.pluginsource"
             library="default.py">

--- a/plugin.video.wabc/changelog.txt
+++ b/plugin.video.wabc/changelog.txt
@@ -1,3 +1,4 @@
+Version 3.0.9 bump t1mlib version to fix timeout request on Kodi 17.0 Android
 Version 3.0.8 Fix crap in metadata
 Version 3.0.7 Website changes
 Version 3.0.6 Website changes

--- a/plugin.video.wabc/readme.txt
+++ b/plugin.video.wabc/readme.txt
@@ -1,3 +1,4 @@
+Version 3.0.9 bump t1mlib version to fix timeout request on Kodi 17.0 Android
 Version 3.0.8 Fix crap in metadata
 Version 3.0.7 Website changes
 Version 3.0.6 Website changes


### PR DESCRIPTION
bump t1mlib version to fix request timeout in Kodi 17.0 android

### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x ] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
