### PR TITLE
[plugin.video.gamekings] 1.2.5

### DIFF
--- a/plugin.video.gamekings/addon.xml
+++ b/plugin.video.gamekings/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.gamekings" 
 	name="GameKings" 
-	version="1.2.4"
+	version="1.2.5"
 	provider-name="Skipmode A1, Amelandbor">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>

--- a/plugin.video.gamekings/changelog.txt
+++ b/plugin.video.gamekings/changelog.txt
@@ -1,3 +1,7 @@
+v1.2.5 (2017-03-11)
+- small fix for tv-episodes
+- added twitch 'Gamekings live' stream support by using the twitch plugin (much respect to authors of the plugin)
+
 v1.2.4 (2016-07-11)
 - fixed premium videos (!!!!) by using the vimeo plugin (big kudo's to bromix for the plugin)
 - don't change titles anymore for premium video's

--- a/plugin.video.gamekings/resources/lib/gamekings_const.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_const.py
@@ -12,5 +12,5 @@ SETTINGS = xbmcaddon.Addon(id=ADDON)
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
 BASE_URL_GAMEKINGS_TV = "http://www.gamekings.tv/"
-DATE = "2016-07-11"
-VERSION = "1.2.4"
+DATE = "2017-03-10"
+VERSION = "1.2.5"

--- a/plugin.video.gamekings/resources/lib/gamekings_main.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_main.py
@@ -50,7 +50,7 @@ class Main:
         # Afleveringen
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30001),
-                      "url": self.BASE_URL + "category/tv-afleveringen/page/001/", "next_page_possible": "True"}
+                      "url": self.BASE_URL + "page/001/?cat=3&s=gamekings+s", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30001), iconImage="DefaultFolder.png")
         is_folder = True

--- a/plugin.video.gamekings/resources/lib/gamekings_play.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_play.py
@@ -15,6 +15,7 @@ import xbmcplugin
 from gamekings_const import ADDON, SETTINGS, LANGUAGE, DATE, VERSION
 
 LOGINURL = 'http://www.gamekings.tv/wp-login.php'
+TWITCHURL =  'plugin://plugin.video.twitch/playLive/gamekings/'
 
 #
 # Main class
@@ -270,6 +271,14 @@ class Main:
                 vimeo_id = vimeo_id.replace("https://player.vimeo.com/video/", "")
                 vimeo_id = vimeo_id[0:vimeo_id.find("?")]
                 video_url = 'plugin://plugin.video.vimeo/play/?video_id=%s' % vimeo_id
+
+            list_item = xbmcgui.ListItem(path=video_url)
+            xbmcplugin.setResolvedUrl(self.plugin_handle, True, list_item)
+        #
+        # Check if it's a twitch live stream
+        #
+        elif str(html_source).find("twitch") > 0:
+            video_url = TWITCHURL
 
             list_item = xbmcgui.ListItem(path=video_url)
             xbmcplugin.setResolvedUrl(self.plugin_handle, True, list_item)


### PR DESCRIPTION
### Description
v1.2.5 (2017-03-11)
- small fix for tv-episodes
- added twitch 'Gamekings live' stream support by using the twitch plugin (much respect to authors of the plugin)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0