### PR TITLE
 [plugin.video.liveleak] 1.3.5 

### DIFF
--- a/plugin.video.liveleak/addon.xml
+++ b/plugin.video.liveleak/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.liveleak"
     name="LiveLeak"
-    version="1.3.4"
+    version="1.3.5"
     provider-name="Botster">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>
@@ -19,6 +19,6 @@
         <license>GNU General Public License Version 3</license>
         <source>https://github.com/botster/plugin.video.liveleak</source>
         <website>https://www.liveleak.com/</website>
-        <news>v1.3.1-3 (2018-2/3)- Improvements, upgrades, bug-fixes; v1.3.0 (2018-1-23) - Add ability to moderate Liveleak users' postings; v1.2.0 (2018-1-21) - Implement multiple page fetch threading for improved performance</news>
+        <news>v1.3.5 (2018-6-9) - Prevent errors caused by 'ghost' threads</news>
     </extension>
 </addon>

--- a/plugin.video.liveleak/changelog.txt
+++ b/plugin.video.liveleak/changelog.txt
@@ -1,3 +1,6 @@
+v1.3.5 (2018-6-9)
+- Prevent errors caused by 'ghost' threads
+
 v1.3.4 (2018-3-19)
 - Recommended changes; fix Search keyboard grep
 

--- a/plugin.video.liveleak/default.py
+++ b/plugin.video.liveleak/default.py
@@ -114,6 +114,11 @@ def fetchItemDetails((url, meta)):
     # Reduce page to video information block
     soup = bs(page.text, 'html.parser')
     vid_block = soup.find('div', class_='step_outer')
+
+    # Prevent errors caused by 'ghost' threads
+    if not vid_block:
+        return None
+
     for script in vid_block("script"):
         script.decompose()
     for style in vid_block("style"):


### PR DESCRIPTION
### Description
Bugfix: Prevent errors caused by 'ghost' threads
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [?] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

I don't know why Github thinks there are 3 commits since I did everything I could think of to squash them.

