### PR TITLE
[plugin.video.noco] 1.0.16

### DIFF
--- a/plugin.video.noco/addon.py
+++ b/plugin.video.noco/addon.py
@@ -676,24 +676,10 @@ def settings():
 
 def getVideoInfos(video):
     guest = isGuestMode()
-    if str(video['episode_number']) == '0':
-        if video['show_TT'] == None:
-            label = video['family_TT'].encode('utf-8')
-        else:
-            label = video['family_TT'].encode('utf-8')+' - '+unicode(video['show_TT']).encode('utf-8')
-    else:
-        if video['show_TT'] == None:
-            label = video['family_TT'].encode('utf-8')+' - '+str(video['episode_number'])
-        else:
-            label = video['family_TT'].encode('utf-8')+' - '+str(video['episode_number']).encode('utf-8')+' - '+unicode(video['show_TT']).encode('utf-8')
-    if video['show_resume'] == None and video['family_resume'] == None:
-        resume = ''
-    elif video['show_resume'] == None and video['family_resume'] != None:
-        resume = video['family_resume']
-    elif video['family_resume'] == None and video['show_resume'] != None:
-        resume = video['show_resume']
-    else:
-        resume = video['family_resume']+'\n\n'+video['show_resume']
+
+    label_ep = u"x".join([unicode(x) for x in [video['season_number'], video['episode_number']] if x is not None and x is not 0]).encode('utf-8')
+    label = u" - ".join([unicode(x) for x in [video['family_TT'], label_ep, video['show_TT']] if x is not None and x is not '']).encode('utf-8')
+    resume = u"\n\n".join([unicode(x) for x in [video['family_resume'], video['show_resume']] if x is not None]).encode('utf-8')
 
     if not guest and video['mark_read'] == 1:
         read = '1'
@@ -760,7 +746,7 @@ def getVideoInfos(video):
         'info': infos,
         'properties': properties,
         'stream_info': stream_infos,
-        'path':  plugin.url_for('playVideo', partner=video['partner_key'], family=video['family_TT'].encode('utf-8'), video=video['id_show']) if advised else plugin.url_for('notAdvised', rate=video['rating_fr']), 
+        'path':  plugin.url_for('playVideo', partner=video['partner_key'], family=video['family_TT'].encode('utf-8') if video['family_TT'] is not None else 'null', video=video['id_show']) if advised else plugin.url_for('notAdvised', rate=video['rating_fr']), 
         'context_menu': ctx_items if advised else [],
         'is_playable': advised
         }

--- a/plugin.video.noco/addon.xml
+++ b/plugin.video.noco/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.noco" name="noco" version="1.0.15" provider-name="Julien Gormotte (gormux)">
+<addon id="plugin.video.noco" name="noco" version="1.0.16" provider-name="Julien Gormotte (gormux)">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
     <import addon="script.module.xbmcswift2" version="2.4.0"/>

--- a/plugin.video.noco/changelog.txt
+++ b/plugin.video.noco/changelog.txt
@@ -69,3 +69,8 @@ v1.0.15
   - Add info text for shows and partners when available
   - Add "Settings" item in root menu
   - New videos since user last visit have a [N] tag in the "Last videos" directory 
+
+v1.0.16
+  - Fix crash for shows with no family
+  - Use season number in show label if any
+  - Add a setting to hide single "News" items in the latest videos folder (all daily news are gathered in another item)   

--- a/plugin.video.noco/resources/language/English/strings.xml
+++ b/plugin.video.noco/resources/language/English/strings.xml
@@ -6,6 +6,7 @@
     <string id="30003">Username</string>
     <string id="30004">Password</string>
     <string id="30005">Tag new videos</string>
+    <string id="30007">Hide news category (fragmented news)</string>
     <string id="30010">Quality</string>
     <string id="30011">Show already seen videos</string>
     <string id="30012">Number of videos per page</string>

--- a/plugin.video.noco/resources/language/French/strings.xml
+++ b/plugin.video.noco/resources/language/French/strings.xml
@@ -6,6 +6,7 @@
     <string id="30003">Nom d'utilisateur</string>
     <string id="30004">Mot de passe</string>
     <string id="30005">Tagger les nouvelles vidéos</string>
+    <string id="30007">Cacher la rubrique des news (news fragmentées)</string>
     <string id="30010">Qualité vidéo</string>
     <string id="30011">Afficher les émissions déjà vues</string>
     <string id="30012">Nombre de vidéos par page</string>

--- a/plugin.video.noco/resources/lib/api.py
+++ b/plugin.video.noco/resources/lib/api.py
@@ -158,6 +158,7 @@ class nocoApi():
     def get_last(self, partner, token, elements_per_page=40, page=0, guest_free=False, user_free=False):
         request = {'access_token': token,
                    'partner_key': partner,
+                   'family_key': None if plugin.get_setting('hidenews') == 'false' else '!NW',
                    'mark_read': None if plugin.get_setting('showseen') == 'true' else '0',
                    'guest_free': None if not guest_free else '1',
                    'user_free': None if not user_free else '1',

--- a/plugin.video.noco/resources/settings.xml
+++ b/plugin.video.noco/resources/settings.xml
@@ -17,6 +17,7 @@
         <setting id="lang" type="labelenum" label="30027" values="fr|ja" default="fr"/>
         <setting id="random" type="bool" label="30030" default="false" visible="eq(-6,false)"/>
         <setting id="tagnew" type="bool" label="30005" default="true"/>
+        <setting id="hidenews" type="bool" label="30007" default="true"/>
     </category>
     <!-- Folders -->
     <category label="30031">


### PR DESCRIPTION
Fix crash with shows without family
Add setting to hide single daily news (gathered in a single show)

### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
