### PR TITLE
[plugin.video.roosterteeth] 1.3.7

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.3.6"
+       version="1.3.7"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,7 @@
+1.3.7 (2018-02-21)
+- removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...
+The error occured when doing urllib.parse.parse_qs of the parameters
+
 1.3.6 (2018-01-31)
 - fixed showing videos in selected video quality
 

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -45,8 +45,8 @@ VQ480P = '480p'
 VQ360P = '360p'
 VQ240P = '240p'
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2018-01-31"
-VERSION = "1.3.6"
+DATE = "2018-02-21"
+VERSION = "1.3.7"
 
 
 if sys.version_info[0] > 2:

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
@@ -227,6 +227,10 @@ class Main(object):
             list_item.setArt({'thumb': thumbnail_url, 'icon': thumbnail_url,
                               'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
             list_item.setProperty('IsPlayable', 'true')
+
+            # let's remove any non-ascii characters from the title, to prevent errors with urllib.parse.parse_qs of the parameters
+            title = title.encode('ascii', 'ignore')
+
             parameters = {"action": "play", "video_page_url": video_page_url, "title": title}
             url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
             is_folder = False

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_shows.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_shows.py
@@ -158,6 +158,10 @@ class Main(object):
             list_item.setArt({'thumb': thumbnail_url, 'icon': thumbnail_url,
                               'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
             list_item.setProperty('IsPlayable', 'false')
+
+            # let's remove any non-ascii characters from the title, to prevent errors with urllib.parse.parse_qs of the parameters
+            title = title.encode('ascii', 'ignore')
+
             parameters = {"action": "list-episodes", "show_name": title, "url": url, "next_page_possible": "False",
                           "title": title}
             url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_play.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_play.py
@@ -167,7 +167,6 @@ class Main(object):
                             # check that the username is in the response. If that's the case, the login was ok
                             # and the username and password in settings are ok.
                             if str(response.text).find(SETTINGS.getSetting('username')) >= 0:
-                                # dialog_wait.create("Login Success", "Currently looking for videos in '%s'" % self.title)
 
                                 log('login was successful!', 'login was successful!')
 


### PR DESCRIPTION
### Description
1.3.7 (2018-02-21)
- removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...
The error occured when doing urllib.parse.parse_qs of the parameters

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
