### PR TITLE
[plugin.video.dumpert] 1.1.5

### DIFF
--- a/plugin.video.dumpert/addon.py
+++ b/plugin.video.dumpert/addon.py
@@ -4,20 +4,20 @@
 #
 # Imports
 #
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import os
 import sys
-import urlparse
+import urllib.parse
 import xbmc
 import xbmcaddon
-
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 LIB_DIR = xbmc.translatePath(
     os.path.join(xbmcaddon.Addon(id="plugin.video.dumpert").getAddonInfo('path'), 'resources', 'lib'))
 sys.path.append(LIB_DIR)
 
-from dumpert_const import ADDON, DATE, VERSION
+from dumpert_const import ADDON, DATE, VERSION, SETTINGS
 
 # Parse parameters...
 if len(sys.argv[2]) == 0:
@@ -27,9 +27,13 @@ if len(sys.argv[2]) == 0:
     xbmc.log("[ADDON] %s, Python Version %s" % (ADDON, str(sys.version)), xbmc.LOGDEBUG)
     xbmc.log("[ADDON] %s v%s (%s) is starting, ARGV = %s" % (ADDON, VERSION, DATE, repr(sys.argv)),
                  xbmc.LOGDEBUG)
-    import dumpert_main as plugin
+
+    if SETTINGS.getSetting('onlyshownewvideocategory') == 'true':
+        import dumpert_list as plugin
+    else:
+        import dumpert_main as plugin
 else:
-    action = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['action'][0]
+    action = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['action'][0]
     #
     # Themas
     #

--- a/plugin.video.dumpert/addon.xml
+++ b/plugin.video.dumpert/addon.xml
@@ -2,13 +2,15 @@
 <addon 
 	id="plugin.video.dumpert" 
 	name="Dumpert" 
-	version="1.1.4"
-	provider-name="Skipmode A1, Sparkline, Martijn">
+	version="1.1.5"
+	provider-name="Skipmode A1">
   <requires>
-    <import addon="xbmc.python"                 version="2.14.0"/>
-	<import addon="script.module.beautifulsoup" version="3.0.8"/>
-	<import addon="script.module.requests"      version="2.4.3"/>
-    <import addon="plugin.video.youtube"        version="5.1.7"/>
+    <import addon="xbmc.python"                     version="2.14.0"/>
+	<import addon="script.module.beautifulsoup4"    version="4.5.3"/>
+    <import addon="script.module.requests"          version="2.4.3"/>
+    <import addon="script.module.future"            version="0.0.1"/>
+  	<import addon="script.module.html5lib"          version="0.999.0"/>
+	<import addon="plugin.video.youtube" 		    version="5.1.7" />
   </requires>
   <extension point="xbmc.python.pluginsource" 	library="addon.py">
     <provides>video</provides>

--- a/plugin.video.dumpert/changelog.txt
+++ b/plugin.video.dumpert/changelog.txt
@@ -1,3 +1,9 @@
+v1.1.5 (2018-01-20)
+- adding a setting for only view new video category
+- addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
+Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
+- fixed scraping of some youtube videos
+
 v1.1.4 (2017-04-06):
 - small fix to enable starting a video with a browser (chrome and 'send to kodi'-extension)
 

--- a/plugin.video.dumpert/resources/language/Dutch/strings.po
+++ b/plugin.video.dumpert/resources/language/Dutch/strings.po
@@ -154,3 +154,7 @@ msgstr "Maandtop voor %s"
 msgctxt "#30600"
 msgid "Show NSFW content"
 msgstr "Toon NSFW filmpjes"
+
+msgctxt "#30610"
+msgid "Only show New video category"
+msgstr "Toon alleen Nieuwe video categorie"

--- a/plugin.video.dumpert/resources/language/English/strings.po
+++ b/plugin.video.dumpert/resources/language/English/strings.po
@@ -154,3 +154,7 @@ msgstr ""
 msgctxt "#30600"
 msgid "Show NSFW content"
 msgstr ""
+
+msgctxt "#30610"
+msgid "Only show New video category"
+msgstr ""

--- a/plugin.video.dumpert/resources/lib/dumpert_const.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_const.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
+import sys
 import os
+import xbmc
 import xbmcaddon
+from bs4 import BeautifulSoup
 
 #
 # Constants
@@ -11,5 +14,37 @@ ADDON = "plugin.video.dumpert"
 SETTINGS = xbmcaddon.Addon(id=ADDON)
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2017-04-06"
-VERSION = "1.1.4"
+DATE = "2018-01-20"
+VERSION = "1.1.5"
+
+
+if sys.version_info[0] > 2:
+    unicode = str
+
+
+def convertToUnicodeString(s, encoding='utf-8'):
+    """Safe decode byte strings to Unicode"""
+    if isinstance(s, bytes):  # This works in Python 2.7 and 3+
+        s = s.decode(encoding)
+    return s
+
+
+def convertToByteString(s, encoding='utf-8'):
+    """Safe encode Unicode strings to bytes"""
+    if isinstance(s, unicode):
+        s = s.encode(encoding)
+    return s
+
+
+def log(name_object, object):
+    try:
+        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
+            ADDON, VERSION, DATE, name_object, convertToUnicodeString(object)), xbmc.LOGDEBUG)
+    except:
+        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
+            ADDON, VERSION, DATE, name_object, "Unable to log the object due to an error while converting it to an unicode string"), xbmc.LOGDEBUG)
+
+
+def getSoup(html,default_parser="html5lib"):
+    soup = BeautifulSoup(html, default_parser)
+    return soup

--- a/plugin.video.dumpert/resources/lib/dumpert_main.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_main.py
@@ -4,9 +4,12 @@
 #
 # Imports
 #
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 import os
 import sys
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import xbmcgui
 import xbmcplugin
 
@@ -16,7 +19,7 @@ from dumpert_const import LANGUAGE, IMAGES_PATH
 #
 # Main class
 #
-class Main:
+class Main(object):
     def __init__(self):
         # Get the command line arguments
         # Get the plugin url in plugin:// notation
@@ -29,7 +32,7 @@ class Main:
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30001), "url": "http://www.dumpert.nl/1/",
                       "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30001), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -41,7 +44,7 @@ class Main:
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30000),
                       "url": "http://www.dumpert.nl/toppers/1/", "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30000), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -55,7 +58,7 @@ class Main:
         #
         parameters = {"action": "timemachine", "plugin_category": LANGUAGE(30005),
                       "url": "", "next_page_possible": "False"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30005), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -67,7 +70,7 @@ class Main:
         #
         parameters = {"action": "list", "plugin_category": LANGUAGE(30003),
                       "url": "http://www.dumpert.nl/floppers/1/", "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30003), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -79,7 +82,7 @@ class Main:
         #
         parameters = {"action": "json", "plugin_category": LANGUAGE(30006),
                       "url": "http://dumpert.nl/mobile_api/json/classics/0/", "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30006), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -90,8 +93,8 @@ class Main:
         # Themas
         #
         parameters = {"action": "list-themas", "plugin_category": LANGUAGE(30002),
-                      "url": "http://www.dumpert.nl/themas/1/", "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+                      "url": "http://www.dumpert.nl/themas/1/", "next_page_possible": "False"}
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30002), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -103,7 +106,7 @@ class Main:
         #
         parameters = {"action": "search", "plugin_category": LANGUAGE(30004),
                       "url": "http://www.dumpert.nl/search/", "next_page_possible": "True"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30004), iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})

--- a/plugin.video.dumpert/resources/lib/dumpert_play.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_play.py
@@ -4,25 +4,27 @@
 #
 # Imports
 #
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import ast
 import base64
 import re
 import requests
 import sys
-import urllib2
-import urlparse
+import urllib.request, urllib.error, urllib.parse
 import xbmc
 import xbmcgui
 import xbmcplugin
-from BeautifulSoup import BeautifulSoup
 
-from dumpert_const import ADDON, SETTINGS, LANGUAGE, DATE, VERSION
+from dumpert_const import LANGUAGE, SETTINGS, convertToUnicodeString, log, getSoup
 
 
 #
 # Main class
 #
-class Main:
+class Main(object):
     #
     # Init
     #
@@ -36,24 +38,22 @@ class Main:
         # Get plugin settings
         self.VIDEO = SETTINGS.getSetting('video')
 
-        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s, %s = %s" % (
-                ADDON, VERSION, DATE, "ARGV", repr(sys.argv), "File", str(__file__)), xbmc.LOGDEBUG)
+        log("ARGV", repr(sys.argv))
 
         # Parse parameters...
-        self.video_page_url = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['video_page_url'][0]
+        self.video_page_url = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['video_page_url'][0]
         # Try and get the title.
         # When starting a video with a browser (f.e. in chrome the 'send to kodi'-extension) the url will be
         # something like this:
         # plugin://plugin.video.dumpert/?action=play&video_page_url=http%3A%2F%2Fwww.dumpert.nl%2Fmediabase%2F7095997%2F1f72985c%2Fmevrouw_heeft_internetje_thuis.html
         # and there won't be a title available.
         try:
-            self.title = urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['title'][0]
+            self.title = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['title'][0]
             self.title = str(self.title)
         except KeyError:
             self.title = ""
 
-        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                ADDON, VERSION, DATE, "self.video_page_url", str(self.video_page_url)), xbmc.LOGDEBUG)
+        log("self.video_page_url",self.video_page_url)
 
         #
         # Play video...
@@ -74,11 +74,11 @@ class Main:
         #
         # Get current list item details...
         #
-        # title = unicode(xbmc.getInfoLabel("listitem.Title"), "utf-8")
-        thumbnail_url = xbmc.getInfoImage("list_item.Thumb")
-        # studio = unicode(xbmc.getInfoLabel("list_item.Studio"), "utf-8")
-        plot = unicode(xbmc.getInfoLabel("list_item.Plot"), "utf-8")
-        genre = unicode(xbmc.getInfoLabel("list_item.Genre"), "utf-8")
+        # title = convertToUnicodeString(xbmc.getInfoLabel("list_item.Title"))
+        thumbnail_url = convertToUnicodeString(xbmc.getInfoImage("list_item.Thumb"))
+        # studio = convertToUnicodeString(xbmc.getInfoLabel("list_item.Studio"))
+        # plot = convertToUnicodeString(xbmc.getInfoLabel("list_item.Plot"))
+        # genre = convertToUnicodeString(xbmc.getInfoLabel("list_item.Genre"))
 
         #
         # Show wait dialog while parsing data...
@@ -88,7 +88,6 @@ class Main:
         # wait 1 second
         xbmc.sleep(1000)
 
-        html_source = ''
         try:
             if SETTINGS.getSetting('nsfw') == 'true':
                 response = requests.get(self.video_page_url, cookies={'nsfw': '1'})
@@ -96,51 +95,67 @@ class Main:
                 response = requests.get(self.video_page_url)
 
             html_source = response.text
-        except urllib2.HTTPError, error:
-            xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                    ADDON, VERSION, DATE, "HTTPError", str(error)), xbmc.LOGDEBUG)
+            html_source = convertToUnicodeString(html_source)
+        except urllib.error.HTTPError as error:
+
+            log('HTTPError', error)
+
             dialog_wait.close()
             del dialog_wait
             xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30507) % (str(error)))
             exit(1)
 
-        soup = BeautifulSoup(html_source)
+        # Parse response
+        soup = getSoup(html_source)
 
         video_url = ''
         # <div class="videoplayer" id="video1" data-files="eyJmbHYiOiJodHRwOlwvXC9tZWRpYS5kdW1wZXJ0Lm5sXC9mbHZcLzI4OTE2NWRhXzEwMjU1NzUyXzYzODMxODA4OTU1NDc2MV84MTk0MzU3MDVfbi5tcDQuZmx2IiwidGFibGV0IjoiaHR0cDpcL1wvbWVkaWEuZHVtcGVydC5ubFwvdGFibGV0XC8yODkxNjVkYV8xMDI1NTc1Ml82MzgzMTgwODk1NTQ3NjFfODE5NDM1NzA1X24ubXA0Lm1wNCIsIm1vYmlsZSI6Imh0dHA6XC9cL21lZGlhLmR1bXBlcnQubmxcL21vYmlsZVwvMjg5MTY1ZGFfMTAyNTU3NTJfNjM4MzE4MDg5NTU0NzYxXzgxOTQzNTcwNV9uLm1wNC5tcDQiLCJzdGlsbCI6Imh0dHA6XC9cL3N0YXRpYy5kdW1wZXJ0Lm5sXC9zdGlsbHNcLzY1OTM1MjRfMjg5MTY1ZGEuanBnIn0="></div></div>
         video_urls = soup.findAll('div', attrs={'class': re.compile("video")}, limit=1)
         if len(video_urls) == 0:
-            no_url_found = True
+            # maybe it's a youtube url
+            # <iframe class='yt-iframe' style='width: 100%' src='https://www.youtube.com/embed/jkdwK_74eEs' frameborder='0' allow='autoplay; encrypted-media' allowfullscreen></iframe>
+            video_urls = soup.findAll('iframe', attrs={'src': re.compile("^http")}, limit=1)
+            if len(video_urls) == 0:
+                no_url_found = True
+            else:
+                url = video_urls[0]['src']
+                start_pos_youtube_id = str(url).rfind("/") + len("/")
+                end_pos_youtube_id = len(url)
+                youtube_id = url[start_pos_youtube_id:end_pos_youtube_id]
+                youtube_url = 'plugin://plugin.video.youtube/play/?video_id=%s' % youtube_id
+                video_url = youtube_url
+                have_valid_url = True
+
+                log("video_url1", video_url)
+
         else:
             video_url_enc = video_urls[0]['data-files']
             # base64 decode
-            video_url_dec = str(base64.b64decode(video_url_enc))
+            video_url_dec = convertToUnicodeString(base64.b64decode(video_url_enc))
             # {"flv":"http:\/\/media.dumpert.nl\/flv\/5770e490_Jumbo_KOOP_DAN__Remix.avi.flv","tablet":"http:\/\/media.dumpert.nl\/tablet\/5770e490_Jumbo_KOOP_DAN__Remix.avi.mp4","mobile":"http:\/\/media.dumpert.nl\/mobile\/5770e490_Jumbo_KOOP_DAN__Remix.avi.mp4","720p":"http:\/\/media.dumpert.nl\/720p\/5770e490_Jumbo_KOOP_DAN__Remix.avi.mp4","still":"http:\/\/static.dumpert.nl\/stills\/6593503_5770e490.jpg"}
             # or
             # {"embed":"youtube:U89fl5fZETE","still":"http:\/\/static.dumpert.nl\/stills\/6650228_24eed546.jpg"}
 
-            xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                    ADDON, VERSION, DATE, "video_url_dec", str(video_url_dec)), xbmc.LOGDEBUG)
+            log("video_url_dec", video_url_dec)
 
             # convert string to dictionary
             video_url_dec_dict = ast.literal_eval(video_url_dec)
 
-            video_url_embed = ''
             try:
-                video_url_embed = str(video_url_dec_dict['embed'])
+                video_url_embed = convertToUnicodeString(video_url_dec_dict['embed'])
                 embed_found = True
             except KeyError:
                 embed_found = False
 
-            video_url = ''
             if embed_found:
                 # make youtube plugin url
                 youtube_id = video_url_embed.replace("youtube:", "")
                 youtube_url = 'plugin://plugin.video.youtube/play/?video_id=%s' % youtube_id
                 video_url = youtube_url
                 have_valid_url = True
-                xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                        ADDON, VERSION, DATE, "video_url1", str(video_url)), xbmc.LOGDEBUG)
+
+                log("video_url2", video_url)
+
             else:
                 # matching the desired and available quality
                 if self.VIDEO == '0':
@@ -172,8 +187,8 @@ class Main:
                     pass
                 else:
                     video_url = video_url.replace('\/', '/')
-                    xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                            ADDON, VERSION, DATE, "video_url2", str(video_url)), xbmc.LOGDEBUG)
+
+                    log("video_url3", video_url)
 
                     # The need for speed: let's guess that the video-url exists
                     have_valid_url = True

--- a/plugin.video.dumpert/resources/lib/dumpert_search.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_search.py
@@ -4,24 +4,20 @@
 #
 # Imports
 #
-import os
-import re
-import requests
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import sys
-import urllib
-import urlparse
 import xbmc
-import xbmcgui
-import xbmcplugin
-from BeautifulSoup import BeautifulSoup
 
-from dumpert_const import ADDON, SETTINGS, LANGUAGE, IMAGES_PATH, DATE, VERSION
+from dumpert_const import LANGUAGE, log, convertToUnicodeString
 
 
 #
 # Main class
 #
-class Main:
+class Main(object):
     #
     # Init
     #
@@ -32,36 +28,21 @@ class Main:
         # Get the plugin handle as an integer number
         self.plugin_handle = int(sys.argv[1])
 
-        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s, %s = %s" % (
-                ADDON, VERSION, DATE, "ARGV", repr(sys.argv), "File", str(__file__)), xbmc.LOGDEBUG)
+        log("ARGV", repr(sys.argv))
 
-        # Parse parameters
-        # urlparse.parse_qs(urlparse.urlparse(sys.argv[2]).query)['url'][0]
-        base = urlparse.urlparse(sys.argv[2])
-        query = base.query
-        args = urlparse.parse_qs(query)
-        url = args['url'][0]
-
-        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
-                ADDON, VERSION, DATE, "self.video_list_page_url", str(url)),
-                     xbmc.LOGDEBUG)
-
-        # Get query
-        q = ''
+        # Get search term from user
         keyboard = xbmc.Keyboard('', LANGUAGE(30508))
         keyboard.doModal()
 
         if keyboard.isConfirmed():
-            q = keyboard.getText()
+            search_term = keyboard.getText()
 
-        url = requests.post(url, data={'q': q, 'cat': '', 'submit': 'zoek'}).url
-
+        sys.argv[2] = convertToUnicodeString(sys.argv[2])
         # Converting URL argument to proper query string like 'http://www.dumpert.nl/search/ALL/fiets/1/'
-        args.update({'url': url + '1/'})
-        encoded_args = urllib.urlencode(args, doseq=True)
+        sys.argv[2] = sys.argv[2] + "/ALL/" + search_term + "/1/'"
 
-        sys.argv[2] = urlparse.ParseResult(base.scheme, base.netloc, base.path, base.params, encoded_args,
-                                           base.fragment).geturl()  # Run list on results
+        log("sys.argv[2]", sys.argv[2])
+
         import dumpert_list as plugin
 
         plugin.Main()

--- a/plugin.video.dumpert/resources/lib/dumpert_timemachine.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_timemachine.py
@@ -4,26 +4,25 @@
 #
 # Imports
 #
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import os
-import re
-import requests
 import sys
-import urllib
-import urlparse
-import xbmc
+import urllib.request, urllib.parse, urllib.error
 import xbmcgui
 import xbmcplugin
-from BeautifulSoup import BeautifulSoup
 from datetime import datetime
 import time
 
-from dumpert_const import ADDON, SETTINGS, LANGUAGE, IMAGES_PATH, DATE, VERSION
+from dumpert_const import LANGUAGE, IMAGES_PATH, log
 
 
 #
 # Main class
 #
-class Main:
+class Main(object):
     #
     # Init
     #
@@ -33,8 +32,8 @@ class Main:
         self.plugin_url = sys.argv[0]
         # Get the plugin handle as an integer number
         self.plugin_handle = int(sys.argv[1])
-        xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s, %s = %s" % (
-                ADDON, VERSION, DATE, "ARGV", repr(sys.argv), "File", str(__file__)), xbmc.LOGDEBUG)
+
+        log("ARGV", repr(sys.argv))
 
         date = xbmcgui.Dialog().numeric(1, LANGUAGE(30509))
         if not date is None:
@@ -62,7 +61,7 @@ class Main:
         # Next page is not available for top5
         parameters = {"action": "json", "plugin_category": title,
                       "url": daytop, "next_page_possible": "False"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(title, iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -73,7 +72,7 @@ class Main:
         # Next page is not available for top5
         parameters = {"action": "json", "plugin_category": title,
                       "url": weektop, "next_page_possible": "False"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(title, iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
@@ -84,7 +83,7 @@ class Main:
         # Next page is not available for top5
         parameters = {"action": "json", "plugin_category": title,
                       "url": monthtop, "next_page_possible": "False"}
-        url = self.plugin_url + '?' + urllib.urlencode(parameters)
+        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(title, iconImage="DefaultFolder.png")
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})

--- a/plugin.video.dumpert/resources/settings.xml
+++ b/plugin.video.dumpert/resources/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 <!--the number after default indicates the index, index 0 is the first lvalue, index 1 is the second lvalue and so on-->
-	<setting id="video"         label="30300" type="enum" default="2" lvalues="30301|30302|30303"/>
-	<setting id="nsfw" 		label="30600" type="bool" default="false"/>
+	<setting id="video"                         label="30300" type="enum" default="2" lvalues="30301|30302|30303"/>
+	<setting id="nsfw" 		                    label="30600" type="bool" default="false"/>
+	<setting id="onlyshownewvideocategory" 		label="30610" type="bool" default="false"/>
 </settings>


### PR DESCRIPTION
### Description
v1.1.5 (2018-01-20)
- adding a setting for only view new video category
- addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
Kudo's to the python future package for making this possible.
- fixed scraping of some youtube videos
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
