### PR TITLE
[plugin.video.hardstyletv] 1.1.1

### DIFF
--- a/plugin.video.hardstyletv/addon.xml
+++ b/plugin.video.hardstyletv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.hardstyletv"
 	name="HardstyleTV"
-	version="1.0.0"
+	version="1.1.1"
 	provider-name="alpadev">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
@@ -12,15 +12,14 @@
     <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
-    <summary lang="en_gb">Hardstyle livesets Youtube video Add-on</summary>
-    <description lang="en_gb">HardstyleTV is an addon that streams Hardstyle livesets from the best festivals in the world. Qlimax, Defqon.1, Decibel, Hard Bass...we got all you need!</description>
-	<disclaimer lang="en_gb">Some videos might be blocked in your country</disclaimer>
+    <summary lang="en_GB">Hardstyle livesets Youtube video Add-on</summary>
+    <description lang="en_GB">HardstyleTV is an addon that streams Hardstyle livesets from the best festivals in the world. Qlimax, Defqon.1, Decibel, Hard Bass...we got all you need!</description>
+	<disclaimer lang="en_GB">Some videos might be blocked in your country</disclaimer>
     <platform>all</platform>
     <source>https://github.com/aureliencousin/plugin.video.hardstyletv</source>
     <website>http://aurelien-cousin.com</website>
 	<language>en nl</language>
     <license>GPL v2.0</license>
-	<forum></forum>
     <assets>
         <icon>icon.png</icon>
         <fanart>fanart.jpg</fanart>

--- a/plugin.video.hardstyletv/changelog.txt
+++ b/plugin.video.hardstyletv/changelog.txt
@@ -1,1 +1,4 @@
-- v1.0.0 initial release
+- 1.0.0 initial release
+- 1.0.1 comply to kodi krypton standards
+- 1.1.0 updated content with 2017/2018 video livesets
+- 1.1.1 removed unused 'forum' tag in addon metadata

--- a/plugin.video.hardstyletv/default.py
+++ b/plugin.video.hardstyletv/default.py
@@ -15,8 +15,6 @@ addon = Addon(addonID, sys.argv)
 local = xbmcaddon.Addon()
 icon = local.getAddonInfo('icon')
 
-YOUTUBE_PLAYLIST_ID = "PLUKXSlbHWi2huhANVImh3RxMQ19ASXw6p"
-
 # Entry point
 def run():
     plugintools.log("hardstyletv.run")
@@ -35,77 +33,31 @@ def run():
 def main_list(params):
     plugintools.log("hardstyletv.main_list "+repr(params))
 
-    plugintools.add_item( 
-        title="Qlimax 2016",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2g6Hp2Sq4Gz5Wte6MRpOX5U/",
-        thumbnail=icon,
-        folder=True )
+    playlists = []
+    playlists.append(("Q-Base 2018","PLUKXSlbHWi2joC0am3Uhj_J2RGVI34K3t"))
+    playlists.append(("Defqon.1 2018","PLUKXSlbHWi2jPniJM-0D3rWavFppOnHPy"))
+    playlists.append(("Hard Bass 2018","PLUKXSlbHWi2jnzPKht6hbcbcXlPMOeOko"))
+    playlists.append(("Qlimax 2017","PLUKXSlbHWi2gbP8-kRpPwzVnMJ8osz3fZ"))
+    playlists.append(("Q-Base 2017","PLUKXSlbHWi2ifrVf6J7icaBrgjYxrl1dY"))
+    playlists.append(("Defqon.1 2017","PLUKXSlbHWi2i-2j0Zv1EppYrDPdDbqoJp"))
+    playlists.append(("Hard Bass 2017","PLUKXSlbHWi2jthONLKZm6YalKIUxMViEm"))
+    playlists.append(("Qlimax 2016","PLUKXSlbHWi2g6Hp2Sq4Gz5Wte6MRpOX5U"))
+    playlists.append(("Q-Base 2016","PLUKXSlbHWi2iWv8pO6ft101PaGS6Qjrv_"))
+    playlists.append(("Defqon.1 2016","PLUKXSlbHWi2i9gLEWlV76dsS_I9pk4RbD"))
+    playlists.append(("Hard Bass 2016","PLUKXSlbHWi2jv7VvXsh1XMNu_0E7LcrWJ"))
+    playlists.append(("Defqon.1 2015","PLUKXSlbHWi2g9sdCH_6scus_EBOZGhq7C"))
+    playlists.append(("Hard Bass 2015","PLUKXSlbHWi2hsUFxs1o2DukBJiqMDAcX2"))
+    playlists.append(("Qapital Sets","PLUKXSlbHWi2jW3pkaYl34gDaUrJ34ncRI"))
+    playlists.append(("Qlimax OLD","PLUKXSlbHWi2jLjh0TYWIde8LjdImdM38f"))
+    playlists.append(("Defqon.1 OLD","PLUKXSlbHWi2hjXmAbhSXlzb33Kbe8MWBo"))
+    playlists.append(("Hard Bass OLD","PLUKXSlbHWi2gpenEDab_9n-RKbRMUViB2"))
 
-    plugintools.add_item( 
-        title="Q-Base 2016",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2iWv8pO6ft101PaGS6Qjrv_/",
-        thumbnail=icon,
-        folder=True )
 
-    plugintools.add_item( 
-        title="Defqon.1 2016",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2i9gLEWlV76dsS_I9pk4RbD/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="QAPITAL 2016",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2jW3pkaYl34gDaUrJ34ncRI/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Hard Bass 2016",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2jv7VvXsh1XMNu_0E7LcrWJ/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Qlimax 2015",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2guDBcyAxQgWuU-uDx8ZL5s/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Defqon.1 2015",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2g9sdCH_6scus_EBOZGhq7C/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="QAPITAL 2015",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2gCKp8OLVZzmGxZI5FAZmSU/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Hard Bass 2015",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2hsUFxs1o2DukBJiqMDAcX2/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Qlimax OLD",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2jLjh0TYWIde8LjdImdM38f/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Defqon.1 OLD",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2hjXmAbhSXlzb33Kbe8MWBo/",
-        thumbnail=icon,
-        folder=True )
-
-    plugintools.add_item( 
-        title="Hard Bass OLD",
-        url="plugin://plugin.video.youtube/playlist/PLUKXSlbHWi2gpenEDab_9n-RKbRMUViB2/",
-        thumbnail=icon,
-        folder=True )
-
+    for playlist in playlists:
+        plugintools.add_item( 
+            title=playlist[0],
+            url="plugin://plugin.video.youtube/playlist/"+playlist[1]+"/",
+            thumbnail=icon,
+            folder=True )
 
 run()


### PR DESCRIPTION
### Description
HardstyleTV is an addon that streams Hardstyle livesets from the best festivals in the world. Qlimax, Defqon.1, Decibel, Hard Bass, etc

It's based on the youtube video plugin from [zag2me](https://github.com/zag2me)

1.1.1 - Fixed some errors in addon.xml
1.1.0 - Update featuring new video content for 2017 and 2018 hardstyle events

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

