### PR TITLE
[plugin.video.zdf_de_2016] 1.0.7

### DIFF
--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.6" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.7" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -25,6 +25,12 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.7 (2017-10-31)
+- handle new content elements after 'heute.de' relaunch
+- use first teaser image for cluster folders
+- added 'Startseite zdf.de' homepage processing
+- fix handling '/sendungen-a-z' properly in all cases 
+
 1.0.6 (2017-10-07)
 - full refactoring for apiToken handling after ZDF website updates 
 - fix for genre/category parsing

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
@@ -15,7 +15,7 @@ catPattern = compile('class="teaser-cat\s*[^"]*"[^>]*>')
 catCategoryPattern = compile('class="teaser-cat-category\s*[^"]*"[^>]*>([^<]*)</[^>]*>')
 catBrandPattern = compile('class="teaser-cat-brand\s*[^"]*"[^>]*>([^<]*)</[^>]*>')
 aPattern = compile('href="([^"]*)"[^>]*>')
-titleIconPattern = compile('class="title-icon icon-[0-9]*_([^"]*)">')
+titleIconPattern = compile('class="[^"]*icon-[0-9]*_(play)">')
 textPattern = compile('class="teaser-text"[^>]*>([^<]*)</[^>]*>')
 datePattern = compile('class="video-airing"[^>]*>([^<]*)</[^>]*>')
 apiTokenPattern = compile('"apiToken"\s*:\s*"([^"]*)"')
@@ -94,8 +94,8 @@ class Teaser(object):
 
         return endPos
 
-    def parseImage(self, article, pos):
-        sourceMatch = sourcePattern.search(article)
+    def parseImage(self, article, pos, pattern=sourcePattern):
+        sourceMatch = pattern.search(article)
         src = None
         if sourceMatch is not None:
             srcset = sourceMatch.group(1)

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
@@ -2,3 +2,4 @@
 class Constants(object):
     baseUrl = 'https://www.zdf.de'
     apiBaseUrl = 'https://api.zdf.de'
+    showsAzUrl = '/sendungen-a-z'

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Mediathek.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Mediathek.py
@@ -12,6 +12,7 @@ class Mediathek(Pagelet):
 
         response.addFolder(self._(32003), Action('RubricsPage'))
 
+        response.addFolder(self._(32043), Action('RubricPage', {'rubricUrl': '/'}))
         response.addFolder(self._(32031), Action('RubricPage', {'rubricUrl': '/bestbewertet'}))
         response.addFolder(self._(32032), Action('RubricPage', {'rubricUrl': '/meist-gesehen'}))
         response.addFolder(self._(32037), Action('ShowsAzPage'))

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/MediathekFactory.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/MediathekFactory.py
@@ -40,6 +40,10 @@ class MediathekFactory(PageletFactory):
         if pageletId == 'RubricsPage':
             return RubricsPage()
         if pageletId == 'RubricPage':
+            rubricUrl = params['rubricUrl']
+            # redirect to ShowsAzPage, if url matches
+            if rubricUrl == Constants.showsAzUrl:
+                return ShowsAzPage()
             return RubricPage()
         if pageletId == 'LiveTvPage':
             return LiveTvPage()

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
@@ -46,7 +46,7 @@ class RubricPage(AbstractPage):
         for cluster in clusters:
             clusterTitle = cluster.title #.encode('ascii', 'ignore')
             action = Action(pagelet='RubricPage', params={'rubricUrl': rubricUrl, 'listType': cluster.listType, 'listStart': str(cluster.listStart), 'listEnd': str(cluster.listEnd)})
-            item = Item(cluster.title, action, isFolder=True)
+            item = Item(cluster.title, action, cluster.image, isFolder=True)
             response.addItem(item)            
     
     

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricsPage.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricsPage.py
@@ -9,7 +9,7 @@ from de.generia.kodi.plugin.frontend.zdf.Constants import Constants
 class RubricsPage(AbstractPage):
 
     excludedRubricUrls = [
-        '/sendungen-a-z',
+        Constants.showsAzUrl,
         '/bestbewertet',
         '/meist-gesehen',
         #'/barrierefreiheit-im-zdf'

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/ShowsAzPage.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/ShowsAzPage.py
@@ -7,7 +7,7 @@ from de.generia.kodi.plugin.frontend.zdf.Constants import Constants
 class ShowsAzPage(AbstractPage):
 
     def service(self, request, response):
-        rubricBaseUrl = '/sendungen-a-z?group='
+        rubricBaseUrl = Constants.showsAzUrl + '?group='
         groups = []
         for i in range (0, 26):
             group = chr(ord('a') + i)

--- a/plugin.video.zdf_de_2016/resources/language/English/strings.po
+++ b/plugin.video.zdf_de_2016/resources/language/English/strings.po
@@ -183,3 +183,7 @@ msgstr ""
 msgctxt "#32042"
 msgid "The page '{0}' was redirected by the ZDF server to '{1}'. This is an external link that can not be opened inside the ZDF Mediathek 2016. Please open this link in a web-browser."
 msgstr ""
+
+msgctxt "#32043"
+msgid "Homepage zdf.de"
+msgstr ""

--- a/plugin.video.zdf_de_2016/resources/language/German/strings.po
+++ b/plugin.video.zdf_de_2016/resources/language/German/strings.po
@@ -201,3 +201,7 @@ msgstr "Weiterleitung erkannt"
 msgctxt "#32042"
 msgid "The page '{0}' was redirected by the ZDF server to '{1}'. This is an external link that can not be opened inside the ZDF Mediathek 2016. Please open this link in a web-browser."
 msgstr "Die Seite '{0}' wurde vom ZDF Server weitergeleitet zu '{1}'. Dies is ein externer Link, der nicht innerhalb der ZDF Mediathek 2016 geöffnet werden kann. Bitte öffnen Sie diesen Link in einem Web-Browser."
+
+msgctxt "#32043"
+msgid "Homepage zdf.de"
+msgstr "Startseite zdf.de"


### PR DESCRIPTION
### Description
New version after website updates:

1.0.7 (2017-10-31)
- handle new content elements after 'heute.de' relaunch
- use first teaser image for cluster folders
- added 'Startseite zdf.de' homepage processing
- fix handling '/sendungen-a-z' properly in all cases 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
