### PR TITLE
Add travis buddy to Krypton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ script:
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then kodi-addon-checker $(git diff --diff-filter=d --name-only HEAD~ | grep / | cut -d / -f1 | sort | uniq); fi'
 
 notifications:
+  webhooks: https://www.travisbuddy.com/
   email:
     on_failure: change # default: always

--- a/travis-buddy-failure-template.md
+++ b/travis-buddy-failure-template.md
@@ -1,0 +1,22 @@
+## Travis Buddy
+Hey **{{author}}**, 
+Please review the following log in order to understand the failure reason. There might also be some helpful tips along the way. 
+It'll be awesome if you fix what's wrong and commit the changes.
+
+{{#jobs}}
+### {{displayName}}
+{{#scripts}}
+<details>
+  <summary>
+    <strong>
+     {{command}}
+    </strong>
+  </summary>
+
+```
+{{&contents}}
+```
+</details>
+<br />
+{{/scripts}}
+{{/jobs}}

--- a/travis-buddy-success-template.md
+++ b/travis-buddy-success-template.md
@@ -1,0 +1,21 @@
+## Travis Buddy
+Hey **{{author}}**, 
+We found no mayor flaw with your code. Still you might want to look at this logfile, as we usually suggest some optional improvements.
+
+{{#jobs}}
+### {{displayName}}
+{{#scripts}}
+<details>
+  <summary>
+    <strong>
+     {{command}}
+    </strong>
+  </summary>
+
+```
+{{&contents}}
+```
+</details>
+<br />
+{{/scripts}}
+{{/jobs}}


### PR DESCRIPTION
Travis buddy will comment on every PR on either failure or success of the ci and attach the log. That way authors don't need to leave github or search in travis.

I figured we can start with one branch take some time, maybe align it and then role it out to everywhere.

So this is mostly about a nice frendly message on success/failure.

@enen92 @Rechi @Lunatixz 