### PR TITLE
[plugin.video.spurs-tv] v2.15.1

### DIFF
--- a/plugin.video.spurs-tv/addon.py
+++ b/plugin.video.spurs-tv/addon.py
@@ -182,7 +182,11 @@ def video_item(entry_id, title, date_str=None, date_format="%d %B %Y", duration_
 def show_index():
     image_path = os.path.join(plugin.addon.getAddonInfo('path'), 'resources', 'images')
 
-    yield {'label': plugin.get_string(30010), 'path': plugin.url_for('show_videos')}
+    yield {
+        'label': plugin.get_string(30010),
+        'path': plugin.url_for('show_videos'),
+        'thumbnail': plugin.addon.getAddonInfo('icon')
+    }
 
     yield {
         'label': plugin.get_string(30017),

--- a/plugin.video.spurs-tv/addon.xml
+++ b/plugin.video.spurs-tv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.spurs-tv" name="Spurs TV" version="2.15.0" provider-name="Leopold">
+<addon id="plugin.video.spurs-tv" name="Spurs TV" version="2.15.1" provider-name="Leopold">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.kodiswift" version="0.0.8" optional="false"/>

--- a/plugin.video.spurs-tv/changelog.txt
+++ b/plugin.video.spurs-tv/changelog.txt
@@ -1,3 +1,6 @@
+v2.15.1 (2018-08-18)
+ - Fixed latest videos listing
+
 v2.15.0 (2018-08-16)
  - The new website broke all the things
 

--- a/plugin.video.spurs-tv/resources/lib/api.py
+++ b/plugin.video.spurs-tv/resources/lib/api.py
@@ -16,7 +16,7 @@ Video = namedtuple('Video', 'entry_id caption thumbnail')
 
 
 def videos():
-    data = re.search(VIDEO_DATA_RE, requests.get(URL).text).group(1)
+    data = re.search(VIDEO_DATA_RE, requests.get(URL).text, re.DOTALL).group(1)
     videos = json.loads(data)['data']['modules']
     for video in videos:
         video_data = video['data']


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
Fixes broken video listing caused by a small website change.
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
