### PR TITLE
[plugin.video.corrieretv] 2.0.1

### DIFF
--- a/plugin.video.corrieretv/addon.xml
+++ b/plugin.video.corrieretv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.corrieretv"
        name="Corriere TV"
-       version="2.0.0"
+       version="2.0.1"
        provider-name="Nightflyer">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/plugin.video.corrieretv/changelog.txt
+++ b/plugin.video.corrieretv/changelog.txt
@@ -1,3 +1,7 @@
+[B]2.0.1[/B]
+- Added li.setInfo video for Kodi 18.
+- Fixed missing thumbnails.
+
 [B]2.0.0[/B]
 - Parsing upstream HTML pages because the RSS video feeds are no longer available.
 - Updated icon.

--- a/plugin.video.corrieretv/default.py
+++ b/plugin.video.corrieretv/default.py
@@ -31,6 +31,8 @@ def addDirectoryItem(parameters, li):
         listitem=li, isFolder=True)
 
 def addLinkItem(parameters, li):
+    li.setProperty('IsPlayable', 'true')
+    li.setInfo('video', {})
     url = sys.argv[0] + '?' + urllib.urlencode(parameters)
     return xbmcplugin.addDirectoryItem(handle=handle, url=url, 
         listitem=li, isFolder=False)
@@ -52,7 +54,6 @@ def show_video_files(url):
     for item in items:
         title = item["title"] + " (" + item["date"] + ")"
         liStyle=xbmcgui.ListItem(title, thumbnailImage=item["thumb"])
-        liStyle.setProperty('IsPlayable', 'true')
         addLinkItem({"mode": "play", "id": item["videoId"]}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
 

--- a/plugin.video.corrieretv/resources/lib/corrieretv.py
+++ b/plugin.video.corrieretv/resources/lib/corrieretv.py
@@ -61,6 +61,8 @@ class CorriereTV:
             thumb = article.find("img")
             if thumb is not None:
                 video["thumb"] = thumb["data-original"]
+                if video["thumb"].startswith("//"):
+                    video["thumb"] = "http:" + video["thumb"]
             else:
                 video["thumb"] = self.__noThumb
             


### PR DESCRIPTION
### Description
**2.0.1**
- Added li.setInfo video for Kodi 18.
- Fixed missing thumbnails.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
