### PR TITLE
[plugin.video.vrt.nu] V1.3.4

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.3.3"
+       version="1.3.4"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,6 +23,8 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.3.4 (10-09-2018)
+- Fixed A-Z menu so it shows items
 v1.3.3 (02-09-2018)
 - Fixed bug where some items would not want to play
 - Fixed bug where some videos would only show one episodes while multiple episodes are present

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
@@ -35,7 +35,7 @@ class MetadataCollector:
     def get_az_metadata(tile):
         metadata_creator = metadatacreator.MetadataCreator()
         description = ""
-        description_item = tile.find(class_="tile__description")
+        description_item = tile.find(class_="nui-tile--content")
         if description_item is not None:
             p_item = description_item.find("p")
             if p_item is not None:


### PR DESCRIPTION
### Description
Changed way of selecting items due to a change in the vrt.nu site. Because of this change the A-Z menu was not working anymore which has been fixed in this update.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
