### PR TITLE
[plugin.video.worldstarhiphop] 1.0.11

### DIFF
--- a/plugin.video.worldstarhiphop/addon.xml
+++ b/plugin.video.worldstarhiphop/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.worldstarhiphop" 
 	name="World Star Hip Hop" 
-	version="1.0.10"
+	version="1.0.11"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>

--- a/plugin.video.worldstarhiphop/changelog.txt
+++ b/plugin.video.worldstarhiphop/changelog.txt
@@ -1,3 +1,7 @@
+v1.0.11 (2017-09-23)
+- removed looking for video dialogue
+- skipping items without videolink
+
 v1.0.10 (2017-06-18):
 - changed getting title due to website changes
 - refactored getting video- and thumbnail-url

--- a/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_const.py
+++ b/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_const.py
@@ -11,5 +11,5 @@ ADDON = "plugin.video.worldstarhiphop"
 SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
-DATE = "2017-06-18"
-VERSION = "1.0.10"
+DATE = "2017-09-23"
+VERSION = "1.0.11"

--- a/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_list.py
+++ b/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_list.py
@@ -121,7 +121,13 @@ class Main:
         xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=listitem, isFolder=folder)
 
         for item in items:
-            video_page_url = BASEURL + str(item.a['href'])
+            try:
+                video_page_url = BASEURL + str(item.a['href'])
+            except:
+                # skip the item if it does not have a href
+                xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
+                    ADDON, VERSION, DATE, "skipping item without href", str(item)), xbmc.LOGDEBUG)
+                continue
 
             xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
                     ADDON, VERSION, DATE, "video_page_url", str(video_page_url)), xbmc.LOGDEBUG)

--- a/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_play.py
+++ b/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_play.py
@@ -62,6 +62,7 @@ class Main:
         listing = []
         unplayable_media_file = False
         have_valid_url = False
+        dialogWait = xbmcgui.DialogProgress()
 
         #
         # Get current list item details...
@@ -71,14 +72,6 @@ class Main:
         studio = unicode(xbmc.getInfoLabel("ListItem.Studio"), "utf-8")
         plot = unicode(xbmc.getInfoLabel("ListItem.Plot"), "utf-8")
         genre = unicode(xbmc.getInfoLabel("ListItem.Genre"), "utf-8")
-
-        #
-        # Show wait dialog while parsing data...
-        #
-        dialogWait = xbmcgui.DialogProgress()
-        dialogWait.create(LANGUAGE(30504), self.title)
-        # wait 1 second
-        xbmc.sleep(1000)
 
         video_url = self.video_page_url
 

--- a/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_search.py
+++ b/plugin.video.worldstarhiphop/resources/lib/worldstarhiphop_search.py
@@ -117,7 +117,13 @@ class Main:
             ADDON, VERSION, DATE, "len(items)", str(len(items))), xbmc.LOGDEBUG)
 
         for item in items:
-            video_page_url = BASEURL + str(item.a['href'])
+            try:
+                video_page_url = BASEURL + str(item.a['href'])
+            except:
+                # skip the item if it does not have a href
+                xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
+                    ADDON, VERSION, DATE, "skipping item without href", str(item)), xbmc.LOGDEBUG)
+                continue
 
             xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
                 ADDON, VERSION, DATE, "video_page_url", str(video_page_url)), xbmc.LOGDEBUG)


### PR DESCRIPTION
### Description
v1.0.11 (2017-09-23)
- removed looking for video dialogue
- skipping items without videolink
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ ] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0