### PR TITLE
[plugin.video.vrt.nu] 0.0.6

### DIFF
--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -1,12 +1,10 @@
 import sys
 import xbmcaddon
-import os
-import requests
 from urlparse import parse_qsl
 from resources.lib.vrtplayer import vrtplayer
 from resources.lib.kodiwrappers import kodiwrapper
 from resources.lib.vrtplayer import actions
-from resources.lib.helperobjects import helperobjects
+from resources.lib.kodiwrappers import sortmethod
 
 _addon_ = xbmcaddon.Addon()
 _url = sys.argv[0]
@@ -19,21 +17,21 @@ def router(params_string):
     params = dict(parse_qsl(params_string))
     if params:
         if params['action'] == actions.LISTING_AZ:
-            kodi_wrapper.show_listing(vrt_player.get_az_menu_items())
+            kodi_wrapper.show_listing(vrt_player.get_az_menu_items(), sortmethod.ALPHABET)
         elif params['action'] == actions.LISTING_CATEGORIES:
-            kodi_wrapper.show_listing(vrt_player.get_category_menu_items())
+            kodi_wrapper.show_listing(vrt_player.get_category_menu_items(), sortmethod.ALPHABET)
         elif params['action'] == actions.LISTING_LIVE:
-            kodi_wrapper.show_listing(vrt_player.get_livestream_items())
+            kodi_wrapper.show_listing(vrt_player.get_livestream_items(), sortmethod.ALPHABET)
         elif params['action'] == actions.LISTING_VIDEOS:
             kodi_wrapper.show_listing(vrt_player.get_videos(params['video']))
         elif params['action'] == actions.LISTING_CATEGORY_VIDEOS:
-            kodi_wrapper.show_listing(vrt_player.get_video_category_episodes(params['video']))
+            kodi_wrapper.show_listing(vrt_player.get_video_category_episodes(params['video']), sortmethod.ALPHABET)
         elif params['action'] == actions.PLAY:
             kodi_wrapper.play_video(params['video'])
         elif params['action'] == actions.PLAY_LIVE:
             kodi_wrapper.play_livestream(params['video'])
     else:
-        kodi_wrapper.show_listing(vrt_player.get_main_menu_items())
+        kodi_wrapper.show_listing(vrt_player.get_main_menu_items(), sortmethod.ALPHABET)
 
 if __name__ == '__main__':
     router(sys.argv[2][1:])

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="0.0.5"
+       version="0.0.6"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -34,7 +34,9 @@ v0.0.4 (20-07-2017)
 - Added dates to videos (Thanks stevenv)
 - Fixed bug where seasons did not get listed
 v0.0.5 (24-07-2017)
-- Fixed broken Sporza logo 
+- Fixed broken Sporza logo
+v0.0.6 (06-08-2017)
+- Fixed ordering bug for videos
 </news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
 		<assets>

--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/kodiwrapper.py
@@ -4,6 +4,7 @@ import xbmcplugin
 from urllib import urlencode
 from resources.lib.vrtplayer import vrtplayer
 from resources.lib.vrtplayer import urltostreamservice
+from resources.lib.kodiwrappers import sortmethod
 
 class KodiWrapper:
 
@@ -12,7 +13,7 @@ class KodiWrapper:
         self._url = url
         self._addon = addon
 
-    def show_listing(self, list_items):
+    def show_listing(self, list_items, sort=None):
         listing = []
         for title_item in list_items:
             list_item = xbmcgui.ListItem(label=title_item.title)
@@ -26,7 +27,12 @@ class KodiWrapper:
 
             listing.append((url, list_item, not title_item.is_playable))
         xbmcplugin.addDirectoryItems(self._handle, listing, len(listing))
-        xbmcplugin.addSortMethod(self._handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+
+        if sort is not None:
+            kodi_sorts = {sortmethod.ALPHABET: xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE}
+            kodi_sortmethod = kodi_sorts.get(sort)
+            xbmcplugin.addSortMethod(self._handle, kodi_sortmethod)
+
         xbmcplugin.endOfDirectory(self._handle)
 
     def play_video(self, path):

--- a/plugin.video.vrt.nu/resources/lib/kodiwrappers/sortmethod.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiwrappers/sortmethod.py
@@ -1,0 +1,1 @@
+ALPHABET = 1


### PR DESCRIPTION
### Description
Fixed a sorting bug where some content was sorted by alphabet and it shouldnt be.

Thx for merging 👍 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x ] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
