### PR TITLE
[plugin.video.nlhardwareinfo] 1.0.7

### DIFF
--- a/plugin.video.nlhardwareinfo/addon.py
+++ b/plugin.video.nlhardwareinfo/addon.py
@@ -4,24 +4,19 @@
 #
 # Imports
 #
-import os
 import sys
 import xbmc
-import xbmcaddon
 
 reload(sys)
 sys.setdefaultencoding('utf8')
 
-LIB_DIR = xbmc.translatePath(
-    os.path.join(xbmcaddon.Addon(id="plugin.video.nlhardwareinfo").getAddonInfo('path'), 'resources', 'lib'))
-sys.path.append(LIB_DIR)
 
-from nlhardwareinfo_const import ADDON, SETTINGS, LANGUAGE, IMAGES_PATH, DATE, VERSION
+from resources.lib.nlhardwareinfo_const import ADDON, DATE, VERSION
 
 xbmc.log("[ADDON] %s, Python Version %s" % (ADDON, str(sys.version)), xbmc.LOGDEBUG)
 xbmc.log("[ADDON] %s v%s (%s) is starting, ARGV = %s" % (ADDON, VERSION, DATE, repr(sys.argv)),
              xbmc.LOGDEBUG)
 
-import nlhardwareinfo_list_play as plugin
+from resources.lib import nlhardwareinfo_list_play as plugin
 
 plugin.Main()

--- a/plugin.video.nlhardwareinfo/addon.xml
+++ b/plugin.video.nlhardwareinfo/addon.xml
@@ -2,11 +2,12 @@
 <addon 
 	id="plugin.video.nlhardwareinfo" 
 	name="Hardware.Info TV" 
-	version="1.0.6"
+	version="1.0.7"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>
 	<import addon="script.module.beautifulsoup" version="3.0.8"/>
+	<import addon="script.module.requests"      version="2.4.3"/>
 	<import addon="plugin.video.youtube" 		version="5.1.7" />
   </requires>
 	<extension point="xbmc.python.pluginsource" library="addon.py">

--- a/plugin.video.nlhardwareinfo/changelog.txt
+++ b/plugin.video.nlhardwareinfo/changelog.txt
@@ -1,3 +1,9 @@
+v1.0.7 (2017-07-12)
+- added listitem.setInfo video for Kodi 18 and up
+- added sorting
+- added context item episode info
+- using requests
+
 v1.0.6 (2017-03-12) :
 - changed addon debugging info to kodi debugging info
 - using po-files

--- a/plugin.video.nlhardwareinfo/resources/__init__.py
+++ b/plugin.video.nlhardwareinfo/resources/__init__.py
@@ -1,0 +1,1 @@
+# Enables relative imports

--- a/plugin.video.nlhardwareinfo/resources/language/Dutch/strings.po
+++ b/plugin.video.nlhardwareinfo/resources/language/Dutch/strings.po
@@ -43,6 +43,14 @@ msgctxt "#30102"
 msgid "Website"
 msgstr "Website"
 
+msgctxt "#30104"
+msgid "Refresh"
+msgstr "Ververs"
+
+msgctxt "#30105"
+msgid "Episode Info"
+msgstr "Aflevering Info"
+
 msgctxt "#30200"
 msgid "Video player"
 msgstr "Video player"

--- a/plugin.video.nlhardwareinfo/resources/language/English/strings.po
+++ b/plugin.video.nlhardwareinfo/resources/language/English/strings.po
@@ -43,6 +43,14 @@ msgctxt "#30102"
 msgid "Website"
 msgstr ""
 
+msgctxt "#30104"
+msgid "Refresh"
+msgstr ""
+
+msgctxt "#30105"
+msgid "Episode Info"
+msgstr ""
+
 msgctxt "#30200"
 msgid "Video player"
 msgstr ""

--- a/plugin.video.nlhardwareinfo/resources/lib/__init__.py
+++ b/plugin.video.nlhardwareinfo/resources/lib/__init__.py
@@ -1,0 +1,1 @@
+# Enables relative imports

--- a/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_const.py
+++ b/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_const.py
@@ -8,8 +8,9 @@ import xbmcaddon
 # Constants
 # 
 ADDON = "plugin.video.nlhardwareinfo"
-SETTINGS = xbmcaddon.Addon(id=ADDON)
+SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
-IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2017-03-12"
-VERSION = "1.0.6"
+IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
+HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+DATE = "2017-07-12"
+VERSION = "1.0.7"


### PR DESCRIPTION
### Description
v1.0.7 (2017-07-12)
- added listitem.setInfo video for Kodi 18 and up
- added sorting
- added context item episode info
- use requests

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ ] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
