### PR TITLE
[plugin.video.worldstarhiphop] 1.0.8

### DIFF
--- a/plugin.video.worldstarhiphop/addon.py
+++ b/plugin.video.worldstarhiphop/addon.py
@@ -15,7 +15,7 @@ import xbmcgui
 import xbmcplugin
 
 LIB_DIR = xbmc.translatePath(
-    os.path.join(xbmcaddon.Addon(id="plugin.video.worldstarhiphop").getAddonInfo('path'), 'resources', 'lib'))
+    os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'lib'))
 sys.path.append(LIB_DIR)
 
 from worldstarhiphop_const import ADDON, DATE, VERSION

--- a/plugin.video.worldstarhiphop/addon.xml
+++ b/plugin.video.worldstarhiphop/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.worldstarhiphop" 
 	name="World Star Hip Hop" 
-	version="1.0.7"
+	version="1.0.8"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>
@@ -17,13 +17,13 @@
 	<platform>all</platform>
 	<summary lang="en">Worldstarhiphop is home to everything entertainment and hip hop</summary>
     <description lang="en">Worldstarhiphop is home to everything entertainment and hip hop</description>
-    <disclaimer lang="en">For bugs, requests or general questions visit the Worldstarhiphop thread on the XBMC forum</disclaimer>
+    <disclaimer lang="en">For bugs, requests or general questions visit the Worldstarhiphop thread on the Kodi forum</disclaimer>
     <language>en</language>
     <platform>all</platform>
     <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
     <forum>http://forum.kodi.tv/showthread.php?tid=229385</forum>
     <website>http://worldstarhiphop.com/</website>
     <email></email>
-    <source>git://github.com/skipmodea1/plugin.video.worldstarhiphop.git</source>
+    <source>https://github.com/skipmodea1/plugin.video.worldstarhiphop</source>
   </extension>
 </addon>

--- a/plugin.video.worldstarhiphop/changelog.txt
+++ b/plugin.video.worldstarhiphop/changelog.txt
@@ -1,8 +1,13 @@
+v1.0.8 (2017-03-12):
+- fixed url in addon.xml as per request
+- changed 'xbmc' to 'kodi' in some text
+- not using addon-name in xbmcaddon.Addon() anymore (thanks enen92)
+- fixed po-file
+
 v1.0.7 (2016-09-21):
 - added support for youtube videos
 - changed addon debugging info to kodi debugging info
 - using po-files
-  
 
 v1.0.6 (2016-03-12):
 - changed the listing and playing of videos

--- a/plugin.video.worldstarhiphop/resources/language/English/strings.po
+++ b/plugin.video.worldstarhiphop/resources/language/English/strings.po
@@ -1,11 +1,11 @@
 # XBMC Media Center language file
-# Addon Name: World Star Candy
-# Addon id: plugin.video.worldstarcandy
+# Addon Name: World Star Hip Hop
+# Addon id: plugin.video.worldstarhiphop
 msgid ""
 msgstr ""
 "Project-Id-Version: XBMC-Addons\n"
 "Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
-"POT-Creation-Date: 2016-05-28 05:41+0000\n"
+"POT-Creation-Date: 2017-03-19 16:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE\n"
@@ -16,19 +16,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgctxt "Addon Summary"
-msgid "WorldstarCandy is a site that features videos of some of the most beautiful women on the planet"
+msgid "Worldstarhiphop is home to everything entertainment and hip hop"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "WorldstarCandy is a site that features videos of some of the most beautiful women on the planet"
+msgid "Worldstarhiphop is home to everything entertainment and hip hop"
 msgstr ""
 
 msgctxt "Addon Disclaimer"
-msgid "For bugs, requests or general questions visit the WorldstarCandy thread on the XBMC forum"
+msgid "For bugs, requests or general questions visit the Worldstarhiphop thread on the Kodi forum"
 msgstr ""
 
 msgctxt "#30000"
-msgid "WorldStarCandy.com"
+msgid "WorldStarHipHop.com"
 msgstr ""
 
 msgctxt "#30100"
@@ -68,19 +68,15 @@ msgid "Video quality"
 msgstr ""
 
 msgctxt "#30301"
-msgid "Low (if available)"
+msgid "Low"
 msgstr ""
 
 msgctxt "#30302"
-msgid "Medium (if available)"
+msgid "Medium"
 msgstr ""
 
 msgctxt "#30303"
 msgid "High (if available)"
-msgstr ""
-
-msgctxt "#30400"
-msgid "Debug"
 msgstr ""
 
 msgctxt "#30501"

--- a/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_const.py
+++ b/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_const.py
@@ -8,8 +8,8 @@ import xbmcaddon
 # Constants
 # 
 ADDON = "plugin.video.worldstarhiphop"
-SETTINGS = xbmcaddon.Addon(id=ADDON)
+SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
-IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2016-09-21"
-VERSION = "1.0.7"
+IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
+DATE = "2017-03-12"
+VERSION = "1.0.8"


### PR DESCRIPTION
### Description
v1.0.8 (2017-03-12):
- fixed url in addon.xml as per request
- changed 'xbmc' to 'kodi' in some text
- not using addon-name in xbmcaddon.Addon() anymore (thanks enen92)
- fixed po-file

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0