### PR TITLE
[plugin.video.zdf_de_2016] 1.0.10

### DIFF
--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.9" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.10" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -25,6 +25,9 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.10 (2018-01-11)
+- fix for rest-api url structure after change by zdf.de (see https://github.com/generia/plugin.video.zdf_de_2016/issues/14)
+
 1.0.9 (2017-12-22)
 - fix for empty cluster lists after website update
 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/LiveTvResource.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/LiveTvResource.py
@@ -8,7 +8,7 @@ from de.generia.kodi.plugin.backend.zdf.Teaser import Teaser
 
 livetvCellPattern = getTagPattern('div', 'js-livetv-scroller-cell')
 titlePattern = compile('<h2[^>]*>([^<]*)</h2>')
-contentNamePattern = compile('data-zdfplayer-id="([^"]*)"')
+contentNamePattern = compile('"embed_content"\s*:\s*"([^"]*)"')
 imagePattern = compile('data-src="([^"]*)"')
 
 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
@@ -183,9 +183,7 @@ class Teaser(object):
                 self.url = url[len(baseUrl):]
             i = url.rfind('.')
             if i != -1:
-                j = url.rfind('/')
-                if j != -1:
-                    self.contentName = url[j+1:i]
+                self.contentName = '/zdf' + url[0:i]
         return pos
     
     def parseText(self, article, pos, pattern=textPattern):

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/Constants.py
@@ -2,4 +2,5 @@
 class Constants(object):
     baseUrl = 'https://www.zdf.de'
     apiBaseUrl = 'https://api.zdf.de'
+    apiContentUrl = apiBaseUrl + '/content/documents'
     showsAzUrl = '/sendungen-a-z'

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/player/PlayVideo.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/player/PlayVideo.py
@@ -42,7 +42,7 @@ class PlayVideo(Pagelet):
             try:
                 dialog = xbmcgui.DialogProgressBG()
                 dialog.create(self._(32007), self._(32008))
-                videoContentUrl = Constants.apiBaseUrl + '/content/documents/' + contentName + '.json?profile=player'
+                videoContentUrl = Constants.apiContentUrl + contentName + '.json?profile=player'
                 self.debug("downloading video-content-url '{1}' ...", videoContentUrl)
                 videoContent = self._getVideoContent(videoContentUrl)
                 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
@@ -53,7 +53,7 @@ class RubricPage(AbstractPage):
     def _checkTeasers(self, teasers, apiToken):
         for teaser in teasers:
             if teaser.image is None and teaser.contentName is not None:
-                videoContentUrl = Constants.apiBaseUrl + '/content/documents/' + teaser.contentName + '.json?profile=player'
+                videoContentUrl = Constants.apiContentUrl + teaser.contentName + '.json?profile=player'
                 self.debug("downloading video-content-url '{1}' ...", videoContentUrl)
                 videoContent = VideoContentResource(videoContentUrl, Constants.apiBaseUrl, apiToken)
                 self._parse(videoContent)


### PR DESCRIPTION
### Description
An edge case slipped through and cause the addon to stop working. Sorry for the inconvenience.

1.0.10 (2018-01-11)
- fix for rest-api url structure after change by zdf.de (see https://github.com/generia/plugin.video.zdf_de_2016/issues/14)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
