### PR TITLE
[plugin.video.popcorntv] 1.0.16

### DIFF
--- a/plugin.video.popcorntv/addon.xml
+++ b/plugin.video.popcorntv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.popcorntv"
        name="PopcornTv"
-       version="1.0.15"
+       version="1.0.16"
        provider-name="Nightflyer">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
@@ -23,5 +23,6 @@
     <website>https://github.com/nightflyer73/plugin.video.popcorntv</website>
     <email></email>
     <source>https://github.com/nightflyer73/plugin.video.popcorntv</source>
+    <broken>PopcornTv now requires youtube addon. Updates will be available only for krypton and higher.</broken>
   </extension>
 </addon>

--- a/plugin.video.popcorntv/changelog.txt
+++ b/plugin.video.popcorntv/changelog.txt
@@ -1,3 +1,7 @@
+[B]1.0.16[/B]
+- This addon now requires youtube addon.
+- Updates will only be available for krypton and higher
+
 [B]1.0.15[/B]
 - Updated page parsing because of upstream HTML changes.
 - Added li.setInfo video for Kodi 18.


### PR DESCRIPTION
### Description
This addon now requires youtube addon.
Updates will only be available for krypton and higher

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
