### PR TITLE
[plugin.video.roosterteeth] 1.3.9

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.3.8"
+       version="1.3.9"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -25,5 +25,9 @@
     <website>http://roosterteeth.com</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.roosterteeth</source>
+    <news>1.3.9 (2018-05-15)
+    - renamed series category
+    - prefix the titles of sponsor-only videos with an asterisk
+    - using news tag in addon.xml</news>
   </extension>
 </addon>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,8 @@
+1.3.9 (2018-05-15)
+- renamed series category
+- prefix the titles of sponsor-only videos with an asterisk
+- using news tag in addon.xml
+
 1.3.8 (2018-03-30)
 - major rewrite due to revamped website
 

--- a/plugin.video.roosterteeth/resources/language/English/strings.po
+++ b/plugin.video.roosterteeth/resources/language/English/strings.po
@@ -120,7 +120,7 @@ msgid "Roosterteeth Recently Added Episodes"
 msgstr ""
 
 msgctxt "#30302"
-msgid "Roosterteeth Series"
+msgid "Series"
 msgstr ""
 
 msgctxt "#30303"

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -30,7 +30,7 @@ SUGARPINE7__RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com
 GAMEATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/game-attack/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
 THEKNOW_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/the-know/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
 JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/jt-music/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-SPONSORED_VIDEO_TITLE_TEXT = '[Sponsored Video]'
+SPONSOR_ONLY_VIDEO_TITLE_PREFIX = '* '
 VQ4K = '4k'
 VQ1080P = '1080p'
 VQ720P = '720p'
@@ -38,8 +38,8 @@ VQ480P = '480p'
 VQ360P = '360p'
 VQ240P = '240p'
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2018-03-30"
-VERSION = "1.3.8"
+DATE = "2018-05-15"
+VERSION = "1.3.9"
 
 
 if sys.version_info[0] > 2:

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
@@ -16,8 +16,8 @@ import xbmcgui
 import xbmcplugin
 import json
 
-from roosterteeth_const import IMAGES_PATH, HEADERS, LANGUAGE, convertToUnicodeString, log, SPONSORED_VIDEO_TITLE_TEXT,\
-    ROOSTERTEETH_BASE_URL
+from roosterteeth_const import IMAGES_PATH, HEADERS, LANGUAGE, convertToUnicodeString, log, \
+    SPONSOR_ONLY_VIDEO_TITLE_PREFIX, ROOSTERTEETH_BASE_URL
 
 
 #
@@ -121,7 +121,7 @@ class Main(object):
                 title = episode_title
 
             if is_sponsor_only:
-                title = title + ' ' + SPONSORED_VIDEO_TITLE_TEXT
+                title = SPONSOR_ONLY_VIDEO_TITLE_PREFIX + ' ' + title
 
             title = convertToUnicodeString(title)
 

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
@@ -44,7 +44,7 @@ class Main(object):
         xbmcplugin.addDirectoryItem(handle=self.plugin_handle, url=url, listitem=list_item, isFolder=is_folder)
 
         #
-        # Roosterteeth Series
+        # Series
         #
         parameters = {"action": "list-series", "plugin_category": LANGUAGE(30302), "url": ROOSTERTEETH_SERIES_URL,
                       "show_serie_name": "True", "next_page_possible": "False"}


### PR DESCRIPTION
### Description
1.3.9 (2018-05-15)
- renamed series category
- prefix the titles of sponsor-only videos with an asterisk
- using news tag in addon.xml

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
