### PR TITLE
[plugin.video.vrt.nu] V1.4.3

### DIFF
--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -18,7 +18,7 @@ def router(params_string):
     stream_service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE,
                                                            vrtplayer.VRTPlayer._VRTNU_BASE_URL,
                                                            kodi_wrapper)
-    livestream_service = urltolivestreamservice.UrlToLivestreamService()
+    livestream_service = urltolivestreamservice.UrlToLivestreamService(kodi_wrapper)
     vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service, livestream_service)
     params = dict(parse_qsl(params_string))
     if params:

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.4.2"
+       version="1.4.3"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -23,6 +23,8 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+          v1.4.3 (07-11-2018)
+          - Livestreams working again
           v1.4.2 (11-10-2018)
           - Changed way of working with urls when a season is refering to href="#"
           v1.4.1 (24-09-2018)
@@ -46,8 +48,6 @@
           - Changed live streaming mechanism
           v1.1.2 (14-06-2018)
           - New stream links for live streaming (Thanks yorickps)
-          v1.1.1 (13-03-2018)
-          - Fixed bug where seasons do not show when there is one malfunctioning
         </news>
         <source>https://github.com/pietje666/plugin.video.vrt.nu</source>
     <website>https://www.facebook.com/kodivrtnu/</website>

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/streamservice.py
@@ -1,0 +1,62 @@
+from abc import ABCMeta, abstractmethod
+import requests
+from resources.lib.helperobjects import helperobjects
+
+class StreamService:
+    __metaclass__ = ABCMeta
+
+    _BASE_MEDIA_SERVICE_URL = 'https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1'
+    _TOKEN_URL = _BASE_MEDIA_SERVICE_URL + '/tokens'
+    _API_KEY ='3_qhEcPa5JGFROVwu5SWKqJ4mVOIkwlFNMSKwzPDAh8QZOtHqu6L4nD5Q7lk0eXOOG'
+
+    @abstractmethod
+    def __init__(self, kodi_wrapper):
+        self._kodi_wrapper = kodi_wrapper
+
+    def _get_session_and_token_from_(self):
+        session = requests.session()
+        token = None
+        cred = helperobjects.Credentials(self._kodi_wrapper)
+        if not cred.are_filled_in():
+            self._kodi_wrapper.open_settings()
+            cred.reload()
+        
+        r = session.post('https://accounts.vrt.be/accounts.login',
+                               {'loginID': cred.username, 'password': cred.password, 'APIKey': self._API_KEY,
+                                'sessionExpiration': '-1',
+                                'targetEnv': 'jssdk',
+                                'include': 'profile,data,emails,subscriptions,preferences,',
+                                'includeUserInfo': 'true',
+                                'loginMode': 'standard',
+                                'lang': 'nl-inf',
+                                'source': 'showScreenSet',
+                                'sdk': 'js_latest',
+                                'authMode': 'cookie',
+                                'format': 'json'})
+
+        session.get('https://token.vrt.be/vrtnuinitlogin?provider=site&destination=https://www.vrt.be/vrtnu/')
+
+        logon_json = r.json()
+
+        if logon_json['errorCode'] == 0:
+            uid = logon_json['UID']
+            sig = logon_json['UIDSignature']
+            ts = logon_json['signatureTimestamp']
+
+            data = {'UID': uid, 
+                   'UIDSignature': sig,
+                   'signatureTimestamp': ts ,
+                   'client_id': 'vrtnu-site', 
+                   'submit': 'submit'
+                   } 
+
+            response = session.post('https://login.vrt.be/perform_login', data=data)
+
+            vrt_player_token_url = session.post(self._TOKEN_URL, headers={'Content-Type': 'application/json'})
+
+            token = vrt_player_token_url.json()['vrtPlayerToken']
+            return (session, token)
+        else:
+            title = self._kodi_wrapper.get_localized_string(32051)
+            message = self._kodi_wrapper.get_localized_string(32052)
+            self._kodi_wrapper.show_ok_dialog(title, message)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltolivestreamservice.py
@@ -1,21 +1,24 @@
 import requests
+from resources.lib.helperobjects import helperobjects
+from resources.lib.vrtplayer import streamservice
 
-class UrlToLivestreamService:
-    
-	_TOKEN_URL = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/tokens"
-	
-	def get_stream_from_url(self, url):
-		token_response = requests.post(self._TOKEN_URL)
-		token = token_response.json()['vrtPlayerToken']
-		stream_response = requests.get(url, {'vrtPlayerToken': token, 'client':'vrtvideo' }).json()
-		target_urls = stream_response['targetUrls']
-		found_url = False
-		index = 0
-		while not found_url and index < len(target_urls):
-			item = target_urls[index]
-			found_url = item['type'] == 'hls_aes'
-			stream = item['url']
-			index +=1
-		return stream
+class UrlToLivestreamService(streamservice.StreamService):
 
+    def __init__(self, kodi_wrapper):
+        super(UrlToLivestreamService, self).__init__(kodi_wrapper)
 
+    _TOKEN_URL = "https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1/tokens"
+
+    def get_stream_from_url(self, url):
+        (session, token) = super(UrlToLivestreamService, self)._get_session_and_token_from_()
+
+        stream_response = requests.get(url, {'vrtPlayerToken': token, 'client':'vrtvideo' }).json()
+        target_urls = stream_response['targetUrls']
+        found_url = False
+        index = 0
+        while not found_url and index < len(target_urls):
+          item = target_urls[index]
+          found_url = item['type'] == 'hls_aes'
+          stream = item['url']
+          index +=1
+        return stream

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
@@ -6,62 +6,21 @@ import os
 from bs4 import BeautifulSoup
 from bs4 import SoupStrainer
 from resources.lib.helperobjects import helperobjects
+from resources.lib.vrtplayer import streamservice
 
 
-class UrlToStreamService:
-
-    _API_KEY ='3_qhEcPa5JGFROVwu5SWKqJ4mVOIkwlFNMSKwzPDAh8QZOtHqu6L4nD5Q7lk0eXOOG'
-    _BASE_MEDIA_SERVICE_URL = 'https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1'
-    _TOKEN_URL = _BASE_MEDIA_SERVICE_URL + '/tokens'
-    _STREAM_URL_PATH = _BASE_MEDIA_SERVICE_URL + '/videos/{}%24{}?vrtPlayerToken={}'
+class UrlToStreamService(streamservice.StreamService):
 
     def __init__(self, vrt_base, vrtnu_base_url, kodi_wrapper):
+        super(UrlToStreamService, self).__init__(kodi_wrapper)
         self._vrt_base = vrt_base
         self._vrtnu_base_url = vrtnu_base_url
-        self._kodi_wrapper = kodi_wrapper
+        self._STREAM_URL_PATH = super(UrlToStreamService, self)._BASE_MEDIA_SERVICE_URL + '/videos/{}%24{}?vrtPlayerToken={}'
 
     def get_stream_from_url(self, url):
-        session = requests.session()
-        cred = helperobjects.Credentials(self._kodi_wrapper)
-        if not cred.are_filled_in():
-            self._kodi_wrapper.open_settings()
-            cred.reload()
-        url = urlparse.urljoin(self._vrt_base, url)
-        r = session.post('https://accounts.vrt.be/accounts.login',
-                               {'loginID': cred.username, 'password': cred.password, 'APIKey': self._API_KEY,
-                                'sessionExpiration': '-1',
-                                'targetEnv': 'jssdk',
-                                'include': 'profile,data,emails,subscriptions,preferences,',
-                                'includeUserInfo': 'true',
-                                'loginMode': 'standard',
-                                'lang': 'nl-inf',
-                                'source': 'showScreenSet',
-                                'sdk': 'js_latest',
-                                'authMode': 'cookie',
-                                'format': 'json'})
-
-        session.get('https://token.vrt.be/vrtnuinitlogin?provider=site&destination=https://www.vrt.be/vrtnu/')
-
-        logon_json = r.json()
-
-        if logon_json['errorCode'] == 0:
-            uid = logon_json['UID']
-            sig = logon_json['UIDSignature']
-            ts = logon_json['signatureTimestamp']
-
-            data = {'UID': uid, 
-                   'UIDSignature': sig,
-                   'signatureTimestamp': ts ,
-                   'client_id': 'vrtnu-site', 
-                   'submit': 'submit'
-                   } 
-
-            response = session.post('https://login.vrt.be/perform_login', data=data)
-
-            vrt_player_token_url = session.post(self._TOKEN_URL, headers={'Content-Type': 'application/json'})
-
-            token = vrt_player_token_url.json()['vrtPlayerToken']
-
+        (session, token) = super(UrlToStreamService, self)._get_session_and_token_from_()
+        if token is not None:
+            url = urlparse.urljoin(self._vrt_base, url)
             url_response = session.get(url);
             strainer = SoupStrainer('div', {'class': 'vrtvideo videoplayer'})
             soup = BeautifulSoup(url_response.content, 'html.parser', parse_only=strainer)
@@ -77,10 +36,6 @@ class UrlToStreamService:
             #if self._kodi_wrapper.get_setting('showsubtitles') == 'true':
             #    subtitle = self.__get_subtitle(stream_response.json()['subtitleUrls'])
             return helperobjects.StreamURLS(hls, subtitle)
-        else:
-            title = self._kodi_wrapper.get_localized_string(32051)
-            message = self._kodi_wrapper.get_localized_string(32052)
-            self._kodi_wrapper.show_ok_dialog(title, message)
 
     @staticmethod
     def __get_hls(dictionary):


### PR DESCRIPTION
### Description
Changed way of getting a token to show some livestreams in my addon. The livestream provider expects to be logged in now for getting the livestreams.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
