### PR TITLE
[plugin.video.dumpert] 1.1.4

### DIFF
--- a/plugin.video.dumpert/addon.xml
+++ b/plugin.video.dumpert/addon.xml
@@ -2,8 +2,8 @@
 <addon 
 	id="plugin.video.dumpert" 
 	name="Dumpert" 
-	version="1.1.3"
-	provider-name="Skipmode A1, Sparkline, MartijnKaiser">
+	version="1.1.4"
+	provider-name="Skipmode A1, Sparkline, Martijn">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>
 	<import addon="script.module.beautifulsoup" version="3.0.8"/>

--- a/plugin.video.dumpert/changelog.txt
+++ b/plugin.video.dumpert/changelog.txt
@@ -1,3 +1,6 @@
+v1.1.4 (2017-04-06):
+- small fix to enable starting a video with a browser (chrome and 'send to kodi'-extension)
+
 v1.1.3 (2017-03-03):
 - fixed url in addon.xml as per request
 

--- a/plugin.video.dumpert/resources/lib/dumpert_const.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_const.py
@@ -11,5 +11,5 @@ ADDON = "plugin.video.dumpert"
 SETTINGS = xbmcaddon.Addon(id=ADDON)
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2017-03-03"
-VERSION = "1.1.3"
+DATE = "2017-04-06"
+VERSION = "1.1.4"

--- a/plugin.video.dumpert/resources/lib/dumpert_play.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_play.py
@@ -41,9 +41,16 @@ class Main:
 
         # Parse parameters...
         self.video_page_url = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['video_page_url'][0]
-        # Get the title.
-        self.title = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['title'][0]
-        self.title = str(self.title)
+        # Try and get the title.
+        # When starting a video with a browser (f.e. in chrome the 'send to kodi'-extension) the url will be
+        # something like this:
+        # plugin://plugin.video.dumpert/?action=play&video_page_url=http%3A%2F%2Fwww.dumpert.nl%2Fmediabase%2F7095997%2F1f72985c%2Fmevrouw_heeft_internetje_thuis.html
+        # and there won't be a title available.
+        try:
+            self.title = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['title'][0]
+            self.title = str(self.title)
+        except KeyError:
+            self.title = ""
 
         xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
                 ADDON, VERSION, DATE, "self.video_page_url", str(self.video_page_url)), xbmc.LOGDEBUG)


### PR DESCRIPTION
### Description
v1.1.4 (2017-04-06):
- small fix to enable starting a video with a browser (chrome and 'send to kodi'-extension)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0