### PR TITLE
[plugin.video.tvkc] 1.0.1

### DIFF
--- a/plugin.video.tvkc/addon.xml
+++ b/plugin.video.tvkc/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.tvkc"
        name="TV Koper Capodistria"
-       version="1.0.0"
+       version="1.0.1"
        provider-name="Nightflyer">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/plugin.video.tvkc/changelog.txt
+++ b/plugin.video.tvkc/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.0.1[/B]
+- use setResolvedUrl for playback.
+
 [B]1.0.0[/B]
 - first release
 

--- a/plugin.video.tvkc/default.py
+++ b/plugin.video.tvkc/default.py
@@ -51,6 +51,7 @@ def show_video_files(url):
     for item in items:
         title = item["title"] + " (" + item["date"] + ")"
         liStyle=xbmcgui.ListItem(title, thumbnailImage=item["thumb"])
+        liStyle.setProperty('IsPlayable', 'true')
         liStyle.setInfo(type="video", infoLabels={"Title": title})
         addLinkItem({"section": "play", "videoId": item["id"]}, liStyle)
     xbmcplugin.endOfDirectory(handle=handle, succeeded=True)
@@ -58,14 +59,16 @@ def show_video_files(url):
 def play_video(videoId):
     tvkc = TVKC()
     metadata = tvkc.getVideoMetadata(videoId)
-    liStyle=xbmcgui.ListItem(metadata["title"], thumbnailImage=metadata["images"]["orig"])
-    liStyle.setInfo(type="video", infoLabels={"Title": metadata["title"]})
     for f in metadata["mediaFiles"]:
         if f["mediaType"] == "MP4":
             video_url = f["streamer"] + \
                 " playpath=mp4:" + f["filename"]
             break
-    xbmc.Player().play(video_url, liStyle)
+    
+    liStyle=xbmcgui.ListItem(metadata["title"], thumbnailImage=metadata["images"]["orig"], path=video_url)
+    liStyle.setInfo(type="video", infoLabels={"Title": metadata["title"]})
+
+    xbmcplugin.setResolvedUrl(handle=handle, succeeded=True, listitem=liStyle)
     
 # parameter values
 params = parameters_string_to_dict(sys.argv[2])


### PR DESCRIPTION
**1.0.1**
- use setResolvedUrl for playback.
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
