### PR TITLE
[plugin.video.zdf_de_2016] 1.0.8

### DIFF
--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.7" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.8" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -25,6 +25,9 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.8 (2017-11-02)
+- hotfix for parsing api-token, if token-cache is empty
+
 1.0.7 (2017-10-31)
 - handle new content elements after 'heute.de' relaunch
 - use first teaser image for cluster folders

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/VideoResource.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/VideoResource.py
@@ -14,7 +14,7 @@ class VideoResource(RubricResource):
     def _isModule(self, class_):
         return class_.find('b-video-module') != -1
     
-    def _parseModule(self, pos):
+    def _parseModule(self, pos, contentPattern, textPattern, datePattern):
         match = None
         
         teaser = Teaser()


### PR DESCRIPTION
### Description
An edge case slipped through and cause the addon to stop working. Sorry for the inconvenience.

1.0.8 (2017-11-02)
- hotfix for parsing api-token, if token-cache is empty (https://github.com/generia/plugin.video.zdf_de_2016/issues/13)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
