### PR TITLE
[plugin.video.cnet.podcasts] 1.1.6

### DIFF
--- a/plugin.video.cnet.podcasts/addon.xml
+++ b/plugin.video.cnet.podcasts/addon.xml
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cnet.podcasts"
        name="CNET Podcasts"
-       version="1.1.5"
+       version="1.1.6"
        provider-name="Skipmode A1, Divingmule">
   <requires>
-    <import addon="xbmc.python" version="2.14.0"/>
-    <import addon="script.module.beautifulsoup4" version="4.3.1"/>
-	<import addon="script.module.requests"      version="2.4.3"/>
-    <import addon="script.common.plugin.cache" version="2.5.2"/>
+    <import addon="xbmc.python"                   version="2.14.0"/>
+    <import addon="script.module.beautifulsoup4"  version="4.3.1"/>
+	<import addon="script.module.requests"        version="2.4.3"/>
+    <import addon="script.module.future"          version="0.0.1"/>
+  	<import addon="script.module.html5lib"        version="0.999.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>

--- a/plugin.video.cnet.podcasts/changelog.txt
+++ b/plugin.video.cnet.podcasts/changelog.txt
@@ -1,65 +1,72 @@
+v1.1.6 (2018-01-20)
+- addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
+Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
+- removed caching
+- adding a setting to only view all video category
+
 v1.1.5 (2017-07-16)
-rolling back changed foldername for strings because that doesn't work for gotham 
+- rolling back changed foldername for strings because that doesn't work for gotham
 
 v1.1.4 (2017-07-12)
-reformatted changelog
-removed strings.xml
-added listitem.setInfo video for Kodi 18 and up
-added sorting
-added context item episode info
-removed 'latest videos' category as that already exists as 'all' category
-refactored listing the videos
-changed foldername for strings
-using requests
+- reformatted changelog
+- removed strings.xml
+- added listitem.setInfo video for Kodi 18 and up
+- added sorting
+- added context item episode info
+- removed 'latest videos' category as that already exists as 'all' category
+- refactored listing the videos
+- changed foldername for strings
+- using requests
 
 v1.1.3 (2017-03-03)
-using po-files
-fixed url in addon.xml as per request
+- using po-files
+- fixed url in addon.xml as per request
 
 v1.1.2 (2016-02-20)
-added some utf-8 stuff
-updated to latest requirements for a Kodi-addon
-added fanart
-added fanart-blurred
+- added some utf-8 stuff
+- updated to latest requirements for a Kodi-addon
+- added fanart
+- added fanart-blurred
 
 v1.1.1 (2014-04-20)
-fix to get the addon working again after changes in the website. 
-I couldn't get in contact with divingmule, therefore i (Skipmode A1) made a new of the addon based on divingmule's sourcecode. 
-Thanks to gtoons for the feedburner tip.
+- fix to get the addon working again after changes in the website.
+- I couldn't get in contact with divingmule, therefore i (Skipmode A1) made a new of the addon based on divingmule's sourcecode.
+- Thanks to gtoons for the feedburner tip.
 
 v1.1.0
-update for frodo/gotham
+- update for frodo/gotham
 
 v1.0.8
-fix for changes in Frodo
+- fix for changes in Frodo
 
 v1.0.7
-updated podcasts list 
+- updated podcasts list
 
 v1.0.6
-fix bug in scraper
+- fix bug in scraper
 
 v1.0.5
-updated show list, thanks pkscuot
+- updated show list, thanks pkscuot
 
 v1.0.2
-fix for feed changes
-new playback setting
+- fix for feed changes
+- new playback setting
 
 v1.0.1
-added the crave podcast
+- added the crave podcast
 
 v1.0.0
-new for eden
+- new for eden
 
 v0.0.4
-added addon settings for video quality instead of categories
+- added addon settings for video quality instead of categories
 
 v0.0.3
-updated icon.png
+- updated icon.png
 
 v0.0.2
-added video descriptions
-added categories for SD and HD
+- added video descriptions
+- added categories for SD and HD
 
 v0.0.1
+- initial version

--- a/plugin.video.cnet.podcasts/resources/language/English/strings.po
+++ b/plugin.video.cnet.podcasts/resources/language/English/strings.po
@@ -90,3 +90,7 @@ msgstr ""
 msgctxt "#30106"
 msgid "Error getting page: %s"
 msgstr ""
+
+msgctxt "#30610"
+msgid "Only show All video category"
+msgstr ""

--- a/plugin.video.cnet.podcasts/resources/settings.xml
+++ b/plugin.video.cnet.podcasts/resources/settings.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 <!--<setting id="playback_type" type="enum" lvalues="30001|30002|30003" label="30004" default="1"/>-->
-    <setting id="view_mode" type="enum" label="30005" lvalues="30006|30007|30008|30009|30010|30011|30012" default="0"/>
+    <setting id="view_mode"              type="enum" label="30005" lvalues="30006|30007|30008|30009|30010|30011|30012" default="0"/>
+    <setting id="onlyshowallcategory" type="bool" label="30610"                                                     default="false"/>
 </settings>


### PR DESCRIPTION
### Description
v1.1.6 (2018-01-20)
- addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
- removed caching
- adding a setting to only view all video category

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
