### PR TITLE
[plugin.video.vrt.nu] 0.0.7

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="0.0.6"
+       version="0.0.7"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,20 +23,22 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
-v0.0.1  (01-05-2017)
-- Initial working release
-v0.0.2 (07-05-2017)
-- Fixed installation issue
-v0.0.3 (22-05-2017)
-- Fixed broken livestreams
+v0.0.7 (09-09-2017)
+- Fixed bug where dates were not always shown
+v0.0.6 (06-08-2017)
+- Fixed ordering bug for videos
+v0.0.5 (24-07-2017)
+- Fixed broken Sporza logo
 v0.0.4 (20-07-2017)
 - Added Sporza livestream
 - Added dates to videos (Thanks stevenv)
 - Fixed bug where seasons did not get listed
-v0.0.5 (24-07-2017)
-- Fixed broken Sporza logo
-v0.0.6 (06-08-2017)
-- Fixed ordering bug for videos
+v0.0.3 (22-05-2017)
+- Fixed broken livestreams
+v0.0.2 (07-05-2017)
+- Fixed installation issue
+v0.0.1  (01-05-2017)
+- Initial working release
 </news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
 		<assets>

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -139,7 +139,7 @@ class VRTPlayer:
         list_item_title = soup.find(class_="content__title").text
 
         if "shortdate" in video_dictionary:
-            video_dictionary["shortdate"] + " " + list_item_title
+            list_item_title = video_dictionary["shortdate"] + " " + list_item_title
 
         vrt_video = soup.find(class_="vrtvideo")
         thumbnail = VRTPlayer.__format_image_url(vrt_video)


### PR DESCRIPTION
### Description
Fixed a bug where dates were not showing, also reordered the the news part where the newest now comes first.

thanks for merging
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
