### PR TITLE
[plugin.video.ign_com] 2.3.6

### DIFF
--- a/plugin.video.ign_com/addon.xml
+++ b/plugin.video.ign_com/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="plugin.video.ign_com"
 	name="IGN.com"
-	version="2.3.5"
+	version="2.3.6"
 	provider-name="Skipmode A1">
     <requires>
         <import addon="xbmc.python"                     version="2.14.0"/>
@@ -18,11 +18,16 @@
         <platform>all</platform>
         <language>en</language>
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
-        <forum>http://forum.kodi.tv/showthread.php?tid=136353</forum>
+        <forum>https://forum.kodi.tv/showthread.php?tid=327964</forum>
         <website>https://www.ign.com</website>
         <source>https://github.com/skipmodea1/plugin.video.ign_com</source>
         <email></email>
         <disclaimer>For bugs, requests or general questions visit the ign_com thread on the Kodi forum</disclaimer>
         <platform>all</platform>
+        <news>2.3.6 (2018-02-02)
+        - adding a setting for only view new video category.
+        - updated forum link to new thread.
+        - using news tag in addon.xml
+        - removed audio podcast category</news>
     </extension>
 </addon>

--- a/plugin.video.ign_com/changelog.txt
+++ b/plugin.video.ign_com/changelog.txt
@@ -1,12 +1,18 @@
-v2.3.5 (2018-01-31)
+2.3.6 (2018-05-17)
+- adding a setting to only view new video category.
+- updated forum link to new thread.
+- using news tag in addon.xml
+- removed audio podcast category
+
+2.3.5 (2018-01-31)
 - small fix (not using future's old_div anymore) that hopefully prevents crashing on android.
 
-v2.3.4 (2018-01-20)
+2.3.4 (2018-01-20)
 - using requests
 - addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
 Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
 
-v2.3.3 (2017-05-30) by Skipmode A1
+2.3.3 (2017-05-30) by Skipmode A1
 - I (Skipmode A1) haven taken over addon by request of Twister
 - Adjusted video detection to new page structure
 - Added refresh to content-menu
@@ -14,73 +20,73 @@ v2.3.3 (2017-05-30) by Skipmode A1
 - Added some debug messages
 - Added next-page picture
 
-v2.3.2 (2017-04-06)
+2.3.2 (2017-04-06)
 - Adjusted video detection to new page structure
 - Added detection for new different video implementation
 
-v2.3.1
+2.3.1
 - Adjusted video detection to new page structure
 - Code clean up
 
-v2.3.0
+2.3.0
 - Dynamically load all available podcasts
 - Removed Ign1 as experimental option since the service was shut down
 - Fixed problem with page counter
 
-v2.2.2
+2.2.2
 - Fixed problem when there was only 1 page available
 
-v2.2.1
+2.2.1
 - Showing running livestreams in the main directory is now enabled by default.
 - Added 'IGN Anime Club' and 'IGN Unfiltered' to podcasts.
 - New Experimental Feature: Show IGN1 24 hour live stream in main directory. Has to be activated via settings.
 
-v2.2.0
+2.2.0
 - Experimental Feature: If IGN is running a live stream it will show up in the main folder (Can be activated via settings)
 - Moved podcasts to separate folder
 - Some code clean up to better match python best practices
 
-v2.1.6
+2.1.6
 - Fixed Daily-Fix
 - Added page counter for video lists
 - Removed 'IGN-First', 'IGN-Live' and 'List Series' from folders since filter options and dedicated pages seem to have disappeared from the page. Looking for an alternative solution, for now these options are not supported. Let me know on the forums if you find any dedicated page.
 - To make up for this I added the following podcasts: Up At Noon, Game Scoop!, Beyond!, Unlocked, Nintendo Voice Chat, Esports Weekly, and Fireteam Chat
 
-v2.1.5
+2.1.5
 - Fixed a bug where wrong bitrate was chosen for some 360p videos
 
-v2.1.4
+2.1.4
 - Adjusted file paths for video reviews and IGN-Daily-Fix to match new layout of web page
 
-v2.1.3
+2.1.3
 - Fixed a bug where multiple videos were available to pick for the plugin and the wrong one was chosen (mainly reviews)
 
-v2.1.2
+2.1.2
 - Fixed duration display
 - Fixed video playback for some videos
 
-v2.1.1
+2.1.1
 - Original code until 2.0.5 done by AddonScriptorDE
 - New code by Twister
 - Fixed video playback
 - Added IGN First folder
 
-v2.0.4
+2.0.4
 - Fixed small bug (error on missing thumb)
 
-v2.0.5
+2.0.5
 - Added 1080p support
 - Fixed video playback for some videos
 
-v1.0.3 / v2.0.3
+1.0.3 / v2.0.3
 - Fixed video playback
 - Fixed search
 
-v1.0.2
+1.0.2
 - Fixed site changes
 
-v1.0.1
+1.0.1
 - Some small fixes
 
-v1.0.0
+1.0.0
 - First Try

--- a/plugin.video.ign_com/resources/language/English/strings.po
+++ b/plugin.video.ign_com/resources/language/English/strings.po
@@ -60,3 +60,7 @@ msgstr ""
 msgctxt "#30104"
 msgid "Live-Stream Feature"
 msgstr ""
+
+msgctxt "#30610"
+msgid "Only show New video category"
+msgstr ""

--- a/plugin.video.ign_com/resources/language/German/strings.po
+++ b/plugin.video.ign_com/resources/language/German/strings.po
@@ -55,8 +55,12 @@ msgstr "View erzwingen"
 
 msgctxt "#30103
 msgid "View"
-msgstr ""
+msgstr "View"
 
 msgctxt "#30104"
 msgid "Live-Stream Feature"
-msgstr ""
+msgstr "Live-Stream Feature"
+
+msgctxt "#30610"
+msgid "Only show New video category"
+msgstr "Nur die neue video categorie anzeigen"

--- a/plugin.video.ign_com/resources/settings.xml
+++ b/plugin.video.ign_com/resources/settings.xml
@@ -1,7 +1,8 @@
 <settings>
-   <setting id="maxVideoQualityRes" type="enum"   label="30101" values="360p|540p|720p|1080p" default="2"/>
-   <setting id="LiveStream"         type="bool"   label="30104"                               default="true"/>
-   <setting                         type="sep" />
-   <setting id="force_view_mode"    type="bool"   label="30102"                               default="false"/>
-   <setting id="viewMode"           type="number" label="30103"                               default="500"/>
+    <setting id="maxVideoQualityRes"        type="enum"   label="30101" values="360p|540p|720p|1080p" default="2"/>
+    <setting id="LiveStream"                type="bool"   label="30104"                               default="true"/>
+    <setting                                type="sep" />
+    <setting id="force_view_mode"           type="bool"   label="30102"                               default="false"/>
+    <setting id="viewMode"                  type="number" label="30103"                               default="500"/>
+    <setting id="onlyshownewvideocategory" 	type="bool"   label="30610"                               default="false"/>
 </settings>


### PR DESCRIPTION
### Description
2.3.6 (2018-05-17)
- adding a setting to only view new video category.
- updated forum link to new thread.
- using news tag in addon.xml
- removed audio podcast category
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
