### PR TITLE
[plugin.video.gamekings] 1.2.13

### DIFF
--- a/plugin.video.gamekings/addon.xml
+++ b/plugin.video.gamekings/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.gamekings" 
 	name="GameKings" 
-	version="1.2.12"
+	version="1.2.13"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -18,19 +18,23 @@
     <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-	<platform>all</platform>
-	<summary lang="en">Watch videos from Gamekings.nl (dutch)</summary>
-	<description lang="en">Watch videos from Gamekings.nl (dutch)</description>
-	<disclaimer lang="en">For bugs, requests or general questions visit the Gamekings.nl thread on the Kodi forum.</disclaimer>
-	<summary lang="nl">Bekijk videos van Gamekings.nl (dutch)</summary>
-	<description lang="nl">Bekijk videos van Gamekings.nl (dutch)</description>
-	<disclaimer lang="nl">Bugs of andere feedback op deze plugin kan geplaatst worden in de Gamekings.nl thread op het Kodi forum.</disclaimer>
+	  <platform>all</platform>
+  	<summary lang="en">Watch videos from Gamekings.tv (dutch)</summary>
+	  <description lang="en">Watch videos from Gamekings.tv (dutch)</description>
+	  <disclaimer lang="en">For bugs, requests or general questions visit the Gamekings.tv thread on the Kodi forum.</disclaimer>
+	  <summary lang="nl">Bekijk videos van Gamekings.tv (dutch)</summary>
+	  <description lang="nl">Bekijk videos van Gamekings.tv (dutch)</description>
+	  <disclaimer lang="nl">Bugs of andere feedback op deze plugin kan geplaatst worden in de Gamekings.tv thread op het Kodi forum.</disclaimer>
     <language>nl</language>
     <platform>all</platform>
     <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
     <forum>http://forum.xbmc.org/showthread.php?tid=161375</forum>
-    <website>https://www.gamekings.nl</website>
+    <website>https://www.gamekings.tv</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.gamekings</source>
+    <news>v1.2.13 (2018-05-18)
+    - prefix the titles of premium-only videos with an asterisk
+    - using news-tag in addon.xml
+    - showing a popup when it's a twitch live stream</news>
   </extension>
 </addon>

--- a/plugin.video.gamekings/changelog.txt
+++ b/plugin.video.gamekings/changelog.txt
@@ -1,3 +1,8 @@
+v1.2.13 (2018-05-18)
+- prefix the titles of premium-only videos with an asterisk
+- using news-tag in addon.xml
+- showing a popup when it's a twitch live stream
+
 v1.2.12 (2018-03-24)
 - fixed video category (website changes)
 

--- a/plugin.video.gamekings/resources/language/Dutch/strings.po
+++ b/plugin.video.gamekings/resources/language/Dutch/strings.po
@@ -16,16 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgctxt "Addon Summary"
-msgid "Watch videos from Gamekings.nl (dutch)"
-msgstr "Bekijk videos van Gamekings.nl (dutch)"
+msgid "Watch videos from Gamekings.tv (dutch)"
+msgstr "Bekijk videos van Gamekings.tv (dutch)"
 
 msgctxt "Addon Description"
-msgid "Watch videos from Gamekings.nl (dutch)"
-msgstr "Bekijk videos van Gamekings.nl (dutch)"
+msgid "Watch videos from Gamekings.tv (dutch)"
+msgstr "Bekijk videos van Gamekings.tv (dutch)"
 
 msgctxt "Addon Disclaimer"
-msgid "For bugs, requests or general questions visit the Gamekings.nl thread on the XBMC forum."
-msgstr "Bugs of andere feedback op deze plugin kan geplaatst worden in de Gamekings.nl thread op het XBMC forum."
+msgid "For bugs, requests or general questions visit the Gamekings.tv thread on the Kodi forum."
+msgstr "Bugs of andere feedback op deze plugin kan geplaatst worden in de Gamekings.tv thread op het Kodi forum."
 
 msgctxt "#30000"
 msgid "Videos"
@@ -160,5 +160,9 @@ msgid "Sorry. You must be a Premium member to see this video."
 msgstr "Sorry. Je moet Premium lid zijn om deze video te zien."
 
 msgctxt "#30610"
-msgid msgid "Only show Videos category"
+msgid "Only show Videos category"
 msgstr "Toon alleen Videos categorie"
+
+msgctxt "#30611"
+msgid "Start the Kodi twitch video addon and go to the Gamekings channel to see the live stream."
+msgstr "Start de Kodi twitch video addon en ga naar het Gamekings kanaal om de live stream te zien"

--- a/plugin.video.gamekings/resources/language/English/strings.po
+++ b/plugin.video.gamekings/resources/language/English/strings.po
@@ -16,15 +16,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgctxt "Addon Summary"
-msgid "Watch videos from Gamekings.nl (dutch)"
+msgid "Watch videos from Gamekings.tv (dutch)"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Watch videos from Gamekings.nl (dutch)"
+msgid "Watch videos from Gamekings.tv (dutch)"
 msgstr ""
 
 msgctxt "Addon Disclaimer"
-msgid "For bugs, requests or general questions visit the Gamekings.nl thread on the XBMC forum."
+msgid "For bugs, requests or general questions visit the Gamekings.tv thread on the Kodi forum."
 msgstr ""
 
 msgctxt "#30000"
@@ -161,4 +161,8 @@ msgstr ""
 
 msgctxt "#30610"
 msgid "Only show Videos category"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Start the Kodi twitch video addon and go to the Gamekings channel to see the live stream."
 msgstr ""

--- a/plugin.video.gamekings/resources/lib/gamekings_const.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_const.py
@@ -16,10 +16,10 @@ SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
 BASE_URL_GAMEKINGS_TV = "https://www.gamekings.tv/"
+PREMIUM_ONLY_VIDEO_TITLE_PREFIX = '* '
 LOGIN_URL = 'https://www.gamekings.tv/wp-login.php'
-TWITCH_URL = 'plugin://plugin.video.twitch/playLive/gamekings/'
-DATE = "2018-03-24"
-VERSION = "1.2.12"
+DATE = "2018-05-18"
+VERSION = "1.2.13"
 
 
 if sys.version_info[0] > 2:
@@ -41,6 +41,12 @@ def convertToByteString(s, encoding='utf-8'):
 
 
 def log(name_object, object):
+    try:
+        # Let's try and remove any non-ascii stuff first
+        object = object.encode('ascii', 'ignore')
+    except:
+        pass
+
     try:
         xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
             ADDON, VERSION, DATE, name_object, convertToUnicodeString(object)), xbmc.LOGDEBUG)

--- a/plugin.video.gamekings/resources/lib/gamekings_play.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_play.py
@@ -15,7 +15,7 @@ import xbmc
 import xbmcgui
 import xbmcplugin
 
-from gamekings_const import ADDON, SETTINGS, LANGUAGE, DATE, VERSION, LOGIN_URL, TWITCH_URL, convertToUnicodeString, log, getSoup
+from gamekings_const import SETTINGS, LANGUAGE, LOGIN_URL, convertToUnicodeString, log
 
 #
 # Main class
@@ -280,12 +280,8 @@ class Main(object):
         # Check if it's a twitch live stream
         #
         elif str(html_source).find("twitch") > 0:
-            video_url = TWITCH_URL
-
-            log("trying twitch channel", video_url)
-
-            list_item = xbmcgui.ListItem(path=video_url)
-            xbmcplugin.setResolvedUrl(self.plugin_handle, False, list_item)
+            #example of a live stream: video_url = 'plugin://plugin.video.twitch/?channel_id=57330659&amp;mode=play;'
+            xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30611))
         #
         # Alert user
         #


### PR DESCRIPTION
### Description
v1.2.13 (2018-05-18)
- prefix the titles of premium-only videos with an asterisk
- using news-tag in addon.xml
- showing a popup when it's a twitch live stream
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
