### PR TITLE
[plugin.video.noco] v1.0.13

### DIFF
--- a/plugin.video.noco/.hg_archival.txt
+++ b/plugin.video.noco/.hg_archival.txt
@@ -1,6 +1,0 @@
-repo: c22ffed8678e5158fb1a0ee8618207621f9b049b
-node: 9b9f0b366c870b28fce41557857d203232c4c7ee
-branch: default
-latesttag: null
-latesttagdistance: 32
-changessincelatesttag: 32

--- a/plugin.video.noco/addon.py
+++ b/plugin.video.noco/addon.py
@@ -25,83 +25,262 @@ api = nocoApi()
 
 @plugin.route('/')
 def index():
-    if plugin.get_setting('username') == '' or plugin.get_setting('password') == '':
+    guest = isGuestMode()
+    if plugin.get_setting('username') == '' or plugin.get_setting('password') == '' and not guest:
         plugin.open_settings()
-    if plugin.get_setting('username') == '' or plugin.get_setting('password') == '':
+    if plugin.get_setting('username') == '' or plugin.get_setting('password') == '' and not guest:
         error=plugin.get_string('30050')
         plugin.notify(msg=error, delay=10000)
     else:
         token = getToken()
-        partners = [{
-            'label': partner['partner_name'],
-            'icon': partner['icon_1024x576'],
-            'path': plugin.url_for('indexMenu', partner=partner['partner_key'])
-            } for partner in api.get_partners(token['token'])]
-        partners.append({'label': plugin.get_string('30067'), 'path': plugin.url_for('indexPlaylists')})
-        partners.append({'label': plugin.get_string('30063'), 'path': plugin.url_for('search')})
-        return plugin.finish(partners)
+        
+        if guest:
+            rootMenuItems = [{
+                'label': partner['partner_name'],
+                'icon': partner['icon_1024x576'],
+                'path': plugin.url_for('indexLast', partner=partner['partner_key'], guest_free=True)
+                } for partner in GuestPartners()]
+        else:        
+            if plugin.get_setting('folder.playlist') == "true":
+                noco_playlists = initNocoPlaylists()
+    
+            rootMenuItems = [{
+                'label': partner['partner_name'],
+                'icon': partner['icon_1024x576'],
+                'path': plugin.url_for('indexPartner', partner=partner['partner_key'])
+                } for partner in SubscribedPartners()]
+                
+            if plugin.get_setting('folder.playlist') == "true":
+                rootMenuItems.append({
+                    'label': plugin.get_string('30067'),
+                    'path': plugin.url_for('indexPlaylists')})
+
+            if plugin.get_setting('folder.favorite') == "true":
+                rootMenuItems.append({
+                    'label': plugin.get_string('30068'),
+                    'context_menu': [(plugin.get_string('30082'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('clearFavorite')))],
+                    'path': plugin.url_for('indexFavorites')})
+
+            if plugin.get_setting('folder.history') == "true":
+                rootMenuItems.append({
+                    'label': plugin.get_string('30069'),
+                    'path': plugin.url_for('indexHistory')})
+
+            if plugin.get_setting('folder.free_content') == "true":
+                rootMenuItems.append({
+                    'label': plugin.get_string('30064'),
+                    'path': plugin.url_for('indexUserFreePartners')})
+
+            rootMenuItems.append({
+                'label': plugin.get_string('30063'),
+                'path': plugin.url_for('search')})
+
+        return plugin.finish(rootMenuItems)
 
 
 @plugin.route('/partners/<partner>')
-def indexMenu(partner):
-    index = [
-        {'label': plugin.get_string('30060'),
-        'path': plugin.url_for('indexLast', partner=partner)},
-        {'label': plugin.get_string('30066'),
-        'path': plugin.url_for('indexAll', partner=partner)},
-        {'label': plugin.get_string('30061'), 
-        'path': plugin.url_for('indexPartner', partner=partner)},
-        {'label': plugin.get_string('30065'), 
-        'path': plugin.url_for('indexTypes', partner=partner)},
-        {'label': plugin.get_string('30062'),
-        'path': plugin.url_for('indexPopular', partner=partner)},
-        ]
+def indexPartner(partner):
+    if 'guest_free' in plugin.request.args:
+        index = [
+            {'label': plugin.get_string('30060'),
+            'path': plugin.url_for('indexLast', partner=partner, guest_free=True)},
+            ]
+    elif 'user_free' in plugin.request.args:
+        index = [
+            {'label': plugin.get_string('30060'),
+            'path': plugin.url_for('indexLast', partner=partner, user_free=True)},
+            ]
+    else:
+        index = [
+            {'label': plugin.get_string('30060'),
+            'path': plugin.url_for('indexLast', partner=partner)},
+            {'label': plugin.get_string('30066'),
+            'path': plugin.url_for('indexAll', partner=partner)},
+            {'label': plugin.get_string('30061'), 
+            'path': plugin.url_for('indexThemes', partner=partner)},
+            {'label': plugin.get_string('30065'), 
+            'path': plugin.url_for('indexTypes', partner=partner)},
+            ]
+        if plugin.get_setting('folder.popular') == "true":
+            index.append({'label': plugin.get_string('30062'),
+                'path': plugin.url_for('indexPopulars', partner=partner)})
+        if plugin.get_setting('folder.top_rated') == "true":
+            index.append({'label': plugin.get_string('30070'),
+                'path': plugin.url_for('indexTopRateds', partner=partner)})
+                    
     return plugin.finish(index)
 
 @plugin.route('/partners/<partner>/last')
-def indexLast(partner):
+@plugin.route('/partners/<partner>/last/<page>', name='last_page')
+def indexLast(partner, page=None):
     token = getToken()
     videos = []
-    num_last = str(plugin.get_setting('show_last'))
-    for video in api.get_last(partner, token['token'], num_last):
-        videos.append(getVideoInfos(video))
-    return plugin.finish(videos)
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, last = api.get_last(partner, token['token'], show_per_page, num_page, guest_free='guest_free' in plugin.request.args, user_free='user_free' in plugin.request.args)
+    videos = [getVideoInfos(video) for video in last]
+    
+    UpdateTemporaryCache(videos)
 
-@plugin.route('/partners/<partner>/popular')
-def indexPopular(partner):
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' + u' \u00BB',
+            'path': plugin.url_for('last_page', partner=partner, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('last_page', partner=partner, page=str(_before)),
+        })
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
+
+@plugin.route('/partners/<partner>/populars')
+def indexPopulars(partner):
+    index = [
+        {'label': plugin.get_string('30046'),
+        'path': plugin.url_for('indexPopular', partner=partner, period='this_week')},
+        {'label': plugin.get_string('30047'),
+        'path': plugin.url_for('indexPopular', partner=partner, period='this_month')},
+        {'label': plugin.get_string('30048'),
+        'path': plugin.url_for('indexPopular', partner=partner, period='all_time')},
+        ]
+    return plugin.finish(index)
+
+@plugin.route('/partners/<partner>/popular/<period>')
+@plugin.route('/partners/<partner>/popular/<period>/<page>', name='popular_page')
+def indexPopular(partner, period, page=None):
     token = getToken()
     videos = []
-    num_last = str(plugin.get_setting('show_last'))
-    for video in api.get_popular(partner, token['token'], num_last):
-        videos.append(getVideoInfos(video))
-    return plugin.finish(videos)
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, popular = api.get_popular(partner, token['token'], show_per_page, num_page, period)
+    videos = [getVideoInfos(video) for video in popular]
+
+    UpdateTemporaryCache(videos)
+
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' +u' \u00BB',
+            'path': plugin.url_for('popular_page', partner=partner, period=period, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('popular_page', partner=partner, period=period, page=str(_before)),
+        })
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
+
+
+@plugin.route('/partners/<partner>/toprateds')
+def indexTopRateds(partner):
+    index = [
+        {'label': plugin.get_string('30046'),
+        'path': plugin.url_for('indexTopRated', partner=partner, period='this_week')},
+        {'label': plugin.get_string('30047'),
+        'path': plugin.url_for('indexTopRated', partner=partner, period='this_month')},
+        {'label': plugin.get_string('30048'),
+        'path': plugin.url_for('indexTopRated', partner=partner, period='all_time')},
+        ]
+    return plugin.finish(index)
+
+
+@plugin.route('/partners/<partner>/toprated/<period>')
+@plugin.route('/partners/<partner>/toprated/<period>/<page>', name='toprated_page')
+def indexTopRated(partner, period, page=None):
+    token = getToken()
+    videos = []
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, toprated = api.get_toprated(partner, token['token'], show_per_page, num_page, period)
+    videos = [getVideoInfos(video) for video in toprated]
+
+    UpdateTemporaryCache(videos)
+
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' +u' \u00BB',
+            'path': plugin.url_for('toprated_page', partner=partner, period=period, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('toprated_page', partner=partner, period=period, page=str(_before)),
+        })
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
+
+
+@plugin.route('/history')
+@plugin.route('/history/<page>', name='history_page')
+def indexHistory(page=None):
+    token = getToken()
+    videos = []
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, history = api.get_history(token['token'], show_per_page, num_page)
+    videos = [getVideoInfos(video) for video in history]
+
+    UpdateTemporaryCache(videos)
+
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' + u' \u00BB',
+            'path': plugin.url_for('history_page', page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('history_page', page=str(_before)),
+        })
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
 
 @plugin.route('/partners/<partner>/all')
 def indexAll(partner):
     token = getToken()
-    res = []
     shows = [{
         'icon': fam['icon_1024x576'],
         'label': fam['family_TT'],
+        'context_menu': [(plugin.get_string('30080'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('addtoFavorites', family=str(fam['id_family']))))] if plugin.get_setting('noco_favorite') == "true" else [],
         'path': plugin.url_for('indexFamily', partner=partner, theme=fam['theme_key'], family=fam['family_key'])
         } for fam in api.get_all(partner, token['token'])]
     return plugin.finish(shows)
 
 @plugin.route('/partners/<partner>/themes')
-def indexPartner(partner):
+def indexThemes(partner):
     token = getToken()
-    res = []
     themes = [{
         'icon': theme['icon'],
         'label': theme['theme_name'],
-        'path': plugin.url_for('indexThemes', partner=partner, theme=theme['theme_key'])
+        'path': plugin.url_for('indexTheme', partner=partner, theme=theme['theme_key'])
         } for theme in api.get_themes(partner, token['token'])]
     return plugin.finish(themes)
 
 @plugin.route('/partners/<partner>/types')
 def indexTypes(partner):
     token = getToken()
-    res = []
     alltypes = [{
         'icon': ty['icon'],
         'label': ty['type_name'],
@@ -110,47 +289,95 @@ def indexTypes(partner):
     return plugin.finish(alltypes)
 
 @plugin.route('/search')
-def search():
+@plugin.route('/search/<query>/<page>', name='search_page')
+def search(query=None, page=None):
     token = getToken()
     videos = []
-    query = plugin.keyboard(heading=plugin.get_string('30064'))
-    try:
-        for video in api.search(query, token['token']):
-            videos.append(getVideoInfos(video))
-        return plugin.finish(videos)
-    except:
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    if query == None:
+        query = plugin.keyboard(heading=plugin.get_string('30045'))
+    if query == None:
+        return
+
+    hasNextPage, search = api.search(query, token['token'], show_per_page, num_page)
+
+    if num_page == 0 and not len(search):
         error=plugin.get_string('30051').encode('utf-8')
         plugin.notify(msg=error, delay=5000)
+        return
+     
+    videos = [getVideoInfos(video) for video in search]
+
+    UpdateTemporaryCache(videos)
+
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' + u' \u00BB',
+            'path': plugin.url_for('search_page', query=query, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('search_page', query=query, page=str(_before)),
+        })
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
 
 
 @plugin.route('/playlists')
 def indexPlaylists():
+    noco_playlists = plugin.get_storage('noco_playlists')
     token = getToken()
     playlists = [{
-        'label': playlist['playlist_title'],
-        'context_menu': [(plugin.get_string('30042'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queuePlaylist', playlist=playlist['playlist'])))],
-        'path': plugin.url_for('indexPlaylist', playlist=playlist['playlist'])
-        } for playlist in api.get_playlists(token['token'])]
+        'label': playlist,
+        'context_menu': [(plugin.get_string('30042'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queuePlaylist', playlist=playlist))),
+                         (plugin.get_string('30094'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('clearPlaylist', playlist=playlist)))],
+        'path': plugin.url_for('indexPlaylist', playlist=playlist)
+        } for playlist in sorted(noco_playlists.keys())]
     return plugin.finish(playlists)
+
 
 @plugin.route('/playlists/<playlist>')
 def indexPlaylist(playlist):
-    token = getToken()
-    videos = []
-    for video in playlist.split(','):
-        v = api.get_videodata(token['token'], video)
-        videos.append(getVideoInfos(v))
+    noco_playlists = plugin.get_storage('noco_playlists')
+    videos = noco_playlists[playlist]
     return plugin.finish(filterSeenVideos(videos))
 
+
+@plugin.route('/favorites')
+def indexFavorites():
+    token = getToken()
+    shows = []
+    favorites = api.get_favorites(token['token'])
+
+    if favorites['favorites']: 
+        fids = [int(fid) for fid in str(favorites['favorites']).split(',')]
+        shows = [{
+            'icon': fam['icon_1024x576'],
+            'label': fam['family_TT'],
+            'context_menu': [(plugin.get_string('30081'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('delfromFavorites', family=str(fam['id_family']))))],
+            'path': plugin.url_for('indexFamily', partner=str(fam['id_partner']), theme=fam['theme_key'], family=fam['family_key'])
+            } for fam in api.get_fambyids(token['token'], fids)]
+    return plugin.finish(shows)
+
+
 @plugin.route('/partners/<partner>/themes/<theme>')
-def indexThemes(partner, theme):
+def indexTheme(partner, theme):
     token = getToken()
     families = [{
         'icon': family['icon_1024x576'],
         'label': family['family_OT'],
+        'context_menu': [(plugin.get_string('30080'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('addtoFavorites', family=str(family['id_family']))))] if plugin.get_setting('noco_favorite') == "true" else [],
         'path': plugin.url_for('indexFamily', partner=partner, theme=theme, family=family['family_key'])
         } for family in api.get_families(partner, theme, token['token'])]
     return plugin.finish(families)
+
 
 @plugin.route('/partners/<partner>/types/<typename>')
 def indexByType(partner, typename):
@@ -158,42 +385,94 @@ def indexByType(partner, typename):
     families = [{
         'icon': family['icon_1024x576'],
         'label': family['family_OT'],
+        'context_menu': [(plugin.get_string('30080'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('addtoFavorites', family=str(family['id_family']))))] if plugin.get_setting('noco_favorite') == "true" else [],
         'path': plugin.url_for('indexFamType', partner=partner, typename=typename, family=family['family_key'])
         } for family in api.get_fambytype(partner, typename, token['token'])]
     return plugin.finish(families)
 
+
 @plugin.route('/partners/<partner>/themes/<theme>/families/<family>')
-def indexFamily(partner, theme, family):
+@plugin.route('/partners/<partner>/themes/<theme>/families/<family>/<page>', name='family_page')
+def indexFamily(partner, theme, family, page=None):
     token = getToken()
     videos = []
-    num_video = str(plugin.get_setting('show_n'))
-    for video in api.get_videos(partner, family, token['token'], num_video):
-        videos.append(getVideoInfos(video))
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, shows = api.get_videos(partner, family, token['token'], show_per_page, num_page)
+    videos = [getVideoInfos(video) for video in shows]
+
+    UpdateTemporaryCache(videos)
+        
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' +u' \u00BB',
+            'path': plugin.url_for('family_page', partner=partner, theme=theme, family=family, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('family_page', partner=partner, theme=theme, family=family, page=str(_before)),
+        })
+
     if plugin.get_setting('random') == "true":
-        rand = { 'label': plugin.get_string('30040'), 'path': plugin.url_for('playVideo', partner=partner, family=family, video='RANDOM'), 'is_playable': True}
+        rand = { 'label': plugin.get_string('30040'),
+                 'properties': {'totaltime': unicode(1),'resumetime': unicode(0)},
+                 'path': plugin.url_for('playVideo', partner=partner, family=family, video='RANDOM'),
+                 'is_playable': True}
         videos.insert(0, rand)
-    return plugin.finish(videos)
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
 
 @plugin.route('/partners/<partner>/types/<typename>/families/<family>')
-def indexFamType(partner, typename, family):
+@plugin.route('/partners/<partner>/types/<typename>/families/<family>/<page>', name='famtype_page')
+def indexFamType(partner, typename, family, page=None):
     token = getToken()
     videos = []
-    num_video = str(plugin.get_setting('show_n'))
-    for video in api.get_videos(partner, family, token['token'], num_video):
-        videos.append(getVideoInfos(video))
+    num_page = 0 if page == None else int(page)
+    show_per_page = int(plugin.get_setting('show_per_page'))
+    hasNextPage, shows = api.get_videos(partner, family, token['token'], show_per_page, num_page)
+    videos = [getVideoInfos(video) for video in shows]
+
+    UpdateTemporaryCache(videos)
+
+    # pagination list items
+    _before = num_page - 1 if num_page > 0 else None 
+    _after = num_page + 1 if hasNextPage else None
+    if not _after == None:
+        videos.append( {
+            'label': u'...' + plugin.get_string('30043') + ' (' + str(_after+1) + ')' +u' \u00BB',
+            'path': plugin.url_for('famtype_page', partner=partner, typename=typename, family=family, page=str(_after)),
+        })
+
+    if not _before == None:
+        videos.insert(0, {
+            'label': u'\u00AB ' + '(' + str(_before+1)  + ') ' + plugin.get_string('30044') + u'...',
+            'path': plugin.url_for('famtype_page', partner=partner, typename=typename, family=family, page=str(_before)),
+        })
+
     if plugin.get_setting('random') == "true":
-        rand = { 'label': plugin.get_string('30040'), 'path': plugin.url_for('playVideo', partner=partner, family=family, video='RANDOM'), 'is_playable': True}
+        rand = { 'label': plugin.get_string('30040'),
+                 'properties': {'totaltime': unicode(1),'resumetime': unicode(0)},
+                 'path': plugin.url_for('playVideo', partner=partner, family=family, video='RANDOM'),
+                 'is_playable': True}
         videos.insert(0, rand)
-    return plugin.finish(videos)
+
+    update_listing = page is not None
+    return plugin.finish(videos, update_listing=update_listing)
 
 @plugin.route('/queue/<video>')
 def queueVideo(video):
     token = getToken()
     quality = getQuality()
-    v = api.get_videodata(token['token'], video)
-    item = getVideoInfos(v)
+    v = api.get_videodata(token['token'], [int(video)])
+    item = getVideoInfos(v[0])
     item['path'] = api.get_video(video, token['token'], quality)
-    item.pop('context_menu', None) # removing specific ctx menu (Queue item) from playlist item
+    item.pop('context_menu', None) # removing all addon specific ctx menu (Queue item, Add to ...) from item
     items = [item]
     plugin.add_to_playlist(items, 'video')
 
@@ -202,14 +481,26 @@ def queuePlaylist(playlist):
     token = getToken()
     quality = getQuality()
     items = []
-    for video in playlist.split(','):
-        v = api.get_videodata(token['token'], video)
-        item = getVideoInfos(v)
-        item['path'] = api.get_video(video, token['token'], quality)
+    noco_playlists = plugin.get_storage('noco_playlists')
+    for item in noco_playlists[playlist]:
+        item['path'] = api.get_video(item['properties']['noco_id_show'], token['token'], quality)
         item.pop('context_menu', None) # removing specific ctx menu (Queue item) from playlist item
         items.append(item)
     items = filterSeenVideos(items)
     plugin.add_to_playlist(items, 'video')
+
+@plugin.route('/clear/playlist/<playlist>')
+def clearPlaylist(playlist):
+    token = getToken()
+    api.clear_playlist(token['token'])
+    noco_playlists = plugin.get_storage('noco_playlists')
+    noco_playlists[playlist] = []
+    noco_playlists.sync()
+
+@plugin.route('/clear/favorite')
+def clearFavorite():
+    token = getToken()
+    api.clear_playlist(token['token'])
 
 @plugin.route('/partners/<partner>/families/<family>/<video>')
 def playVideo(partner, family, video):
@@ -224,7 +515,173 @@ def playVideo(partner, family, video):
     else: 
         plugin.set_resolved_url(api.get_video(video, token['token'], quality))
 
+
+@plugin.route('/addtoplaylist/<playlist>/<video>')
+def addtoPlaylist(playlist, video):
+    noco_playlists = plugin.get_storage('noco_playlists')
+    token = getToken()
+    temp_items = plugin.get_storage('temp_items')
+    temp_item = temp_items[video]
+    temp_item['context_menu'] = [temp_item['context_menu'][0]] # Keep only Queue item
+    temp_item['context_menu'].append((plugin.get_string('30091'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('delfromPlaylist', playlist=playlist, video=video))))
+    temp_item['context_menu'].append((plugin.get_string('30092'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveupinPlaylist', playlist=playlist, video=video))))
+    temp_item['context_menu'].append((plugin.get_string('30093'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('movedowninPlaylist', playlist=playlist, video=video))))
+    temp_item['context_menu'].append((plugin.get_string('30095'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveinPlaylist', playlist=playlist, video=video))))
+    playlist_vids = [int(item['properties']['noco_id_show']) for item in noco_playlists[playlist]]
+    vid = int(video)
+    if not vid in playlist_vids:
+        # upd noco queuelist
+        playlist_vids.append(vid)
+        api.set_playlist(token['token'], playlist_vids)
+        # upd noco_playlists obj 
+        noco_playlists[playlist].append(temp_item)
+        noco_playlists.sync()
+
+
+@plugin.route('/delfromplaylist/<playlist>/<video>')
+def delfromPlaylist(playlist, video):
+    noco_playlists = plugin.get_storage('noco_playlists')
+    token = getToken()
+    # remove matching indexes
+    match_indexes = [idx for idx,item in enumerate(noco_playlists[playlist]) if item['properties']['noco_id_show'] == video]
+    for i in reversed(match_indexes):
+        del noco_playlists[playlist][i]    
+
+    playlist_vids = [int(item['properties']['noco_id_show']) for item in noco_playlists[playlist]]
+    api.set_playlist(token['token'], playlist_vids)
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/moveupinPlaylist/<playlist>/<video>')
+def moveupinPlaylist(playlist, video):
+    noco_playlists = plugin.get_storage('noco_playlists')
+    token = getToken()
+    # search index to move
+    for idx,item in enumerate(noco_playlists[playlist]):
+        if item['properties']['noco_id_show'] == video:
+            if idx > 0: # do not move up 1st item
+                noco_playlists[playlist][idx-1], noco_playlists[playlist][idx] = noco_playlists[playlist][idx], noco_playlists[playlist][idx-1]
+            break
+
+    playlist_vids = [int(item['properties']['noco_id_show']) for item in noco_playlists[playlist]]
+    api.set_playlist(token['token'], playlist_vids)
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/movedowninPlaylist/<playlist>/<video>')
+def movedowninPlaylist(playlist, video):
+    noco_playlists = plugin.get_storage('noco_playlists')
+    token = getToken()
+    # search index to move
+    for idx,item in enumerate(noco_playlists[playlist]):
+        if item['properties']['noco_id_show'] == video:
+            if idx < len(noco_playlists[playlist])-1: # do not move down last item
+                noco_playlists[playlist][idx+1], noco_playlists[playlist][idx] = noco_playlists[playlist][idx], noco_playlists[playlist][idx+1]
+            break
+
+    playlist_vids = [int(item['properties']['noco_id_show']) for item in noco_playlists[playlist]]
+    api.set_playlist(token['token'], playlist_vids)
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/moveinPlaylist/<playlist>/<video>')
+def moveinPlaylist(playlist, video):
+    token = getToken()
+    noco_playlists = plugin.get_storage('noco_playlists')
+    # search index to move
+    for idx,item in enumerate(noco_playlists[playlist]):
+        if item['properties']['noco_id_show'] == video:
+            idx_from = idx
+            break
+    # switch context menu to target
+    for idx,item in enumerate(noco_playlists[playlist]):
+        ctx_items = []
+        if not idx == idx_from:
+            ctx_items.append((plugin.get_string('30097'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('movehereinPlaylist', playlist=playlist, from_idx=str(idx_from), to_idx=str(idx)))))
+        ctx_items.append((plugin.get_string('30096'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('cancelmoveinPlaylist', playlist=playlist))))
+        noco_playlists[playlist][idx]['context_menu'] = ctx_items
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/cancelmoveinPlaylist/<playlist>')
+def cancelmoveinPlaylist(playlist):
+    noco_playlists = plugin.get_storage('noco_playlists')
+    # switch context menu back to normal
+    for idx,item in enumerate(noco_playlists[playlist]):
+        vid = item['properties']['noco_id_show']
+        ctx_items = [(plugin.get_string('30041'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queueVideo', video=vid)))]
+        ctx_items.append((plugin.get_string('30091'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('delfromPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30092'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveupinPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30093'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('movedowninPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30095'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveinPlaylist', playlist=playlist, video=vid))))
+        noco_playlists[playlist][idx]['context_menu'] = ctx_items
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/movehereinPlaylist/<playlist>/<from_idx>/<to_idx>')
+def movehereinPlaylist(playlist, from_idx, to_idx):
+    token = getToken()
+    noco_playlists = plugin.get_storage('noco_playlists')
+    noco_playlists[playlist].insert(int(to_idx), noco_playlists[playlist].pop(int(from_idx)))
+    # switch context menu back to normal
+    for idx,item in enumerate(noco_playlists[playlist]):
+        vid = item['properties']['noco_id_show']
+        ctx_items = [(plugin.get_string('30041'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queueVideo', video=vid)))]
+        ctx_items.append((plugin.get_string('30091'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('delfromPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30092'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveupinPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30093'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('movedowninPlaylist', playlist=playlist, video=vid))))
+        ctx_items.append((plugin.get_string('30095'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveinPlaylist', playlist=playlist, video=vid))))
+        noco_playlists[playlist][idx]['context_menu'] = ctx_items
+    playlist_vids = [int(item['properties']['noco_id_show']) for item in noco_playlists[playlist]]
+    api.set_playlist(token['token'], playlist_vids)
+    noco_playlists.sync()
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/addtoFavorites/<family>')
+def addtoFavorites(family):
+    token = getToken()
+    favorites = api.get_favorites(token['token'])
+    fids = []
+    if favorites['favorites']: 
+        fids = [int(fid) for fid in str(favorites['favorites']).split(',')]
+    fids.append(int(family))
+    api.set_favorite(token['token'], fids)
+
+
+@plugin.route('/delfromFavorites/<family>')
+def delfromFavorites(family):
+    token = getToken()
+    favorites = api.get_favorites(token['token'])
+    if favorites['favorites']: 
+        fids = [int(fid) for fid in str(favorites['favorites']).split(',')]
+
+    # remove matching indexes
+    match_indexes = [idx for idx,fid in enumerate(fids) if fid == int(family)]
+    for i in reversed(match_indexes):
+        del fids[i]    
+    api.set_favorite(token['token'], fids)
+    xbmc.executebuiltin('Container.Refresh')
+
+
+@plugin.route('/userfreepartners')
+def indexUserFreePartners():
+    token = getToken()
+    menu = [{
+        'label': partner['partner_name'],
+        'icon': partner['icon_1024x576'],
+        'path': plugin.url_for('indexLast', partner=partner['partner_key'], user_free=True)
+        } for partner in UserFreePartners()]
+    return plugin.finish(menu)
+
+
 def getVideoInfos(video):
+    guest = isGuestMode()
     if str(video['episode_number']) == '0':
         if video['show_TT'] == None:
             label = video['family_TT'].encode('utf-8')
@@ -243,7 +700,7 @@ def getVideoInfos(video):
         resume = video['show_resume']
     else:
         resume =  video['family_resume']+'\n\n'+video['show_resume']
-    if video['mark_read'] == 1:
+    if not guest and video['mark_read'] == 1:
         read = '1'
     else:
         read = '0'
@@ -264,18 +721,24 @@ def getVideoInfos(video):
         'aired': video['online_date_start_utc']
         }
     properties = {
-        'fanart_image': video['banner_family']
+        'fanart_image': video['banner_family'],
+        'noco_id_show': unicode(video['id_show'])
     }
     if read == '0':
         totaltime  = unicode(video['duration_ms']/1000)
-        resumetime = unicode(video['resume_play']/1000)
+        if not guest:
+            resumetime = unicode(video['resume_play']/1000)
+        else:
+            resumetime = unicode(0)
         properties['totaltime']  = totaltime
         properties['resumetime'] = resumetime
     stream_infos = {'video': {'duration': video['duration_ms']/1000 }}
 
-    # Add specific ctx menu for queueing item
-    # XBMC.Action(Queue) doesn't work on Android (tested with Kodi 17.1)
-    ctx_items = [(plugin.get_string('30041'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queueVideo', video=video['id_show'])))]
+    # Add specific ctx menu for queueing item and adding to Noco playlist
+    ctx_items = [(plugin.get_string('30041'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('queueVideo', video=str(video['id_show']))))]
+    if not guest and plugin.get_setting('noco_playlist') == "true":
+        noco_playlists = plugin.get_storage('noco_playlists')
+        ctx_items = ctx_items + [(plugin.get_string('30090') % name, 'XBMC.RunPlugin(%s)' % (plugin.url_for('addtoPlaylist', playlist=name, video=str(video['id_show'])))) for name in noco_playlists.keys()]
 
     v = {
         'label': label.decode("utf-8"),
@@ -293,15 +756,75 @@ def getVideoInfos(video):
 
 def getToken():
     token = plugin.get_storage('token')
-    username = plugin.get_setting('username')
-    password = plugin.get_setting('password')
+    guest = isGuestMode()
+
     if 'token' in token:
-        if float(token['expire']) < ( time.time() + 600 ):
-            #token['token'], token['expire'], token['renew'] = api.renew_token(token['renew'])
-            token['token'], token['expire'], token['renew'] = api.get_token(username, password)
-    else:
+        # detect switch guest/user mode
+        switchMode = (guest == (not 'guest' in token)) 
+        if not switchMode and float(token['expire']) > time.time() + 600 :
+            return token
+        
+    if not guest:
+        username = plugin.get_setting('username')
+        password = plugin.get_setting('password')
+        #token['token'], token['expire'], token['renew'] = api.renew_token(token['renew'])
         token['token'], token['expire'], token['renew'] = api.get_token(username, password)
+        token.pop('guest', None)
+    else:
+        token['token'], token['expire'] = api.get_guest_token()
+        token['guest'] = 1
     return token
+
+def initNocoPlaylists():
+    plist = plugin.get_storage('noco_playlists')
+    token = getToken()
+    for playlist in api.get_playlists(token['token']):
+        videos = []
+        if not playlist['playlist'] == '': 
+            vids = api.get_videodata(token['token'], eval('['+str(playlist['playlist'])+']'))
+            for video in vids:
+                item = getVideoInfos(video)
+                item['context_menu'] = [item['context_menu'][0]] # Keep only Queue item
+                item['context_menu'].append((plugin.get_string('30091'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('delfromPlaylist', playlist=playlist['playlist_title'], video=video['id_show']))))
+                item['context_menu'].append((plugin.get_string('30092'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveupinPlaylist', playlist=playlist['playlist_title'], video=video['id_show']))))
+                item['context_menu'].append((plugin.get_string('30093'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('movedowninPlaylist', playlist=playlist['playlist_title'], video=video['id_show']))))
+                item['context_menu'].append((plugin.get_string('30095'), 'XBMC.RunPlugin(%s)' % (plugin.url_for('moveinPlaylist', playlist=playlist['playlist_title'], video=video['id_show']))))
+                videos.append(item)
+        plist[playlist['playlist_title']] = videos
+    return plist
+
+def UpdateTemporaryCache(videos):
+    # Each time we show a listing with playable items, we store the items in
+    # temporary storage. Then, if a user add the item to a playlist, we already
+    # have all the metadata available.
+    temp_items = plugin.get_storage('temp_items')
+    temp_items.clear()
+
+    # Need to use the same referenced dict object for the cache, so we call
+    # update() instead of assigning to a new dict.
+    temp_items.update((item['properties']['noco_id_show'], item) for item in videos)
+
+# Cache to not always loop on partners and check for free contents (to avoid too many requests)
+def UserFreePartners():
+    partners = plugin.get_storage('noco_partners',TTL=24*60)
+    if not 'user_free' in partners:
+        token = getToken()
+        partners['user_free'] = api.get_user_free_partners(token['token'])
+    return partners['user_free']
+
+def GuestPartners():
+    partners = plugin.get_storage('noco_partners',TTL=24*60)
+    if not 'guest' in partners:
+        token = getToken()
+        partners['guest'] = api.get_guest_partners(token['token'])
+    return partners['guest']
+
+def SubscribedPartners():
+    partners = plugin.get_storage('noco_partners',TTL=24*60)
+    if not 'subscribed' in partners:
+        token = getToken()
+        partners['subscribed'] = api.get_subscribed_partners(token['token'])
+    return partners['subscribed']
 
 def getQuality():
     quality = plugin.get_setting('quality')
@@ -316,6 +839,9 @@ def getQuality():
     if quality == "4": 
         quality = 'HD_1080' 
     return quality
+
+def isGuestMode():
+    return True if plugin.get_setting('guest') == "true" else False
 
 def filterSeenVideos(videos):
     if plugin.get_setting('showseen') == 'true':

--- a/plugin.video.noco/addon.xml
+++ b/plugin.video.noco/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.noco" name="noco" version="1.0.13" provider-name="Julien Gormotte (gormux)">
   <requires>
-    <import addon="xbmc.python" version="2.1.14"/>
+    <import addon="xbmc.python" version="2.14.0"/>
     <import addon="script.module.xbmcswift2" version="2.4.0"/>
     <import addon="script.module.requests" version="2.3.0"/>
   </requires>

--- a/plugin.video.noco/addon.xml
+++ b/plugin.video.noco/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.noco" name="noco" version="1.0.12" provider-name="Julien Gormotte (gormux)">
+<addon id="plugin.video.noco" name="noco" version="1.0.13" provider-name="Julien Gormotte (gormux)">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.xbmcswift2" version="2.4.0"/>
@@ -18,8 +18,8 @@
     <email>julien@gormotte.info</email>
     <summary lang="fr">Plugin pour noco.tv</summary>
     <summary lang="en">Plugin for noco.tv</summary>
-    <description lang="fr">Un plugin pour acceder aux services de noco.tv. Necessite un compte pour fonctionner</description>
-    <description lang="en">A plugin to access noco.tv services. An account is needed for the plugin to work</description>
+    <description lang="fr">Un plugin pour accéder aux services de noco.tv. Nécessite un compte pour fonctionner. Un mode invité est disponible avec un contenu limité.</description>
+    <description lang="en">A plugin to access noco.tv services. An account is needed for the plugin to work. A guest mode is available with limited content.</description>
     <disclaimer lang="fr">Ce plugin n'est ni publié ni maintenu par noco, et donc non officiel.</disclaimer>
     <disclaimer lang="en">This plugin is not official. Any questions are for me and not noco stafff.</disclaimer>
   </extension>

--- a/plugin.video.noco/addon.xml
+++ b/plugin.video.noco/addon.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.noco" name="noco" version="1.0.13" provider-name="Julien Gormotte (gormux)">
   <requires>
-    <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="xbmc.python" version="2.1.14"/>
     <import addon="script.module.xbmcswift2" version="2.4.0"/>
     <import addon="script.module.requests" version="2.3.0"/>
   </requires>
@@ -17,10 +17,10 @@
     <source>http://dev.gormotte.info/plugin.video.noco</source>
     <email>julien@gormotte.info</email>
     <summary lang="fr">Plugin pour noco.tv</summary>
-    <summary lang="en">Plugin for noco.tv</summary>
+    <summary lang="en_GB">Plugin for noco.tv</summary>
     <description lang="fr">Un plugin pour accéder aux services de noco.tv. Nécessite un compte pour fonctionner. Un mode invité est disponible avec un contenu limité.</description>
-    <description lang="en">A plugin to access noco.tv services. An account is needed for the plugin to work. A guest mode is available with limited content.</description>
+    <description lang="en_GB">A plugin to access noco.tv services. An account is needed for the plugin to work. A guest mode is available with limited content.</description>
     <disclaimer lang="fr">Ce plugin n'est ni publié ni maintenu par noco, et donc non officiel.</disclaimer>
-    <disclaimer lang="en">This plugin is not official. Any questions are for me and not noco stafff.</disclaimer>
+    <disclaimer lang="en_GB">This plugin is not official. Any questions are for me and not noco stafff.</disclaimer>
   </extension>
 </addon>

--- a/plugin.video.noco/changelog.txt
+++ b/plugin.video.noco/changelog.txt
@@ -26,3 +26,32 @@ v1.0.8
  - Now the plugin only shows subscribed sections (in the menus, still to do in
  search results)
  - Do not show episode number when not set
+
+v1.0.9
+  - Changed requirement from resquests2 to requests
+  - Changed fanart
+
+v1.0.10
+  - Corrected version number on requests
+
+v1.0.11
+  - Corrected a bug in the process to get the "code" from the api (Thanks to Tsukaniki for the solution)
+    http://forum.nolife-tv.com/showpost.php?p=2464647&postcount=447
+   
+v1.0.12
+  - Support for queuing an item on Kodi video playlist
+  - Support for queuing the complete "Noco playlist" (File d'attente) on Kodi video playlist
+
+v1.0.13
+  - Navigation in list of videos now shows N items per page and navigations items (Next page, Previous page)
+  - Add "Free content" entry to see free content of other catalogs (when logged as user) 
+  - Add setting to use in guest mode to see free content without being logged (some recent videos from Nolife catalog)
+  - Adding "History" entry to view previously seen video
+  - "Most popular" entry allows to choose the period of popularity (week, month, all time) 
+  - Adding "Top Rated" entry 
+  - Renaming "Playlists" entry by "Noco playlists" (only "File d'attente" inside atm)
+  - Adding basic support on "Noco playlists" : adding/deleting/moving videos & clear/queue playlist
+  - Adding "Noco favorite shows" entry with basic support (adding/deleting favorite shows, clear favorites)
+  - Already seen videos are now filtered directly within noco api request
+  - Random video is now asked using a noco api request (faster)
+  

--- a/plugin.video.noco/resources/language/English/strings.xml
+++ b/plugin.video.noco/resources/language/English/strings.xml
@@ -2,17 +2,16 @@
 <strings>
     <!-- Parameters -->
     <string id="30001">Authentication</string>
-    <string id="30002">Use a noco account</string>
+    <string id="30002">Guest mode</string>
     <string id="30003">Username</string>
     <string id="30004">Password</string>
     <string id="30005">See previews</string>
     <string id="30006">Appearance</string>
     <string id="30007">Order by</string>
     <string id="30008">Show all videos</string>
-    <string id="30009">Number of videos to show</string>
     <string id="30010">Quality</string>
     <string id="30011">Show already seen videos</string>
-    <string id="30012">Number of shows in last shows</string>
+    <string id="30012">Number of shows per page</string>
     <string id="30013">Autorefresh directories</string>
     <string id="30024">Show autopromos</string>
     <string id="30025">Show announces</string>
@@ -21,25 +20,57 @@
     <string id="30028">Show subtitles when available</string>
     <string id="30029">Preferred language for subtitles</string>
     <string id="30030">Show a random element in directories</string>
+    <string id="30031">Folders</string>
+    <string id="30032">Show Noco playlists</string>
+    <string id="30033">Show Noco favorites shows</string>
+    <string id="30034">Show History</string>
+    <string id="30035">Show Free Content</string>
+    <string id="30036">Not available in guest mode</string>
+    <string id="30037">Show Most popular</string>
+    <string id="30038">Show Top Rated</string>
 
     <!-- Various strings -->
     <string id="30040">Random</string>
     <string id="30041">Queue item</string>
     <string id="30042">Queue playlist</string>
+    <string id="30043">Next page</string>
+    <string id="30044">Previous page</string>
+    <string id="30045">Enter your search terms</string>
+    <string id="30046">This week</string>
+    <string id="30047">This month</string>
+    <string id="30048">All time</string>
 
     <!-- Messages -->
-    <string id="30050">You MUST provide a user and a password !</string>
+    <string id="30050">You MUST provide a user and a password  or use Guest mode !</string>
     <string id="30051">The search did not return any results</string>
     <string id="30052">Did not found any not played element</string>
 
     <!-- Categories names -->
     <string id="30060">Last videos</string>
     <string id="30061">Themes</string>
-    <string id="30065">Types</string>
     <string id="30062">Most popular</string>
     <string id="30063">Search</string>
-    <string id="30064">Enter your search terms</string>
+    <string id="30064">Free content</string>
+    <string id="30065">Types</string>
     <string id="30066">All shows</string>
-    <string id="30067">Playlists</string>
+    <string id="30067">Noco playlists</string>
+    <string id="30068">Noco favorite shows</string>
+    <string id="30069">View history</string>
+    <string id="30070">Top Rated</string>
+
+    <!-- Noco favorites -->
+    <string id="30080">Add to favorites shows</string>
+    <string id="30081">Remove</string>
+    <string id="30082">Clear</string>
+
+    <!-- Noco playlist -->
+    <string id="30090">Add to %s (noco)</string>
+    <string id="30091">Remove</string>
+    <string id="30092">Move up</string>
+    <string id="30093">Move down</string>
+    <string id="30094">Clear</string>
+    <string id="30095">Move item</string>
+    <string id="30096">Cancel move</string>
+    <string id="30097">Move item here</string>
 
 </strings>

--- a/plugin.video.noco/resources/language/French/strings.xml
+++ b/plugin.video.noco/resources/language/French/strings.xml
@@ -2,17 +2,16 @@
 <strings>
     <!-- Paramètres -->
     <string id="30001">Authentification</string>
-    <string id="30002">Utiliser un compte noco</string>
+    <string id="30002">Mode invité</string>
     <string id="30003">Nom d'utilisateur</string>
     <string id="30004">Mot de passe</string>
     <string id="30005">Voir les extraits des émissions</string>
     <string id="30006">Apparence</string>
     <string id="30007">Classement</string>
     <string id="30008">Afficher toutes les émissions</string>
-    <string id="30009">Nombre d'émissions à afficher</string>
     <string id="30010">Qualité vidéo</string>
     <string id="30011">Afficher les émissions déjà vues</string>
-    <string id="30012">Nombre d'émissions dans les récentes</string>
+    <string id="30012">Nombre d'émissions par page</string>
     <string id="30013">Rafraichir automatiquement les dossiers</string>
     <string id="30024">Afficher les autopromos</string>
     <string id="30025">Afficher les annonces</string>
@@ -21,25 +20,57 @@
     <string id="30028">Afficher les sous titres si disponibles</string>
     <string id="30029">Langue préférée pour les sous titres</string>
     <string id="30030">Afficher un élément aléatoire dans les dossiers</string>
+    <string id="30031">Dossiers</string>
+    <string id="30032">Afficher la liste de lecture noco</string>
+    <string id="30033">Afficher les émissions favorites noco</string>
+    <string id="30034">Afficher l'historique</string>
+    <string id="30035">Afficher le contenu gratuit</string>
+    <string id="30036">Non disponible en mode invité</string>
+    <string id="30037">Afficher Les plus populaires</string>
+    <string id="30038">Afficher Les mieux évalués</string>
 
     <!-- Various strings -->
     <string id="30040">Aléatoire</string>
     <string id="30041">Placer en file d'attente</string>
     <string id="30042">Placer la liste en file d'attente</string>
+    <string id="30043">Page suivante</string>
+    <string id="30044">Page précédente</string>
+    <string id="30045">Entrez votre recherche</string>
+    <string id="30046">Cette semaine</string>
+    <string id="30047">Ce mois</string>
+    <string id="30048">Depuis le début</string>
 
     <!-- Messages -->
-    <string id="30050">Vous DEVEZ fournir un utilisateur et un mot de passe !</string>
+    <string id="30050">Vous DEVEZ fournir un utilisateur et un mot de passe ou alors utiliser le mode invité !</string>
     <string id="30051">La recherche n'a donné aucun résultat</string>
     <string id="30052">Aucun élément non lu trouvé !</string>
 
     <!-- Categories names -->
     <string id="30060">Dernières vidéos</string>
     <string id="30061">Emissions par thème</string>
-    <string id="30065">Emissions par type</string>
     <string id="30062">Les plus populaires</string>
     <string id="30063">Recherche</string>
-    <string id="30064">Entrez votre recherche</string>
+    <string id="30064">Contenu gratuit</string>
+    <string id="30065">Emissions par type</string>
     <string id="30066">Toutes les émissions</string>
-    <string id="30067">Listes de lecture</string>
+    <string id="30067">Listes de lecture noco</string>
+    <string id="30068">Émissions favorites noco</string>
+    <string id="30069">Voir l'historique</string>
+    <string id="30070">Les mieux évalués</string>
     
+    <!-- Noco favorites -->
+    <string id="30080">Ajouter aux émissions favorites</string>
+    <string id="30081">Retirer</string>
+    <string id="30082">Effacer</string>
+
+    <!-- Noco playlist -->
+    <string id="30090">Ajouter à %s (noco)</string>
+    <string id="30091">Retirer</string>
+    <string id="30092">Monter</string>
+    <string id="30093">Descendre</string>
+    <string id="30094">Effacer</string>
+    <string id="30095">Déplacer l'élément</string>
+    <string id="30096">Annuler le déplacement</string>
+    <string id="30097">Déplacer l'élément ici</string>
+
 </strings>

--- a/plugin.video.noco/resources/settings.xml
+++ b/plugin.video.noco/resources/settings.xml
@@ -3,13 +3,13 @@
 
     <!-- Authentication -->
     <category label="30001">
-        <setting id="username" type="text" label="30003" default="" />
-        <setting id="password" type="text" option="hidden" label="30004" default=""/>
+        <setting id="guest" type="bool" label="30002" default="false" />
+        <setting id="username" type="text" label="30003" default="" visible="eq(-1,false)"/>
+        <setting id="password" type="text" option="hidden" label="30004" default="" visible="eq(-2,false)"/>
     </category>
     <!-- Affichage -->
     <category label="30006">
-        <setting id="show_n" subsetting="true" type="slider" label="30009" default="100" range="10,10,1000" option="int"/>
-        <setting id="show_last" subsetting="true" type="slider" label="30012" default="30" range="10,10,100" option="int"/>
+        <setting id="show_per_page" type="slider" label="30012" default="30" range="10,10,100" option="int"/>
         <setting id="showseen" type="bool" label="30011" default="true"/>
         <setting id="quality" type="labelenum" label="30010" values="LQ|HQ|TV|HD_720|HD_1080" default="HD_720"/>
         <setting id="lang" type="labelenum" label="30027" values="fr|ja" default="fr"/>
@@ -18,6 +18,16 @@
         <setting id="subs" type="bool" label="30028" default="False"/>
         <setting id="subs_lang" type="labelenum" label="30029" values="fr|ja" default="fr" enable="eq(-1,true)"/>
         -->
+    </category>
+    <!-- Folders -->
+    <category label="30031">
+        <setting id="folder.playlist" type="bool" label="30032" default="true"/>
+        <setting id="folder.favorite" type="bool" label="30033" default="true"/>
+        <setting id="folder.history" type="bool" label="30034" default="true"/>
+        <setting id="folder.free_content" type="bool" label="30035" default="true"/>
+        <setting id="folder.popular" type="bool" label="30037" default="true"/>
+        <setting id="folder.top_rated" type="bool" label="30038" default="true"/>
+        <setting label="30036" type="lsep"/>
     </category>
 
 </settings>


### PR DESCRIPTION
### Description
  - Navigation in list of videos now shows N items per page and navigations items (Next page, Previous page)
  - Add "Free content" entry to see free content of other catalogs (when logged as user) 
  - Add setting to use in guest mode to see free content without being logged (some recent videos from Nolife catalog)
  - Adding "History" entry to view previously seen video
  - "Most popular" entry allows to choose the period of popularity (week, month, all time) 
  - Adding "Top Rated" entry 
  - Renaming "Playlists" entry by "Noco playlists" (only "File d'attente" inside atm)
  - Adding basic support on "Noco playlists" : adding/deleting/moving videos & clear/queue playlist
  - Adding "Noco favorite shows" entry with basic support (adding/deleting favorite shows, clear favorites)
  - Already seen videos are now filtered directly within noco api request
  - Random video is now asked using a noco api request (faster)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0