### PR TITLE
[plugin.video.zdf_de_2016] 1.0.5

### DIFF
--- a/plugin.video.zdf_de_2016/README.md
+++ b/plugin.video.zdf_de_2016/README.md
@@ -20,6 +20,6 @@ This addon was tested with
 - Kodi 17.0 "Krypton" beta 5, Estouchy Skin, MacOS/Linux 
 
 This addon is known to work with
-- XBMC 13.2 "Gotham", see issue #4
+- XBMC 13.2 "Gotham", see [issue #4](/../../issues/4)
 
 Have fun.

--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.4" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.5" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -25,6 +25,11 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.5 (2017-07-28)
+- fix for apiToken handling (see https://github.com/generia/plugin.video.zdf_de_2016/issues/8)
+- fix for streamInfoUrl not (yet) available (see https://github.com/generia/plugin.video.zdf_de_2016/issues/7)
+- minor variable initialization cleanups
+
 1.0.4 (2017-06-03)
 - inform about redirects to external sites (see https://github.com/generia/plugin.video.zdf_de_2016/issues/5)
 - fixes for minor labeling issues after updates on zdf.de 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/api/VideoContentResource.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/api/VideoContentResource.py
@@ -33,10 +33,13 @@ class VideoContentResource(ApiResource):
             
         self.url = None
         self.duration = None
+        self.streamInfoUrl = None
         if 'mainVideoContent' in self.content:
             mainVideoContent = self.content.get('mainVideoContent')
             target = mainVideoContent.get('http://zdf.de/rels/target')
-            self.streamInfoUrl = self.apiBaseUrl + target.get('http://zdf.de/rels/streams/ptmd')
+            self.streamInfoUrl = target.get('http://zdf.de/rels/streams/ptmd')
+            if self.streamInfoUrl is not None:
+                self.streamInfoUrl = self.apiBaseUrl + self.streamInfoUrl
             duration = target.get('duration')
             if duration is not None:
                 self.duration = int(duration)

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
@@ -3,3 +3,4 @@ class Constants(object):
     baseUrl = 'https://www.zdf.de'
     apiBaseUrl = 'https://api.zdf.de'
     configUrl = baseUrl + '/ZDFplayer/configs/zdf/zdf2016/configuration.json'
+    apiToken = 'd2726b6c8c655e42b68b0db26131b15b22bd1a32' 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Mediathek.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Mediathek.py
@@ -9,9 +9,10 @@ from de.generia.kodi.plugin.frontend.zdf.Constants import Constants
 class Mediathek(Pagelet):
 
     def service(self, request, response):
-        configuration = ConfigurationResource(Constants.configUrl)
-        self._parse(configuration)
-        apiToken = configuration.apiToken
+        #configuration = ConfigurationResource(Constants.configUrl)
+        #self._parse(configuration)
+        #apiToken = configuration.apiToken
+        apiToken = Constants.apiToken
 
         response.addFolder(self._(32005), Action('SearchMenuPage', {'apiToken': apiToken}))
 


### PR DESCRIPTION
### Description
New version after website updates:

1.0.5 (2017-07-28)
- fix for apiToken handling (see https://github.com/generia/plugin.video.zdf_de_2016/issues/8)
- fix for streamInfoUrl not (yet) available (see https://github.com/generia/plugin.video.zdf_de_2016/issues/7)
- minor variable initialization cleanups

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
