### PR TITLE
[plugin.video.vrt.nu] V1.4.2

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.4.1"
+       version="1.4.2"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,6 +23,8 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+          v1.4.2 (11-10-2018)
+          - Changed way of working with urls when a season is refering to href="#"
           v1.4.1 (24-09-2018)
           - Adapted plugin to new vrtnu layout for showing multiple seasons
           v1.4.0 (20-09-2018)
@@ -46,28 +48,6 @@
           - New stream links for live streaming (Thanks yorickps)
           v1.1.1 (13-03-2018)
           - Fixed bug where seasons do not show when there is one malfunctioning
-          v1.1.0 (15-12-2017)
-          - Refactored internal code
-          v1.0.0 (01-10-2017)
-          - Fixed issue where all the videos would not be able to play, implemented new way of getting the streaming urls
-          - Fixed bug where a single video would not be listed when there is also a part "ANDEREN BEKEKEN OOK" present
-          - New versioning system now starting from 1.0.0
-          v0.0.7 (09-09-2017)
-          - Fixed bug where dates were not always shown
-          v0.0.6 (06-08-2017)
-          - Fixed ordering bug for videos
-          v0.0.5 (24-07-2017)
-          - Fixed broken Sporza logo
-          v0.0.4 (20-07-2017)
-          - Added Sporza livestream
-          - Added dates to videos (Thanks stevenv)
-          - Fixed bug where seasons did not get listed
-          v0.0.3 (22-05-2017)
-          - Fixed broken livestreams
-          v0.0.2 (07-05-2017)
-          - Fixed installation issue
-          v0.0.1  (01-05-2017)
-          - Initial working release
         </news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
     <website>https://www.facebook.com/kodivrtnu/</website>

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtplayer.py
@@ -99,7 +99,7 @@ class VRTPlayer:
                 }
         self._kodi_wrapper.show_listing(livestream_items, sortmethod.ALPHABET)
 
-    def     show_videos(self, path):
+    def show_videos(self, path):
         url = urljoin(self._VRT_BASE, path)
         #xbmc.log(url, xbmc.LOGWARNING)
         # go to url.relevant gets redirected and go on with this url
@@ -109,9 +109,12 @@ class VRTPlayer:
         title_items = []
         episodes_list = soup.find(class_='episodeslist')
         li_tags = []
-
-        if episodes_list is not None :
-            li_tags.extend(episodes_list.find_all('li', class_='vrt-labelnav--item'))
+        if episodes_list is not None:
+            lis_to_add = episodes_list.find_all('li', class_='vrt-labelnav--item')
+            if lis_to_add: 
+                has_non_self_refering_a_tags = lis_to_add[0].find('a', {'href': '#'})
+                if has_non_self_refering_a_tags is None:
+                    li_tags.extend(lis_to_add)
 
         episode_items = self.__get_episodes(li_tags, path)
         if len(li_tags) != 0 and episode_items:


### PR DESCRIPTION
### Description
Changed way of getting streaming urls so the addon is working again. Removed some news from addon.xml as travis check told me. (sorry for all pull requests was messing things up)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
