### PR TITLE
[plugin.video.vrt.nu] 1.2.0

### DIFF
--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -6,6 +6,7 @@ from resources.lib.kodiwrappers import kodiwrapper
 from resources.lib.vrtplayer import actions
 from resources.lib.kodiwrappers import sortmethod
 from resources.lib.vrtplayer import urltostreamservice
+from resources.lib.vrtplayer import urltolivestreamservice
 
 _url = sys.argv[0]
 _handle = int(sys.argv[1])
@@ -17,7 +18,8 @@ def router(params_string):
     stream_service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE,
                                                            vrtplayer.VRTPlayer._VRTNU_BASE_URL,
                                                            kodi_wrapper)
-    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo("path"), kodi_wrapper, stream_service)
+    livestream_service = urltolivestreamservice.UrlToLivestreamService()
+    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo("path"), kodi_wrapper, stream_service, livestream_service)
     params = dict(parse_qsl(params_string))
     if params:
         if params['action'] == actions.LISTING_AZ:

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.1.1"
+       version="1.2.0"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,6 +23,10 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.2.0 (17-06-2018)
+- Changed live streaming mechanism
+v1.1.2 (14-06-2018)
+- New stream links for live streaming (Thanks yorickps)
 v1.1.1 (13-03-2018)
 - Fixed bug where seasons do not show when there is one malfunctioning
 v1.1.0 (15-12-2017)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
@@ -1,0 +1,21 @@
+import requests
+
+class UrlToLivestreamService:
+    
+	_TOKEN_URL = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/tokens"
+	
+	def get_stream_from_url(self, url):
+		token_response = requests.post(self._TOKEN_URL)
+		token = token_response.json()['vrtPlayerToken']
+		stream_response = requests.get(url, {'vrtPlayerToken': token, 'client':'vrtvideo' }).json()
+		target_urls = stream_response['targetUrls']
+		found_url = False
+		index = 0
+		while not found_url and index < len(target_urls):
+			item = target_urls[index]
+			found_url = item['type'] == 'hls_aes'
+			stream = item['url']
+			index +=1
+		return stream
+
+

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -14,20 +14,22 @@ from resources.lib.kodiwrappers import sortmethod
 class VRTPlayer:
 
     #Url met de urls https://services.vrt.be/videoplayer/r/live.json
-    _EEN_LIVESTREAM = "https://live-w.lwc.vrtcdn.be/groupc/live/d05012c2-6a5d-49ff-a711-79b32684615b/live.isml/.m3u8"
-    _CANVAS_LIVESTREAM_ = "https://live-w.lwc.vrtcdn.be/groupc/live/905b0602-9719-4d14-ae2a-a9b459630653/live.isml/.m3u8"
-    _KETNET_LIVESTREAM = "https://live-w.lwc.vrtcdn.be/groupc/live/8b898c7d-adf7-4d44-ab82-b5bb3a069989/live.isml/.m3u8"
-    _SPORZA_LIVESTREAM = "https://live-w.lwc.vrtcdn.be/groupa/live/bf2f7c79-1d77-4cdc-80e8-47ae024f30ba/live.isml/.m3u8"
+    _EEN_LIVESTREAM = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/videos/vualto_een_geo"
+    _CANVAS_LIVESTREAM_ = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/videos/vualto_canvas_geo"
+    _KETNET_LIVESTREAM = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/videos/vualto_ketnet_geo"
+    _SPORZA_LIVESTREAM = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/videos/vualto_sporza_geo"
 
     _VRT_BASE = "https://www.vrt.be/"
     _VRTNU_BASE_URL = urljoin(_VRT_BASE, "/vrtnu/")
     _VRTNU_SEARCH_URL = "https://search.vrt.be/suggest?facets[categories]="
 
-    def __init__(self, addon_path, kodi_wrapper, url_to_stream_service):
+    def __init__(self, addon_path, kodi_wrapper, url_to_stream_service, url_to_livestream_service):
         self.metadata_collector = metadatacollector.MetadataCollector()
         self._addon_path = addon_path
         self._kodi_wrapper = kodi_wrapper
         self._url_toStream_service = url_to_stream_service
+        self.url_to_livestream_service = url_to_livestream_service
+
 
     def show_main_menu_items(self):
         menu_items = {helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32091), {'action': actions.LISTING_AZ}, False,
@@ -77,7 +79,8 @@ class VRTPlayer:
         self._kodi_wrapper.play_video(stream)
 
     def play_livestream(self, url):
-        self._kodi_wrapper.play_livestream(url)
+        stream = self.url_to_livestream_service.get_stream_from_url(url)
+        self._kodi_wrapper.play_livestream(stream)
 
     def show_livestream_items(self):
         livestream_items = {helperobjects.TitleItem(self._kodi_wrapper.get_localized_string(32101),
@@ -200,5 +203,3 @@ class VRTPlayer:
         if found_element is not None:
             title = statichelper.replace_newlines_and_strip(found_element.contents[0])
         return thumbnail, title
-
-


### PR DESCRIPTION
### Description
Changed the mechanism for live streaming. Instead of passing a URL i need to get a token before getting a playable URL
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
