### PR TITLE
[plugin.video.jupiterbroadcasting] 3.6.2

### DIFF
--- a/plugin.video.jupiterbroadcasting/addon.xml
+++ b/plugin.video.jupiterbroadcasting/addon.xml
@@ -2,11 +2,12 @@
 <addon
     id="plugin.video.jupiterbroadcasting"
     name="Jupiter Broadcasting"
-    version="3.6.0"
+    version="3.6.2"
     provider-name="Jupiter Broadcasting">
     <requires>
         <import addon="xbmc.python" version="2.25.0" />
         <import addon="script.module.beautifulsoup" version="3.2.1" />
+        <import addon="script.module.requests" version="2.18.4" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>
@@ -14,7 +15,7 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Jupiter Broadcasting video addon</summary>
         <summary lang="bg_BG">Видео добавка за Jupiter Broadcasting</summary>
-        <description lang="en_GB">Watch shows from the Jupiter Broadcasting Network including Linux Action News, TechSNAP, Ask Noah, Coder Radio,  and more.</description>
+        <description lang="en_GB">Watch shows from the Jupiter Broadcasting Network including Linux Action News, TechSNAP, Ask Noah, Coder Radio, and more.</description>
         <description lang="bg_BG">Гледайте предавания от мрежата на Jupiter Broadcasting: Linux Action News, TechSNAP, Ask Noah, Coder Radio, и други.</description>
         <disclaimer lang="en_GB">For more information, visit JupiterBroadcasting.com.</disclaimer>
         <disclaimer lang="bg_BG">За повече информация посетете www.JupiterBroadcasting.com</disclaimer>

--- a/plugin.video.jupiterbroadcasting/changelog.txt
+++ b/plugin.video.jupiterbroadcasting/changelog.txt
@@ -1,4 +1,7 @@
-[B]Version 3.6.1 Unreleased[/B]
+[B]Version 3.6.2 March 6th, 2018[/B]
+- Restore script.module.requests as a dependency
+
+[B]Version 3.6.1 February 23rd, 2018[/B]
 - Krypton API changes
 
 [B]Version 3.6.0 February 14th, 2018[/B]

--- a/plugin.video.jupiterbroadcasting/default.py
+++ b/plugin.video.jupiterbroadcasting/default.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Jupiter Broadcasting Kodi Addon
-http://github.com/robloach/plugin.video.jupiterbroadcasting
+https://github.com/JupiterBroadcasting/plugin.video.jupiterbroadcasting
 """
 
 import sys, urllib, urllib2, re, xbmcplugin, xbmcgui, xbmcaddon, os


### PR DESCRIPTION
### Description

- Restore `script.module.requests` as a dependency

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
