### PR TITLE
[plugin.image.500px] broken (closes #1931)

### DIFF
--- a/plugin.image.500px/addon.xml
+++ b/plugin.image.500px/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.image.500px" name="500px" version="0.3.2"
+<addon id="plugin.image.500px" name="500px" version="0.3.3"
        provider-name="Patrick L Archibald [patrick.archibald@gmail.com]">
   <requires>
     <import addon="script.module.simplejson" version="2.0.10"/>
@@ -11,6 +11,7 @@
   <extension point="xbmc.python.module" library="resources/lib"/>
   <extension point="xbmc.addon.metadata">
     <platform>all</platform>
+    <broken>500px shutdown their API.</broken>
     <summary lang="en">View photos from http://500px.com.</summary>
     <description lang="en">
       View photos from http://500px.com.


### PR DESCRIPTION
500px shutdown their api, requested by the plugin author