### PR TITLE
[plugin.video.revision3] broken

### DIFF
--- a/plugin.video.revision3/addon.xml
+++ b/plugin.video.revision3/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.revision3"
        name="Revision3"
-       version="3.0.14" 
+       version="3.0.15" 
        provider-name="stacked">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
@@ -18,6 +18,7 @@
     <summary lang="en">Revision3: The Best TV Shows on the Internet</summary>
     <description lang="en">The leading independent free online video service.</description>
     <platform>all</platform>
+  <broken>Deprecated. New version is available for Krypton and above versions</broken>
 	<language>en</language>
 	<website>https://code.google.com/p/plugin</website>
 	<source>https://github.com/stacked/plugin.video.revision3</source>


### PR DESCRIPTION
Marking this plugin as broken

-Last update was 4 years ago
-I attempted to submit fixes for some broken sections (didn't receive feedback for almost 2 years)
-Author is away from our forums for 2 years

So, decided to do a full re-write and to be the new maintainer of the addon, since I use it a lot myself. The original author has been added as an author in the new addon.
My version will be submitted through another pull request.