### PR TITLE
[plugin.video.vrt.nu] 1.3.0

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.2.0"
+       version="1.3.0"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,6 +23,8 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.3.0 (14-07-2018)
+- Adapted code to new vrtnu website layout, this fixes a bug where only the first episode would be shown while multiple episodes are present.
 v1.2.0 (17-06-2018)
 - Changed live streaming mechanism
 v1.1.2 (14-06-2018)
@@ -53,6 +55,7 @@ v0.0.1  (01-05-2017)
 - Initial working release
 </news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
+		<website>https://www.facebook.com/kodivrtnu/</website>
 		<assets>
 			<icon>resources/icon.png</icon>
 			<fanart>resources/fanart.jpg</fanart>

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
@@ -72,6 +72,7 @@ class MetadataCollector:
         seconds = None
         minutes_element = soup.find("abbr", {"title": "minuten"})
         if minutes_element is not None and minutes_element.parent is not None:
-            minutes = minutes_element.parent.next_element
-            seconds = statichelper.minutes_string_to_seconds_int(minutes)
+            minutes_with_mintext = minutes_element.parent.text.split("|")[-1];
+            stripped_minutes = re.findall("\d+", minutes_with_mintext)[0]
+            seconds = statichelper.minutes_string_to_seconds_int(stripped_minutes)
         return seconds


### PR DESCRIPTION
### Description
Reworked the mechanism of getting the streams because the source site changed.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
