### PR TITLE
[plugin.video.vrt.nu] V1.3.1

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.3.0"
+       version="1.3.1"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,8 +23,10 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.3.1 (20-07-2018)
+- Changed way of selecting item title for single video's
 v1.3.0 (14-07-2018)
-- Adapted code to new vrtnu website layout, this fixes a bug where only the first episode would be shown while multiple episodes are present.
+- Adapted code to new vrtnu website layout, this fixes a bug where only the first episode would be shown while multiple episodes are present
 v1.2.0 (17-06-2018)
 - Changed live streaming mechanism
 v1.1.2 (14-06-2018)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -165,7 +165,8 @@ class VRTPlayer:
     def __get_single_video(self, path, soup):
         title_items = []
         video_dictionary = self.metadata_collector.get_single_layout_episode_metadata(soup)
-        list_item_title = soup.find(class_="content__title").text
+        content = soup.find(class_="content2");
+        list_item_title = content.find("h1").text
 
         if "shortdate" in video_dictionary:
             list_item_title = video_dictionary["shortdate"] + " " + list_item_title


### PR DESCRIPTION
### Description
The content providor changed a CSS class so i had to change as well.
Thx for merging!
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
