### PR TITLE
[plugin.video.fatstone] 1.0.3

### DIFF
--- a/plugin.video.fatstone/addon.xml
+++ b/plugin.video.fatstone/addon.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.fatstone"
        name="Fatstone.TV"
-       version="1.0.2"
+       version="1.0.3"
        provider-name="trippel-m">
   <requires>
     <import addon="xbmc.python" version="2.20.0"/>
     <import addon="script.module.requests" version="1.0.4"/>
     <import addon="script.module.routing" version="0.1.0"/>
+    <import addon="script.module.m3u8" version="0.2.2"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>

--- a/plugin.video.fatstone/addon.xml
+++ b/plugin.video.fatstone/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.fatstone"
        name="Fatstone.TV"
-       version="1.0.1"
+       version="1.0.2"
        provider-name="trippel-m">
   <requires>
     <import addon="xbmc.python" version="2.20.0"/>

--- a/plugin.video.fatstone/changelog.txt
+++ b/plugin.video.fatstone/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.0.2[/B]
+- Updated stream source address
+
 [B]1.0.1[/B]
 - Removed .gitignore and .gitattribute files
 - Removed unused translation data

--- a/plugin.video.fatstone/changelog.txt
+++ b/plugin.video.fatstone/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.0.3[/B]
+- Now lets user choose bitrate
+
 [B]1.0.2[/B]
 - Updated stream source address
 

--- a/plugin.video.fatstone/default.py
+++ b/plugin.video.fatstone/default.py
@@ -37,7 +37,7 @@ def root():
     li.setInfo('video', {'title': "Fatstone Live"})
     li.addStreamInfo('video', {'codec': 'h264', 'width': 1024, 'height': 576})
     li.addStreamInfo('audio', {'codec': 'aac', 'channels': 2})
-    addDirectoryItem(plugin.handle, "http://bgo1.cdn.trippelm.tv/fs/live/ngrp:live_all/manifest.m3u8", li, False)
+    addDirectoryItem(plugin.handle, "http://usa1.cdn.trippelm.tv/fs/live/ngrp:live_all/manifest.m3u8", li, False)
 
     endOfDirectory(plugin.handle)
 

--- a/plugin.video.fatstone/resources/language/English/strings.xml
+++ b/plugin.video.fatstone/resources/language/English/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <string id="30005">Bitrate can be selected in Settings->System-></string>
-    <string id="30006">Internet access->Internet connection bandwidth limitation</string>
+		<string id="30007">Download error</string>
+		<string id="30008">Could not connect to server. Please try again later.</string>
 </strings>

--- a/plugin.video.fatstone/resources/language/Norwegian/strings.xml
+++ b/plugin.video.fatstone/resources/language/Norwegian/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
-    <string id="30005">Bitrate kan bli valgt i Innstillinger-></string>
-    <string id="30006">System->Internettilgang->Båndbreddebegrensning</string>
+		<string id="30007">Nedlastningsfeil</string>
+		<string id="30008">Kunne ikke koble til tjeneren. Vennligst prøv igjen senere.</string>
 </strings>

--- a/plugin.video.fatstone/resources/settings.xml
+++ b/plugin.video.fatstone/resources/settings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting label="30005" type="lsep"/>
-    <setting label="30006" type="lsep"/>
 </settings>


### PR DESCRIPTION
### Description

Made it possible for users to choose bitrate themselves. Since Kodi does not do it automatically.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
