### PR TITLE
[plugin.video.zdf_de_2016] 1.0.11

### DIFF
--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.10" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.11" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -25,6 +25,10 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.11 (2018-05-13)
+- fix for handling lazyload teasers newly introduced by zdf.de
+- performance improvements for long lists
+
 1.0.10 (2018-01-11)
 - fix for rest-api url structure after change by zdf.de (see https://github.com/generia/plugin.video.zdf_de_2016/issues/14)
 

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Regex.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Regex.py
@@ -3,6 +3,9 @@ import re
 def getTagPattern(tag, class_):
     return re.compile('<' + tag + '[^>]*class="([^"]*' + class_ + '[^"]*)"[^>]*>', re.DOTALL)
 
+def getAttrPattern(attr):
+    return re.compile(attr + '="([^"]*)"', re.DOTALL)
+
 def getTag(tag, string, match):
     if match is None:
         return None

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyload.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyload.py
@@ -1,0 +1,72 @@
+import urllib
+from datetime import datetime
+
+from de.generia.kodi.plugin.backend.zdf.Regex import getAttrPattern
+from de.generia.kodi.plugin.backend.zdf.Teaser import Teaser
+
+idPattern = getAttrPattern('data-teaser-id')
+typePattern = getAttrPattern('data-teaser-type')
+stylePattern = getAttrPattern('data-teaser-style')
+headlinePattern = getAttrPattern('data-teaser-headline')
+textPattern = getAttrPattern('data-teaser-text')
+sourceModuleTypePattern = getAttrPattern('data-source-module-type')
+titlePattern = getAttrPattern('data-cluster-title')
+
+
+class TeaserLazyload(object):
+
+    def __init__(self, teaserPattern):
+        self.teaserPattern = teaserPattern
+                    
+    def valid(self):
+        return True 
+     
+    def __str__(self):
+        return "<TeaserLazyload url='%s'>" % (self.url)
+        
+
+    def parse(self, string, pos=0, baseUrl=None, teaserMatch=None):
+        if teaserMatch is None:
+            return -1
+        teaser = teaserMatch.group(0)
+
+        endPos = teaserMatch.end(0)
+        id = self._parseAttr(teaser, idPattern)
+        type = self._parseAttr(teaser, typePattern)
+        style = self._parseAttr(teaser, stylePattern)
+        headline = self._parseAttr(teaser, headlinePattern)
+        text = self._parseAttr(teaser, textPattern)
+        sourceModuleType = self._parseAttr(teaser, sourceModuleTypePattern)
+        title = self._parseAttr(teaser, titlePattern)
+        
+        url = None
+        url = self._appendUrl(url, 'sophoraId', id)
+        url = self._appendUrl(url, 'type', type)
+        url = self._appendUrl(url, 'sourceModuleType', sourceModuleType)
+        url = self._appendUrl(url, 'style', style)
+        url = self._appendUrl(url, 'teaserHeadline', headline)
+        url = self._appendUrl(url, 'teasertext', text)
+        url = self._appendUrl(url, 'clusterTitle', title)
+        
+        url = baseUrl + '/teaserElement' + url
+        self.url = url
+        self.baseUrl = baseUrl
+        print "teaser-lazyload: " + url      
+        
+        return endPos
+
+    def _parseAttr(self, teaser, pattern):
+        match = pattern.search(teaser)
+        value = None
+        if match is not None:
+            value = match.group(1)
+        return value
+
+
+    def _appendUrl(self, url, attr, value):
+        encodedValue = urllib.quote(value, '')
+        if url is None:
+            return '?' + attr + '=' + encodedValue
+         
+        return url + '&' + attr + '=' + encodedValue 
+    

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyloadResolver.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyloadResolver.py
@@ -1,0 +1,54 @@
+import urllib
+
+import random
+import time
+
+from threading import Thread
+
+from de.generia.kodi.plugin.backend.zdf.Teaser import Teaser
+from de.generia.kodi.plugin.backend.zdf.TeaserLazyloadResource import TeaserLazyloadResource       
+
+
+class LazyloadTeaserThread(Thread):
+    log = None
+    lazyloadTeaser = None
+    teaser = None
+    
+    def __init__(self, lazyloadTeaser, log):
+        super(LazyloadTeaserThread, self).__init__()
+        self.log = log
+        self.lazyloadTeaser = lazyloadTeaser
+        
+    def run(self):
+        resource = TeaserLazyloadResource(self.lazyloadTeaser)
+        resource.log = self.log
+        resource.parse()
+        self.teaser = resource.teaser
+
+
+class TeaserLazyloadResolver(object):
+    log = None
+    
+    def __init__(self, log=None):
+        self.log = log
+
+    def resolveTeasers(self, lazyloadTeasers):
+        threads = []
+        i = 0
+        # using 'multiprocessing.pool' would have been nice, but this does not work inside kodi
+        for lazyloadTeaser in lazyloadTeasers:
+            thread = LazyloadTeaserThread(lazyloadTeaser, self.log)
+            threads.append(thread)
+            thread.start()
+            i = i + 1
+        
+        for thread in threads:
+            thread.join()
+
+        teasers = []            
+        for thread in threads:
+            teaser = thread.teaser
+            if teaser is not None:
+                teasers.append(teaser)
+        
+        return teasers

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyloadResource.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/TeaserLazyloadResource.py
@@ -1,0 +1,24 @@
+
+from de.generia.kodi.plugin.backend.web.HtmlResource import HtmlResource
+from de.generia.kodi.plugin.backend.zdf.Teaser import Teaser
+
+
+class TeaserLazyloadResource(HtmlResource):
+    baseUrl = None
+    
+    def __init__(self, teaserLazyload):
+        super(TeaserLazyloadResource, self).__init__(teaserLazyload.url)
+        self.teaserLazyload = teaserLazyload
+            
+    def parse(self):
+        super(TeaserLazyloadResource, self).parse()
+
+        teaser = Teaser()
+        pos = 0
+        teaserMatch = self.teaserLazyload.teaserPattern.search(self.content, pos)
+        teaser.parse(self.content, pos, self.teaserLazyload.baseUrl, teaserMatch)
+
+        self.teaser = None
+        if teaser.valid():
+            #teaser.title = "LL: " + teaser.title
+            self.teaser = teaser

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/frontend/zdf/rubrics/RubricPage.py
@@ -1,6 +1,7 @@
 import xbmcgui
 
 from de.generia.kodi.plugin.backend.zdf.RubricResource import RubricResource       
+from de.generia.kodi.plugin.backend.zdf.TeaserLazyloadResolver import TeaserLazyloadResolver       
 from de.generia.kodi.plugin.backend.zdf.api.VideoContentResource import VideoContentResource
 
 from de.generia.kodi.plugin.frontend.base.Pagelet import Item        
@@ -22,7 +23,8 @@ class RubricPage(AbstractPage):
 
         rubricResource = RubricResource(Constants.baseUrl + rubricUrl, listType, listStart, listEnd)
         self._parse(rubricResource)
-
+        self._resolveLazyloadTeasers(rubricResource)
+        
         if rubricResource.isRedirect:
             self.info("redirect detected to url='{}', skipping ...", rubricResource.responseLocation)
             dialog = xbmcgui.Dialog()
@@ -41,7 +43,12 @@ class RubricPage(AbstractPage):
             self._renderTeasers(rubricResource.teasers, response)
             self._renderClusters(clusters, response, rubricUrl)
             
-        
+    
+    def _resolveLazyloadTeasers(self, rubricResource):
+        teaserLazyloadResolver = TeaserLazyloadResolver(self.log)
+        for cluster in rubricResource.clusters:
+            cluster.teasers.extend(teaserLazyloadResolver.resolveTeasers(cluster.lazyloadTeasers))
+   
     def _renderClusters(self, clusters, response, rubricUrl):
         for cluster in clusters:
             clusterTitle = cluster.title #.encode('ascii', 'ignore')


### PR DESCRIPTION
### Description
1.0.11 (2018-05-13)
- fix for handling lazyload teasers newly introduced by zdf.de
- performance improvements for long lists
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
