### PR TITLE
[plugin.video.vercelliwebtv] 1.0.1

### DIFF
--- a/plugin.video.vercelliwebtv/addon.xml
+++ b/plugin.video.vercelliwebtv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vercelliwebtv"
        name="VercelliWeb.TV"
-       version="1.0.0"
+       version="1.0.1"
        provider-name="Nightflyer">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>

--- a/plugin.video.vercelliwebtv/changelog.txt
+++ b/plugin.video.vercelliwebtv/changelog.txt
@@ -1,3 +1,7 @@
+[B]1.0.1[/B]
+- updated HTML parsing due to upstream changes.
+- added li.setInfo video for Kodi 18.
+
 [B]1.0.0[/B]
 - first release
 

--- a/plugin.video.vercelliwebtv/default.py
+++ b/plugin.video.vercelliwebtv/default.py
@@ -28,6 +28,8 @@ def parameters_string_to_dict(parameters):
     return paramDict
  
 def addLinkItem(parameters, li):
+    li.setProperty('IsPlayable', 'true')
+    li.setInfo('video', {})
     url = sys.argv[0] + '?' + urllib.urlencode(parameters)
     return xbmcplugin.addDirectoryItem(handle=handle, url=url, 
         listitem=li, isFolder=False)
@@ -40,7 +42,6 @@ def show_root_menu():
     for entry in f.entries: 
         pageUrl = entry["link"]
         liStyle=xbmcgui.ListItem(entry.title + " (" + time.strftime("%d-%m-%Y %H:%M", entry.published_parsed) + ")" )
-        liStyle.setProperty('IsPlayable', 'true')
         addLinkItem({"mode": "play", "url": pageUrl}, liStyle)
 
     # TODO: Sort from most recent entry
@@ -53,14 +54,10 @@ def play(pageUrl):
     tree = BeautifulSoup(htmlData, convertEntities=BeautifulSoup.HTML_ENTITIES)
 
     videoUrl = None
-    iframeTags = tree.findAll("iframe")
-    for iframeTag in iframeTags:
-        src = iframeTag["src"]
-        if src.find("https://www.youtube.com") != -1:
-            videoId = src[src.rfind("/")+1:src.rfind("?")]
-            videoUrl = "plugin://plugin.video.youtube/play/?video_id=%s" % videoId
-            break
-    xbmc.log("Video URL: " + videoUrl)
+    iframeUrl = tree.find("iframe", "youtube-player")["src"]
+    if iframeUrl.find("http://www.youtube.com") != -1:
+        videoId = iframeUrl[iframeUrl.rfind("/")+1:iframeUrl.rfind("?")]
+        videoUrl = "plugin://plugin.video.youtube/play/?video_id=%s" % videoId
     
     # Check is video not supported
     if videoUrl == None: 
@@ -68,6 +65,7 @@ def play(pageUrl):
         dialog.ok("VercelliWeb.TV", "Formato video non supportato.")
         return
 
+    xbmc.log("Video URL: " + videoUrl)
     xbmcplugin.setResolvedUrl(handle=handle, succeeded=True, listitem=xbmcgui.ListItem(path=videoUrl))
 
 # parameter values


### PR DESCRIPTION
**1.0.1**
- updated HTML parsing due to upstream changes.
- added li.setInfo video for Kodi 18.
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
