### PR TITLE
[plugin.video.cbcolympics] v1.0.1

### DIFF
--- a/plugin.video.cbcolympics/README.md
+++ b/plugin.video.cbcolympics/README.md
@@ -2,3 +2,36 @@ CBC Olympics
 ============
 
 A Kodi/XBMC plugin for watching the CBC Olympics streams
+
+Behaviour
+============
+When loading videos, if an English audio stream is available it prefers that.
+
+By default only the highest bitrate streams are used (typically 720p 3.4 Mbit/s) however the addon features a setting that can be set to limit this in case you're on a limited bandwidth connection. Available stream choices are 3.5 Mbit/s (default), 2.2 Mbit/s, 1.4 Mbit/s, 950 kbit/s, 600 kbit/s, 400 kbit/s, 250 kbit/s, and 150 kbit/s. Incredibly, it's still watchable at the lowest setting though the resolution is 256x144.
+
+Until this gets added to the official repository, installation must be done manually. Follow the steps below for a manual installation.
+
+To install
+============
+
+1. Download this .zip into your Kodi's downloads folder (/storage/downloads/)
+
+2. Navigate to Add-Ons
+![screenshot000](https://user-images.githubusercontent.com/31328055/36081530-0290d314-0f55-11e8-9ebd-f6e7d866ac84.png)
+
+3. Select the "Install" box icon at the top left of the Add-ons menu
+![screenshot001](https://user-images.githubusercontent.com/31328055/36081513-da9b30e8-0f54-11e8-95a0-ff5f0169a5bf.png)
+
+4. Select "Install from zip file"
+![screenshot002](https://user-images.githubusercontent.com/31328055/36081542-2e26b156-0f55-11e8-987a-b9a07275ca28.png)
+
+_The file selection dialog opens_
+
+5. Select Home folder
+![screenshot003](https://user-images.githubusercontent.com/31328055/36081543-300b03fa-0f55-11e8-98aa-9f25f161e8f6.png)
+
+6. Select downloads
+![screenshot004](https://user-images.githubusercontent.com/31328055/36081544-31c86a3e-0f55-11e8-8e4d-aee81531871b.png)
+
+7. Select the zip file and click OK to install
+![screenshot005](https://user-images.githubusercontent.com/31328055/36081548-3457e7de-0f55-11e8-94d1-86bc95f7794d.png)

--- a/plugin.video.cbcolympics/addon.xml
+++ b/plugin.video.cbcolympics/addon.xml
@@ -1,21 +1,27 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cbcolympics"
        name="CBC Olympics"
-       version="1.0.0"
+       version="1.0.1"
        provider-name="fourpointsix">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
+    <import addon="xbmc.python" version="2.24.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
-  	<provides>video</provides>
+    <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">CBC Olympics</summary>
     <description lang="en">2018 Winter Olympic streams from the CBC. Streams are geo-blocked so you must be on a Canadian IP for this to work.</description>
     <platform>all</platform>
     <language>en</language>
+    <news>v1.0.1
+- Added bitrate limit setting
+- Changed Python dependency to 2.24 for Kodi 16 compatibility
+- Added durations to video listing
+- Added start times to upcoming events</news>
   </extension>
   <assets>
     <icon>icon.png</icon>
+    <fanart>fanart.jpg</fanart>
   </assets>
 </addon>

--- a/plugin.video.cbcolympics/changelog.txt
+++ b/plugin.video.cbcolympics/changelog.txt
@@ -1,2 +1,8 @@
 v1.0.0
 - Initial version for 2018 Winter Olympics
+
+v1.0.1
+- Added bitrate limit setting
+- Changed Python dependency to 2.24 for Kodi 16 compatibility
+- Added durations to video listing
+- Added start times to upcoming events

--- a/plugin.video.cbcolympics/default.py
+++ b/plugin.video.cbcolympics/default.py
@@ -1,6 +1,8 @@
 import sys
 from urllib import urlencode
 from urlparse import urlparse, parse_qsl
+import datetime
+import time
 import json
 import re
 import xbmcgui
@@ -25,6 +27,12 @@ def strings(id):
 CBC_HOST = 'https://olympics.cbc.ca'
 
 USERAGENT   = 'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.101 Safari/537.36'
+
+STATE_UPCOMING = 'upcoming'
+STATE_LIVE = 'live'
+STATE_REPLAY = 'replay'
+
+TIME_FORMAT = '%I:%M %p'
 
 httpHeaders = {'User-Agent': USERAGENT,
                 'Accept':"application/json, text/javascript, text/html,*/*",
@@ -112,7 +120,7 @@ STATIC_ENTRIES = [
                 'type': 'folder',
                 'page': 'json_videos',
                 'title': strings(30206),
-                'uri': 'https://olympics.cbc.ca/api-live/online-listing/must-see/list.json',
+                'uri': CBC_HOST + '/api-live/online-listing/must-see/list.json',
             },
             {
                 'type': 'folder',
@@ -139,6 +147,31 @@ STATIC_ENTRIES = [
                 'uri': 'whats-on-tv',
             },
         ]
+
+# This assumes the input format is fixed at yyyy-mm-ddThh:mm:ssZ
+# (eg. '2018-02-19T10:55:00Z')
+def iso8601UtcStrToLocalDateTime(text):
+    # The lack of native support for time zones in Python is surprising
+    # so we have to calculate it ourselves
+
+    # Calculate the UTC offset for this machine
+    utcOffset = datetime.datetime.now() - datetime.datetime.utcnow()
+
+    # Round the offset to the nearest second because utcnow() and now() were
+    # called serially so there's a few microseconds between them
+    utcOffset = datetime.timedelta(seconds = int(utcOffset.total_seconds()))
+
+    try:
+        # Convert the input UTC string into a UTC datetime object
+        eventTimeUtc = datetime.datetime.strptime(text, '%Y-%m-%dT%H:%M:%SZ')
+    except TypeError:
+        # This is screwy. Some calls to strptime throw "TypeError: attribute of type 'NoneType' is not callable"
+        # so this workaround is necessary. It happened to me and it could happen to you.
+        # See https://forum.kodi.tv/showthread.php?tid=112916
+        eventTimeUtc = datetime.datetime(*(time.strptime(text, '%Y-%m-%dT%H:%M:%SZ')[0:6]))        
+
+    # Return the datetime object offset by utcOffset to get local time
+    return eventTimeUtc + utcOffset
 
 # Lovingly borrowed from t1mlib
 def get_url(**kwargs):
@@ -180,6 +213,15 @@ def list_entries(folder_title, entries):
                     'plot': entry.get('description', None),
                     'mediatype': 'video'
                 })
+
+            # Set the stream duration if it was provided so it shows
+            # in the listing
+            duration = entry.get('duration')
+            if duration is not None:
+                list_item.addStreamInfo('video',
+                    {
+                        'duration': duration.total_seconds()
+                    })
 
             list_item.setArt(entry['art'])
             list_item.setProperty('IsPlayable', 'true')
@@ -240,11 +282,56 @@ def list_json_videos_bydate(folder_title, category):
 
 def list_json_append_video(entries, video):
     try:
+        if (video.get('startDate') is not None) and (video.get('endDate') is not None):
+            # For videos with start and end dates, calculate and include the event duration
+            startDate = iso8601UtcStrToLocalDateTime(video['startDate'])
+            endDate = iso8601UtcStrToLocalDateTime(video['endDate'])
+            duration = endDate - startDate
+        else:
+            duration = None
+
         if ('state' in video) and (video['state'] != ''):
-            video['description'] = u'{0}\n\n({1})'.format(video['description'], video['state'].title())
-            video['title'] = u'{0} ({1})'.format(video['title'].rstrip(), video['state'])
+            titleState = video['state']
+            descState = video['state']
+
+            if video['state'] != STATE_REPLAY:
+                # For non-replay entries, include the event start time
+                try:
+                    # Convert the UTC start date string into a local datetime object
+                    startDate = iso8601UtcStrToLocalDateTime(video['startDate'])
+
+                    # Get the event start time string, stripping off leading zeroes because
+                    # apparently Python doesn't have a format specifier for 12-hour hours
+                    # without leading zeroes
+                    startTimeStr = startDate.strftime(TIME_FORMAT).lstrip('0')
+
+                    # For events today just include the time but for
+                    # events on another day, include the date and time
+                    if datetime.datetime.now().date() == startDate.date():
+                        startDateStr = startTimeStr
+                    else:
+                        monthStr = startDate.strftime('%b')
+                        dayStr = startDate.strftime('%d').lstrip('0')       # There's that leading zero strip again
+                        startDateStr = '{0} {1} {2}'.format(startTimeStr, monthStr, dayStr)
+
+                    # Build a description of the start date
+                    if video['state'] == STATE_UPCOMING:
+                        titleState = strings(30303).format(startDateStr)
+                        descState = strings(30303).format(startDateStr)
+                    elif video['state'] == STATE_LIVE:
+                        titleState = strings(30304).format(startDateStr)
+                        descState = strings(30304).format(startDateStr)
+                except:
+                    # Something went wrong so just go with the default state string
+                    pass
+            elif video['state'] == STATE_REPLAY:
+                titleState = strings(30305)
+                descState = strings(30305)
+
+            video['title'] = u'{0} ({1})'.format(video['title'].rstrip(), titleState)
+            video['description'] = u'{0}\n\n({1})'.format(video['description'], descState)
     except:
-        raise ValueError(str(video))
+        raise # ValueError(str(video))
 
     entries.append(
         {
@@ -252,6 +339,7 @@ def list_json_append_video(entries, video):
             'title': video['title'],
             'description': video['description'],
             'videoId': video['key'],
+            'duration': duration,
             'art':
             {
 
@@ -281,7 +369,7 @@ def list_json_videos(folder_title, url):
 
 def videoIdToIsmUrl(videoId):
     # Build URL to the video's XML document
-    xml_url = 'https://olympics.cbc.ca/videodata/{0}.xml'
+    xml_url = CBC_HOST + '/videodata/{0}.xml'
 
     # Fetch the XML
     xml = getRequest(xml_url.format(videoId))
@@ -320,15 +408,23 @@ def videoIsmUrlToMpegUrl(video_ism_url):
     xml_streams = re.compile('<StreamIndex (.+)>(.+?)</StreamIndex>', re.DOTALL).search(xml).group(1)
     quality_levels = re.compile('<QualityLevel Index="(.+?)" Bitrate="(.+?)"', re.DOTALL).findall(xml_streams)
 
-    # Find the highest quality level
-    highest_quality = 0
-    for quality_level in quality_levels:
-        if int(quality_level[1]) > highest_quality:
-            highest_quality = int(quality_level[1])
+    # Get the bitrate limit setting, if there is one
+    try:
+        # Load the kbps bitrate setting and convert to bps
+        bitrateLimit = int(xbmcplugin.getSetting(_handle, 'bitrateLimitKbps')) * 1000
+    except ValueError:
+        bitrateLimit = 10000000000       # 10 Gbit/sec is essentially unlimited, right?
 
-    # Default to the most popular highest quality level
-    if highest_quality == 0:
-        highest_quality = 3449984
+    # Find the highest bitrate within the setting limit
+    selected_bitrate = 0
+    for quality_level in quality_levels:
+        bitrate = int(quality_level[1])
+        if (bitrate <= bitrateLimit) and (bitrate > selected_bitrate):
+            selected_bitrate = bitrate
+
+    # Default to the most popular highest bitrate
+    if selected_bitrate == 0:
+        selected_bitrate = 3449984
 
     # Get the audio track format
     # Find all stream tags
@@ -350,7 +446,7 @@ def videoIsmUrlToMpegUrl(video_ism_url):
             if audiotrack_eng.find('eng') != -1:
                 audiotrack = audiotrack_eng
 
-    url = video_ism_url + '/QualityLevels({0})/Manifest(video,format=m3u8-aapl-v3,audiotrack={1},filter=hls)|User-Agent={2}'.format(highest_quality, audiotrack, user_agent)
+    url = video_ism_url + '/QualityLevels({0})/Manifest(video,format=m3u8-aapl-v3,audiotrack={1},filter=hls)|User-Agent={2}'.format(selected_bitrate, audiotrack, user_agent)
 
     return url
 

--- a/plugin.video.cbcolympics/resources/language/English/strings.po
+++ b/plugin.video.cbcolympics/resources/language/English/strings.po
@@ -188,6 +188,26 @@ msgctxt "#30300"
 msgid "Root"
 msgstr ""
 
+msgctxt "#30301"
+msgid "General"
+msgstr ""
+
+msgctxt "#30302"
+msgid "Bit rate limit (kbit/s)"
+msgstr ""
+
+msgctxt "#30303"
+msgid "Upcoming at {0}"
+msgstr ""
+
+msgctxt "#30304"
+msgid "Live since {0}"
+msgstr ""
+
+msgctxt "#30305"
+msgid "Replay"
+msgstr ""
+
 # Errors
 msgctxt "#30900"
 msgid "No URL or ID provided for video"

--- a/plugin.video.cbcolympics/resources/settings.xml
+++ b/plugin.video.cbcolympics/resources/settings.xml
@@ -1,3 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
+  <category label="30301">
+    <setting id="bitrateLimitKbps" type="select" label="30302" default="Unlimited" values="Unlimited|3500|2200|1400|950|600|400|250|150" />
+  </category>
 </settings>


### PR DESCRIPTION
### Description
- Added news tag to addon.xml
- Added bitrate limit setting
- Changed Python dependency to 2.24 for Kodi 16 compatibility
- Added durations to video listing
- Added start times to upcoming events
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
