### PR TITLE
[plugin.video.media-ccc-de] 0.1.2

### DIFF
--- a/plugin.video.media-ccc-de/addon.xml
+++ b/plugin.video.media-ccc-de/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.media-ccc-de" name="media.ccc.de" version="0.1.1" provider-name="Tobias Gruetzmacher">
+<addon id="plugin.video.media-ccc-de" name="media.ccc.de" version="0.1.2" provider-name="Tobias Gruetzmacher">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
     <import addon="script.module.requests" version="2.3.0"/>
@@ -14,19 +14,13 @@
     <description lang="en_GB">This addon provides access to videos published on https://media.ccc.de/ (mostly lecture recordings of CCC events) </description>
     <description lang="de_DE">Dieses Add-On ermöglicht den Zugriff auf Videos, die auf https://media.ccc.de/ veröffentlicht wurden (größtenteils Vortragsmitschnitte von CCC-Veranstaltungen)</description>
     <disclaimer lang="en_GB"></disclaimer>
-    <news>v0.1.1 (2017-12-20)
-- The tuwat! release
-- Supports multiple translated streams (if available)
+    <news>v0.1.2 (2018-01-01)
+- The guckwat! release
+- Select correct stream even when slides are present. (Fixes #20)
 
-v0.1.0 (2017-04-16)
-- EasterHegg 2017 release.
-- Use "slug" instead of obsolete "webgen_location".
-- Track coverage on Travis-CI.
-- Refactor GUI code into extra file. (also fixes #11)
-- Migrated translations from XML to PO.
-- Add "insecure" option for devices with old/broken TLS setup (fixes #2, #12).
-- Skip streams without urls.
-- Switch to streaming API v2.</news>
+v0.1.1 (2017-12-20)
+- The tuwat! release
+- Supports multiple translated streams (if available)</news>
     <language>de en</language>
     <platform>all</platform>
     <license>MIT License</license>

--- a/plugin.video.media-ccc-de/changelog.txt
+++ b/plugin.video.media-ccc-de/changelog.txt
@@ -1,3 +1,7 @@
+v0.1.2 (2018-01-01)
+- The guckwat! release
+- Select correct stream even when slides are present. (Fixes #20)
+
 v0.1.1 (2017-12-20)
 - The tuwat! release
 - Supports multiple translated streams (if available)

--- a/plugin.video.media-ccc-de/resources/lib/recording.py
+++ b/plugin.video.media-ccc-de/resources/lib/recording.py
@@ -10,9 +10,10 @@ class Recordings(object):
     def recordings_sorted(self, quality, format, video=True):
         print("Requested quality %s and format %s" % (quality, format))
         typematch = "video" if video else "audio"
-        want = sorted(filter(lambda rec: rec.type == typematch,
-                             self.recordings),
-                      key=user_preference_sorter(quality, format))
+        want = sorted(filter(lambda rec: (rec.type == typematch and
+            not rec.folder.startswith('slides')),
+            self.recordings),
+            key=user_preference_sorter(quality, format))
         print(want)
         return want
 
@@ -25,6 +26,7 @@ class Recording(object):
         self.url = json['recording_url']
         self.length = maybe_json(json, 'length', 0)
         self.size = maybe_json(json, 'size', 0)
+        self.folder = maybe_json(json, 'folder', '')
         lang = maybe_json(json, 'language', 'unk')
         if lang:
             self.languages = lang.split('-')

--- a/plugin.video.media-ccc-de/resources/lib/test_recording.py
+++ b/plugin.video.media-ccc-de/resources/lib/test_recording.py
@@ -8,12 +8,13 @@ from .testdata import getfile
 
 def test_recordings():
     r = Recordings(SampleJson)
-    assert len(r.recordings) == 10
+    assert len(r.recordings) == 9
     recordings = r.recordings_sorted("hd", "mp4")
     assert len(recordings) == 6
     preferred = recordings[0]
     assert preferred.hd is True
     assert preferred.format == 'mp4'
+    assert preferred.folder == 'h264-hd'
     assert len(preferred.languages) == 2
 
 


### PR DESCRIPTION
### Description

Bugfix to work with newly added slide streams (ignore them for now).

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
