### PR TITLE
[plugin.video.roosterteeth] 1.3.4

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.3.3"
+       version="1.3.4"
        provider-name="Skipmode A1, Abolfazl, Divingmule">
   <requires>
     <import addon="xbmc.python"                 version="2.14.0"/>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,9 @@
+v1.3.4 (2017-12-12)
+removed looking for video dialogue
+small log fix
+added shows for Sugar Pine 7
+added recent video's for Sugar Pine 7
+
 v1.3.3 (2017-03-03):
 fixed some typos
 fixed url in addon.xml as per request

--- a/plugin.video.roosterteeth/resources/language/English/strings.po
+++ b/plugin.video.roosterteeth/resources/language/English/strings.po
@@ -158,3 +158,11 @@ msgstr ""
 msgctxt "#30314"
 msgid "Cow Chop Shows"
 msgstr ""
+
+msgctxt "#30315"
+msgid "Sugar Pine 7 Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30316"
+msgid "Sugar Pine 7 Shows"
+msgstr ""

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -25,5 +25,7 @@ THEKNOWRECENTLYADDEDURL = 'http://theknow.roosterteeth.com/episode/recently-adde
 THEKNOWSHOWSURL = 'http://theknow.roosterteeth.com/show'
 COWCHOPRECENTLYADDEDURL = 'http://cowchop.roosterteeth.com/episode/recently-added?page=001'
 COWCHOPSHOWSURL = 'http://cowchop.roosterteeth.com/show'
-DATE = "2017-03-03"
-VERSION = "1.3.3"
+SUGARPINE7RECENTLYADDEDURL = 'http://sugarpine7.roosterteeth.com/episode/recently-added?page=001'
+SUGARPINE7SHOWSURL = 'http://sugarpine7.roosterteeth.com/show'
+DATE = "2017-12-12"
+VERSION = "1.3.4"

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
@@ -88,6 +88,9 @@ class Main:
         # Parse response
         soup = BeautifulSoup(html_source)
 
+        # xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
+        #     ADDON, VERSION, DATE, "html_source", str(html_source)), xbmc.LOGDEBUG)
+
         # <li>
         #	<a href="http://ah.roosterteeth.com/episode/red-vs-blue-season-13-episode-2">
         # 			<div class="block-container">
@@ -149,14 +152,8 @@ class Main:
             # Skip the episode if it does not contain /episode/
             if str(video_page_url).find("/episode/") < 0:
                 xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                    ADDON, VERSION, DATE, "skipped episode without /episode/", str(episode)), xbmc.LOGDEBUG)
+                    ADDON, VERSION, DATE, "skipped episode without /episode/", str(video_page_url)), xbmc.LOGDEBUG)
                 continue
-            else:
-                xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                    ADDON, VERSION, DATE,
-                    "skipped episode without /episode/ ",
-                    str(video_page_url)), xbmc.LOGDEBUG)
-                pass
 
             # Skip a video_page_url is empty
             if video_page_url == '':

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
@@ -13,7 +13,8 @@ import os
 from roosterteeth_const import LANGUAGE, IMAGES_PATH, ROOSTERTEETHRECENTLYADDEDURL, ROOSTERTEETHSHOWSURL, \
     ACHIEVEMENTHUNTERRECENTLYADDEDURL, ACHIEVEMENTHUNTERSHOWSURL, FUNHAUSRECENTLYADDEDURL, FUNHAUSSHOWURL, \
     SCREWATTACKRECENTLYADDEDURL, SCREWATTACKSHOWSURL, GAMEATTACKRECENTLYADDEDURL, GAMEATTACKSHOWSURL, \
-    THEKNOWRECENTLYADDEDURL, THEKNOWSHOWSURL, COWCHOPRECENTLYADDEDURL, COWCHOPSHOWSURL
+    THEKNOWRECENTLYADDEDURL, THEKNOWSHOWSURL, COWCHOPRECENTLYADDEDURL, COWCHOPSHOWSURL, SUGARPINE7RECENTLYADDEDURL, \
+    SUGARPINE7SHOWSURL
 #
 # Main class
 #
@@ -188,6 +189,30 @@ class Main:
                       "next_page_possible": "False"}
         url = self.plugin_url + '?' + urllib.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30314))
+        is_folder = True
+        list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
+        list_item.setProperty('IsPlayable', 'false')
+        xbmcplugin.addDirectoryItem(handle=self.plugin_handle, url=url, listitem=list_item, isFolder=is_folder)
+
+        #
+        # Sugar Pine 7 Recently Added Episodes
+        #
+        parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30315), "url": SUGARPINE7RECENTLYADDEDURL,
+                      "next_page_possible": "True"}
+        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        list_item = xbmcgui.ListItem(LANGUAGE(30315))
+        is_folder = True
+        list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
+        list_item.setProperty('IsPlayable', 'false')
+        xbmcplugin.addDirectoryItem(handle=self.plugin_handle, url=url, listitem=list_item, isFolder=is_folder)
+
+        #
+        # Sugar Pine 7 Shows
+        #
+        parameters = {"action": "list-shows", "plugin_category": LANGUAGE(30316), "url": SUGARPINE7SHOWSURL,
+                      "next_page_possible": "False"}
+        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        list_item = xbmcgui.ListItem(LANGUAGE(30316))
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
         list_item.setProperty('IsPlayable', 'false')

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_play.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_play.py
@@ -23,6 +23,7 @@ LOGINURL_SA = 'http://screwattack.roosterteeth.com/login'
 LOGINURL_GA = 'http://gameattack.roosterteeth.com/login'
 LOGINURL_TK = 'http://theknow.roosterteeth.com/login'
 LOGINURL_CC = 'http://cowchop.roosterteeth.com/login'
+LOGINURL_SP7 = 'http://sugarpine7.roosterteeth.com/login'
 
 NEWHLS = 'NewHLS-'
 VQ1080P = '1080P'
@@ -73,6 +74,7 @@ class Main:
         #
         # Init
         #
+        dialog_wait = xbmcgui.DialogProgress()
 
         #
         # Get current list item details...
@@ -82,14 +84,6 @@ class Main:
         # studio = unicode(xbmc.getInfoLabel("list_item.Studio"), "utf-8")
         plot = unicode(xbmc.getInfoLabel("list_item.Plot"), "utf-8")
         genre = unicode(xbmc.getInfoLabel("list_item.Genre"), "utf-8")
-
-        #
-        # Show wait dialog while parsing data...
-        #
-        dialog_wait = xbmcgui.DialogProgress()
-        dialog_wait.create(LANGUAGE(30100), self.title)
-        # wait 1 second
-        xbmc.sleep(1000)
 
         reply = ''
         session = ''
@@ -120,6 +114,8 @@ class Main:
                             reply = session.get(LOGINURL_TK)
                         elif 'cowchop' in reply.url:
                             reply = session.get(LOGINURL_CC)
+                        elif 'sugarpine7' in reply.url:
+                            reply = session.get(LOGINURL_SP7)
                         else:
                             reply = session.get(LOGINURL_RT)
 
@@ -158,6 +154,8 @@ class Main:
                             reply = session.post(LOGINURL_TK, data=payload)
                         elif 'cowchop' in reply.url:
                             reply = session.post(LOGINURL_CC, data=payload)
+                        elif 'sugarpine7' in reply.url:
+                            reply = session.get(LOGINURL_SP7)
                         else:
                             reply = session.post(LOGINURL_RT, data=payload)
 


### PR DESCRIPTION
+v1.3.4 (2017-12-12)
+removed looking for video dialogue
+small log fix
+added shows for Sugar Pine 7
+added recent video's for Sugar Pine 7
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
