### PR TITLE
[plugin.video.tweakers] 1.1.10

### DIFF
--- a/plugin.video.tweakers/addon.xml
+++ b/plugin.video.tweakers/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.tweakers" 
 	name="Tweakers" 
-	version="1.1.9"
+	version="1.1.10"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -15,19 +15,23 @@
     <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-  	<platform>all</platform>
-	<summary lang="en">Watch tech videos from Tweakers.net (dutch)</summary>
-	<description lang="en">Watch tech videos from Tweakers.net (dutch)</description>
-	<disclaimer lang="en">For bugs, requests or general questions visit the tweakers.net thread on the Kodi forum.</disclaimer>
-	<summary lang="nl">Bekijk technologie videos van Tweakers.net (dutch)</summary>
-	<description lang="nl">Bekijk technologie videos van Tweakers.net (dutch)</description>
-	<disclaimer lang="nl">Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het Kodi forum.</disclaimer>
+	<summary lang="en_GB">Watch tech videos from Tweakers.net (dutch)</summary>
+	    <description lang="en_GB">Watch tech videos from Tweakers.net (dutch)</description>
+	    <disclaimer lang="en_GB">For bugs, requests or general questions visit the tweakers.net thread on the Kodi forum.</disclaimer>
+	<summary lang="nl_NL">Bekijk technologie videos van Tweakers.net (dutch)</summary>
+	    <description lang="nl_NL">Bekijk technologie videos van Tweakers.net (dutch)</description>
+	    <disclaimer lang="nl_NL">Bugs of andere feedback op deze plugin kan geplaatst worden in de Tweakers.net thread op het Kodi forum.</disclaimer>
     <language>nl</language>
-    <platform>all</platform>
     <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
-    <forum>http://forum.xbmc.org/showthread.php?tid=167812</forum>
-    <website>http://www.tweakers.net</website>
-    <email></email>
+    <forum>https://forum.kodi.tv/showthread.php?tid=167812</forum>
+    <website>https://www.tweakers.net</website>
     <source>https://github.com/skipmodea1/plugin.video.tweakers</source>
+    <email></email>
+  	<platform>all</platform>
+    <news>v1.1.10 (2018-10-01)
+    - removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...
+    The error occured when doing urllib.parse.parse_qs of the parameters
+    - using youtube now (website change)
+    </news>
   </extension>
 </addon>

--- a/plugin.video.tweakers/changelog.txt
+++ b/plugin.video.tweakers/changelog.txt
@@ -1,7 +1,13 @@
+v1.1.10 (2018-10-01)
+- removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...
+The error occured when doing urllib.parse.parse_qs of the parameters
+- using youtube now (website change)
+
 v1.1.9 (2018-01-12)
 - removed looking for video dialogue
 - fix to match the correct thumbnail with the item
-- addon now works in kode python 2 and also 3 (!!) thanks to the future project
+- addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
+Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
 
 v1.1.8 (2017-03-12):
 - fixed url in addon.xml as per request

--- a/plugin.video.tweakers/resources/lib/tweakers_const.py
+++ b/plugin.video.tweakers/resources/lib/tweakers_const.py
@@ -18,8 +18,9 @@ ADDON = "plugin.video.tweakers"
 SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
-DATE = "2018-01-12"
-VERSION = "1.1.9"
+YOUTUBE_ID_STRING_TO_FIND = '"youtubeId":"'
+DATE = "2018-09-30"
+VERSION = "1.1.10"
 
 if sys.version_info[0] > 2:
     unicode = str
@@ -40,6 +41,12 @@ def convertToByteString(s, encoding='utf-8'):
 
 
 def log(name_object, object):
+    try:
+        # Let's try and remove any non-ascii stuff first
+        object = object.encode('ascii', 'ignore')
+    except:
+        pass
+
     try:
         xbmc.log("[ADDON] %s v%s (%s) debug mode, %s = %s" % (
             ADDON, VERSION, DATE, name_object, convertToUnicodeString(object)), xbmc.LOGDEBUG)

--- a/plugin.video.tweakers/resources/lib/tweakers_list.py
+++ b/plugin.video.tweakers/resources/lib/tweakers_list.py
@@ -13,7 +13,6 @@ import re
 import requests
 import sys
 import urllib.request, urllib.parse, urllib.error
-import urllib.parse
 import xbmc
 import xbmcgui
 import xbmcplugin
@@ -181,6 +180,10 @@ class Main(object):
             list_item.setArt({'thumb': thumbnail_url, 'icon': thumbnail_url,
                               'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
             list_item.setProperty('IsPlayable', 'true')
+
+            # let's remove any non-ascii characters
+            title = title.encode('ascii', 'ignore')
+
             parameters = {"action": "play", "video_page_url": video_page_url, "title": title}
             url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
             is_folder = False

--- a/plugin.video.tweakers/resources/lib/tweakers_search.py
+++ b/plugin.video.tweakers/resources/lib/tweakers_search.py
@@ -13,7 +13,6 @@ import re
 import sys
 import requests
 import urllib.request, urllib.parse, urllib.error
-import urllib.parse
 import xbmc
 import xbmcgui
 import xbmcplugin
@@ -169,6 +168,10 @@ class Main(object):
             list_item.setArt({'thumb': thumbnail_url, 'icon': thumbnail_url,
                               'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
             list_item.setProperty('IsPlayable', 'true')
+
+            # let's remove any non-ascii characters
+            title = title.encode('ascii', 'ignore')
+
             parameters = {"action": "play", "video_page_url": video_page_url, "title": title}
             url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
             is_folder = False


### PR DESCRIPTION
### Description
v1.1.10 (2018-10-01)
- removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...
The error occured when doing urllib.parse.parse_qs of the parameters
- using youtube now (website change)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0