### PR TITLE
[plugin.video.vrt.nu] 0.0.3

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="0.0.2"
+       version="0.0.3"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,10 +23,12 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
-v0.0.1  (2017-5-01)
+v0.0.1  (01-05-2017)
 - Initial working release
-v0.0.2 (2017-5-07)
-- Fixed installation issue</news>
+v0.0.2 (07-05-2017)
+- Fixed installation issue
+v0.0.3 (22-05-2017)
+- Fixed broken livestreams</news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
 		<assets>
 			<icon>resources/icon.png</icon>

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -22,9 +22,9 @@ from resources.lib.vrtplayer import metadatacreator
 
 class VRTPlayer:
 
-    _VRT_LIVESTREAM_URL = "http://live.stream.vrt.be/vrt_video1_live/smil:vrt_video1_live.smil/playlist.m3u8"
-    _CANVAS_LIVESTREAM_ = "http://live.stream.vrt.be/vrt_video2_live/smil:vrt_video2_live.smil/playlist.m3u8"
-    _KETNET_VRT = "http://live.stream.vrt.be/vrt_events3_live/smil:vrt_events3_live.smil/playlist.m3u8"
+    _VRT_LIVESTREAM_URL = "https://live-w.lwc.vrtcdn.be/groupc/live/d05012c2-6a5d-49ff-a711-79b32684615b/live.isml/.m3u8"
+    _CANVAS_LIVESTREAM_ = "https://live-w.lwc.vrtcdn.be/groupc/live/905b0602-9719-4d14-ae2a-a9b459630653/live.isml/.m3u8"
+    _KETNET_VRT = "https://live-w.lwc.vrtcdn.be/groupc/live/8b898c7d-adf7-4d44-ab82-b5bb3a069989/live.isml/.m3u8"
 
     _VRT_BASE = "https://www.vrt.be/"
     _VRTNU_BASE_URL = urljoin(_VRT_BASE, "/vrtnu/")


### PR DESCRIPTION
### Description
Fixed broken streaming urls, the provider switched to a new one. 

By the way i was wondering the counter on the https://kodi.tv/addon/plugins-video-add-ons/vrt-nu-0 site always says 35. Are this unique downloads or how is this counted? And is this correct for my addon since the first time i uploaded my addon with the wrong addonid. Because i am thinking 35 downloads is really really low :/.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
