### PR TITLE
[plugin.video.tweakers] 1.1.8

### DIFF
--- a/plugin.video.tweakers/addon.py
+++ b/plugin.video.tweakers/addon.py
@@ -11,7 +11,7 @@ import xbmc
 import xbmcaddon
 
 LIB_DIR = xbmc.translatePath(
-    os.path.join(xbmcaddon.Addon(id="plugin.video.tweakers").getAddonInfo('path'), 'resources', 'lib'))
+    os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'lib'))
 sys.path.append(LIB_DIR)
 
 from tweakers_const import ADDON, DATE, VERSION

--- a/plugin.video.tweakers/addon.xml
+++ b/plugin.video.tweakers/addon.xml
@@ -2,8 +2,8 @@
 <addon 
 	id="plugin.video.tweakers" 
 	name="Tweakers" 
-	version="1.1.7"
-	provider-name="Skipmode A1,Amelandbor,ninovanhooff,MartijnKaijser">
+	version="1.1.8"
+	provider-name="Skipmode A1,Amelandbor,ninovanhooff,Martijn">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>
 	<import addon="script.module.beautifulsoup" version="3.0.8"/>
@@ -16,16 +16,16 @@
   	<platform>all</platform>
 	<summary lang="en">Watch tech videos from Tweakers.net (dutch)</summary>
 	<description lang="en">Watch tech videos from Tweakers.net (dutch)</description>
-	<disclaimer lang="en">For bugs, requests or general questions visit the tweakers.net thread on the XBMC forum.</disclaimer>
+	<disclaimer lang="en">For bugs, requests or general questions visit the tweakers.net thread on the Kodi forum.</disclaimer>
 	<summary lang="nl">Bekijk technologie videos van Tweakers.net (dutch)</summary>
 	<description lang="nl">Bekijk technologie videos van Tweakers.net (dutch)</description>
-	<disclaimer lang="nl">Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het XBMC forum.</disclaimer>
+	<disclaimer lang="nl">Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het Kodi forum.</disclaimer>
     <language>nl</language>
     <platform>all</platform>
     <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
     <forum>http://forum.xbmc.org/showthread.php?tid=167812</forum>
     <website>http://www.tweakers.net</website>
     <email></email>
-    <source>git://github.com/skipmodea1/plugin.video.tweakers.git</source>
+    <source>https://github.com/skipmodea1/plugin.video.tweakers</source>
   </extension>
 </addon>

--- a/plugin.video.tweakers/changelog.txt
+++ b/plugin.video.tweakers/changelog.txt
@@ -1,5 +1,10 @@
-v1.1.7 (2017-12-07): 
-(kudos to MartijnKaijser for these improvement-suggestions)
+v1.1.8 (2017-03-12):
+- fixed url in addon.xml as per request
+- changed 'xbmc' to 'kodi' in some text
+- not using addon-name in xbmcaddon.Addon() anymore (thanks enen92)
+
+v1.1.7 (2016-12-07):
+(kudos to Martijn for these improvement-suggestions)
 - improved adding info to the video
 - using higher res thumbnail if available
 - added the brief version of the plot to the video

--- a/plugin.video.tweakers/resources/language/Dutch/strings.po
+++ b/plugin.video.tweakers/resources/language/Dutch/strings.po
@@ -24,8 +24,8 @@ msgid "Watch tech videos from Tweakers.net (dutch)"
 msgstr "Bekijk technologie videos van Tweakers.net (dutch)"
 
 msgctxt "Addon Disclaimer"
-msgid "For bugs, requests or general questions visit the tweakers.net thread on the XBMC forum."
-msgstr "Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het XBMC forum."
+msgid "For bugs, requests or general questions visit the tweakers.net thread on the Kodi forum."
+msgstr "Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het Kodi forum."
 
 msgctxt "#30000"
 msgid "Videos"

--- a/plugin.video.tweakers/resources/language/English/strings.po
+++ b/plugin.video.tweakers/resources/language/English/strings.po
@@ -24,7 +24,7 @@ msgid "Watch tech videos from Tweakers.net (dutch)"
 msgstr ""
 
 msgctxt "Addon Disclaimer"
-msgid "For bugs, requests or general questions visit the tweakers.net thread on the XBMC forum."
+msgid "For bugs, requests or general questions visit the tweakers.net thread on the Kodi forum."
 msgstr ""
 
 msgctxt "#30000"

--- a/plugin.video.tweakers/resources/lib/tweakers_const.py
+++ b/plugin.video.tweakers/resources/lib/tweakers_const.py
@@ -8,8 +8,8 @@ import xbmcaddon
 # Constants
 #
 ADDON = "plugin.video.tweakers"
-SETTINGS = xbmcaddon.Addon(id=ADDON)
+SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
-IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2016-12-07"
-VERSION = "1.1.7"
+IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
+DATE = "2017-03-12"
+VERSION = "1.1.8"


### PR DESCRIPTION
### Description
v1.1.8 (2017-03-12):
- fixed url in addon.xml as per request
- changed 'xbmc' to 'kodi' in some text
- not using addon-name in xbmcaddon.Addon() anymore (thanks enen92)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0