### PR TITLE
[plugin.video.jupiterbroadcasting] 3.6.3

### DIFF
--- a/plugin.video.jupiterbroadcasting/README.md
+++ b/plugin.video.jupiterbroadcasting/README.md
@@ -15,6 +15,7 @@ Watch shows from the [Jupiter Broadcasting](http://jupiterbroadcasting.com) netw
 * [Linux Action News](http://linuxactionnews.com)
 * [Linux Unplugged](http://www.jupiterbroadcasting.com/show/linuxun/)
 * [TechSNAP](http://www.jupiterbroadcasting.com/show/techsnap/)
+* [Tech Talk Today](http://www.jupiterbroadcasting.com/show/today/)
 * [Unfilter](http://www.jupiterbroadcasting.com/show/unfilter/)
 * [User Error](http://www.jupiterbroadcasting.com/show/error/)
 
@@ -32,7 +33,6 @@ Watch shows from the [Jupiter Broadcasting](http://jupiterbroadcasting.com) netw
 * [Plan B](http://www.jupiterbroadcasting.com/show/planb/)
 * [SciByte](http://www.jupiterbroadcasting.com/show/scibyte/)
 * [STOked](http://www.jupiterbroadcasting.com/show/stoked/)
-* [Tech Talk Today](http://www.jupiterbroadcasting.com/show/today/)
 * [TORked](http://www.jupiterbroadcasting.com/show/torked/)
 * [Women's Tech Radio](http://www.jupiterbroadcasting.com/show/wtr/)
 

--- a/plugin.video.jupiterbroadcasting/addon.xml
+++ b/plugin.video.jupiterbroadcasting/addon.xml
@@ -2,7 +2,7 @@
 <addon
     id="plugin.video.jupiterbroadcasting"
     name="Jupiter Broadcasting"
-    version="3.6.2"
+    version="3.6.3"
     provider-name="Jupiter Broadcasting">
     <requires>
         <import addon="xbmc.python" version="2.25.0" />

--- a/plugin.video.jupiterbroadcasting/changelog.txt
+++ b/plugin.video.jupiterbroadcasting/changelog.txt
@@ -1,3 +1,9 @@
+[B]Version 3.6.3 May 12th, 2018[/B]
+- Added default encoding to file parsing rss feeds
+  - By @rickyphewitt
+- Updated Audio Feed URLs and moved Tech Talk Today to active show list
+  - By @Xmetalfanx
+
 [B]Version 3.6.2 March 6th, 2018[/B]
 - Restore script.module.requests as a dependency
 

--- a/plugin.video.jupiterbroadcasting/jb_shows.py
+++ b/plugin.video.jupiterbroadcasting/jb_shows.py
@@ -130,7 +130,7 @@ def _shows():
     shows[30016] = {
         'feed': JUPITER_COM + 'feeds/unfilterHD.xml',
         'feed-low': JUPITER_COM + 'feeds/unfilterMob.xml',
-        'feed-audio': JUPITER_COM + 'feeds/unfilterMP3.xml',
+        'feed-audio': 'http://unfilter.show/rss',
         'image': 'unfilter.jpg',
         'plot': 30216,
         'genre': 'Technology',
@@ -218,7 +218,7 @@ def _shows():
     shows[30017] = {
         'feed': FEED_BURNER + 'coderradiovideo?format=xml',
         'feed-low': FEED_BURNER + 'coderradiomp3?format=xml',
-        'feed-audio': FEED_BURNER + 'coderradiomp3?format=xml',
+        'feed-audio': 'http://coder.show/rss',
         'image': 'coder-radio.jpg',
         'plot': 30217,
         'genre': 'Technology',
@@ -240,7 +240,7 @@ def _shows():
     shows[30019] = {
         'feed': FEED_BURNER + 'linuxunvid?format=xml',
         'feed-low': FEED_BURNER + 'linuxunplugged?format=xml',
-        'feed-audio': FEED_BURNER + 'linuxunplugged?format=xml',
+        'feed-audio': 'http://linuxunplugged.com/rss',
         'image': 'linux-unplugged.jpg',
         'plot': 30219,
         'genre': 'Technology',
@@ -273,11 +273,11 @@ def _shows():
     shows[30022] = {
         'feed': FEED_PRESS + 't3mob',
         'feed-low': FEED_PRESS + 't3ogg',
-        'feed-audio': FEED_PRESS + 't3ogg',
+        'feed-audio': 'http://techtalk.today/rss',
         'image': 'tech-talk-today.png',
         'plot': 30222,
         'genre': 'Technology',
-        'archived': True
+        'archived': False
     }
 
     # Women's Tech Radio
@@ -314,7 +314,7 @@ def _shows():
     shows[30026] = {
         'feed': FEED_PRESS + 'AskNoahHD',
         'feed-low': FEED_PRESS + 'AskNoahHD',
-        'feed-audio': 'https://asknoah.fireside.fm/rss',
+        'feed-audio': 'http://podcast.asknoahshow.com/rss',
         'image': 'asknoah.png',
         'plot': 30226,
         'genre': 'Technology',
@@ -325,7 +325,7 @@ def _shows():
     shows[30027] = {
         'feed': 'http://linuxactionnews.com/rss',
         'feed-low': 'http://linuxactionnews.com/rss',
-        'feed-audio': 'https://linuxactionnews.fireside.fm/rss',
+        'feed-audio': 'http://linuxactionnews.com/rss',
         'image': 'linux-action-news.jpg',
         'plot': 30227,
         'genre': 'Technology',

--- a/plugin.video.jupiterbroadcasting/ml_stripper.py
+++ b/plugin.video.jupiterbroadcasting/ml_stripper.py
@@ -1,19 +1,32 @@
 #!/usr/bin/env python
-#solution from: http://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
+# -*- coding: UTF-8 -*-
+# encoding=utf8
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
+# solution from: http://stackoverflow.com/1/753052/strip-html-from-strings-in-python
 from HTMLParser import HTMLParser
+
 
 class MLStripper(HTMLParser):
     def __init__(self):
         self.reset()
         self.fed = []
+
     def handle_data(self, d):
         self.fed.append(d)
+
     def handle_entityref(self, name):
         self.fed.append('&%s;' % name)
+
     def get_data(self):
         return ''.join(self.fed)
 
-def html_to_text(html):
-    s = MLStripper()
-    s.feed(html)
-    return s.get_data()
+
+def html_to_text(html_str):
+    data = ""
+    if html_str is not None:
+        s = MLStripper()
+        s.feed(html_str)
+        data = s.get_data()
+    return data

--- a/plugin.video.jupiterbroadcasting/tests/test_ml_stripper.py
+++ b/plugin.video.jupiterbroadcasting/tests/test_ml_stripper.py
@@ -38,3 +38,11 @@ class TestFeedParser(unittest.TestCase):
         paragraph_string = expected_string
 
         self.assertEquals(expected_string, ml_stripper.html_to_text(paragraph_string))
+
+    def test_unicode_character(self):
+        """
+        Verify a unicode character does not cause the html_to_text method to throw an error
+        """
+
+        unicode_string =  u'\u0420\u0024'
+        ml_stripper.html_to_text(unicode_string)


### PR DESCRIPTION
### Description

This updates to [Jupiter Broadcasting Kodi addon](https://github.com/JupiterBroadcasting/plugin.video.jupiterbroadcasting) to [3.6.3](https://github.com/JupiterBroadcasting/plugin.video.jupiterbroadcasting/releases/tag/3.6.3), which includes...

- Added default encoding to file parsing rss feeds
  - By @rickyphewitt
- Updated Audio Feed URLs and moved Tech Talk Today to active show list
  - By @Xmetalfanx

<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0