### PR TITLE
[plugin.video.media-ccc-de] 0.0.6 (Mark old versions as broken, see #1154).

### DIFF
--- a/plugin.video.media-ccc-de/addon.xml
+++ b/plugin.video.media-ccc-de/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.media-ccc-de" name="CCC-TV (media.ccc.de)" version="0.0.5" provider-name="Tobias Gruetzmacher">
+<addon id="plugin.video.media-ccc-de" name="CCC-TV (media.ccc.de)" version="0.0.6" provider-name="Tobias Gruetzmacher">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
     <import addon="script.module.simplejson" version="3.3.0"/>
@@ -20,6 +20,7 @@
     <license>MIT License</license>
     <website>http://media.ccc.de/</website>
     <email>tobias-xbmc@23.gs</email>
+    <broken>Using this plugin in Kodi &lt; 16 is not supported any more.</broken>
     <source>http://github.com/cccc/plugin.video.media-ccc-de</source>
   </extension>
 </addon>

--- a/plugin.video.media-ccc-de/changelog.txt
+++ b/plugin.video.media-ccc-de/changelog.txt
@@ -1,3 +1,6 @@
+v0.0.6
+- Deprecate old version for Kodi < 16.
+
 v0.0.5
 - The everything-was-broken release
 - Fix route to capture complete path (fixes #5).


### PR DESCRIPTION
### Description

Remove the old version of the plugin from the Gotham repository, to be reintroduced in Jarvis, mostly out of TLS 1.2 compatibility concerns (all media.ccc.de servers only support TLS 1.2, some still support TLS 1.1).

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
