### PR TITLE
[plugin.video.myvevo] v3.0.8

### DIFF
--- a/plugin.video.myvevo/README.txt
+++ b/plugin.video.myvevo/README.txt
@@ -4,6 +4,7 @@ plugin.video.myvevo
 
 Kodi Addon for VEVO
 
+Version 3.0.8 another m3u8 version fix
 Version 3.0.7 m3u8 version fix
 Version 3.0.6 auth fix
 Version 3.0.5 fix playlists, remove live channels, fix navigation

--- a/plugin.video.myvevo/addon.xml
+++ b/plugin.video.myvevo/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.myvevo"
        name="VEVO"
-       version="3.0.7"
+       version="3.0.8"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>

--- a/plugin.video.myvevo/changelog.txt
+++ b/plugin.video.myvevo/changelog.txt
@@ -1,3 +1,4 @@
+Version 3.0.8 another m3u8 version fix
 Version 3.0.7 m3u8 version fix
 Version 3.0.6 auth fix
 Version 3.0.5 fix playlists, remove live channels, fix navigation

--- a/plugin.video.myvevo/resources/lib/scraper.py
+++ b/plugin.video.myvevo/resources/lib/scraper.py
@@ -337,10 +337,7 @@ class myAddon(t1mAddon):
       if not '.m3u8' in url:
           url = ('https://apiv2.vevo.com/video/%s/streams/hls?token=%s' % (url, self.getAutho()))
           a = self.getAPI(url)
-          for b in a:
-              if (b["version"] == 4) or (b["version"] == 2):
-                  url = b['url']
-                  break
+          url = a[0]['url']
       thumb = xbmc.getInfoLabel('ListItem.Art(thumb)')
       liz = xbmcgui.ListItem(path = url, thumbnailImage = thumb)
       infoList ={}

--- a/plugin.video.myvevo/resources/lib/scraper.py
+++ b/plugin.video.myvevo/resources/lib/scraper.py
@@ -338,6 +338,8 @@ class myAddon(t1mAddon):
           url = ('https://apiv2.vevo.com/video/%s/streams/hls?token=%s' % (url, self.getAutho()))
           a = self.getAPI(url)
           url = a[0]['url']
+          m3u8_contents = self.getRequest( url , None , self.defaultHeaders.copy() )
+          url = re.search(r'^([^#].+_1920x1080_.+\.m3u8)$', m3u8_contents, re.MULTILINE).group(1)          
       thumb = xbmc.getInfoLabel('ListItem.Art(thumb)')
       liz = xbmcgui.ListItem(path = url, thumbnailImage = thumb)
       infoList ={}


### PR DESCRIPTION
### Description

version field in json answer doesn't seem valuable (there are values of 2, 3 or 4 at least), and in fact restricting it hides legit videos from loading.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
