### PR TITLE
[plugin.video.rtsplaytv] v1.1.0

### DIFF
--- a/plugin.video.rtsplaytv/addon.xml
+++ b/plugin.video.rtsplaytv/addon.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtsplaytv" name="RTS Play TV" version="1.0.0" provider-name="Alexander Seiler">
+<addon id="plugin.video.rtsplaytv" name="RTS Play TV" version="1.1.0" provider-name="Alexander Seiler">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.simplecache" version="1.0.0"/>
+    <import addon="plugin.video.youtube" version="6.2.2" optional="true"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>
@@ -24,7 +25,9 @@
     <website>https://www.rts.ch/play/tv</website>
     <email>seileralex@gmail.com</email>
     <source>https://github.com/goggle/plugin.video.rtsplaytv</source>
-    <news>v1.0.0 (2018-11-07)
+    <news>v1.1.0 (2018-11-13)
+ - Add support for the official RTS YouTube channels.
+v1.0.0 (2018-11-07)
  - Add french translation.
 v0.9.3 (2018-10-09)
  - Allow plugin to parse the date indicator "Aujourd'hui".

--- a/plugin.video.rtsplaytv/resources/data/youtube_channels.json
+++ b/plugin.video.rtsplaytv/resources/data/youtube_channels.json
@@ -1,0 +1,55 @@
+{
+    "channels": [{
+            "name": "RTS - Radio Télévision Suisse",
+            "channel": "UCQyyY2Izw8hin7c8T5YY4sg"
+        },
+        {
+            "name": "Les archives de la RTS",
+            "channel": "UCe1rxEqz65ZWXwvWLrvq0Rw"
+        },
+        {
+            "name": "Temps Présent",
+            "channel": "UCBm0mt3q5l8xDy9PRIohaFw"
+        },
+        {
+            "name": "Nouvo",
+            "channel": "UCN24XiX1e8fTJEfanFRWeaw"
+        },
+        {
+            "name": "Géopolitis",
+            "channel": "UC8jSdiTfai1PFwjQ9MrkkBg"
+        },
+        {
+            "name": "Passe-moi les jumelles",
+            "channel": "UCW3--jh4FUnSxw-gofzKnqg"
+        },
+        {
+            "name": "Mise au Point",
+            "channel": "UCoLxAkyUJH1Zr6lE6M8WTwg"
+        },
+        {
+            "name": "Tataki",
+            "channel": "UCde0cBJrjHbmUio1ZU4LijQ"
+        },
+        {
+            "name": "36.9",
+            "channel": "UCBsnveG0qp0WNQRCtbqfONg"
+        },
+        {
+            "name": "Point Barre: Édition Pixel",
+            "channel": "UCc9E74Lnab6thrFB5Bbl22Q"
+        },
+        {
+            "name": "Couleur3",
+            "channel": "UCMKTFLrYiRerhOR9-lZnb3Q"
+        },
+        {
+            "name": "Les repérages Couleur3",
+            "channel": "UCLWGmqDVMSmVNTgBWJEDYZA"
+        },
+        {
+            "name": "Signes",
+            "channel": "UCzvOeolkdwDCtrDYqs1FZag"
+        }
+    ]
+}

--- a/plugin.video.rtsplaytv/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.rtsplaytv/resources/language/resource.language.de_de/strings.po
@@ -139,6 +139,10 @@ msgctxt "#30073"
 msgid ">> Next page"
 msgstr ">> Nächste Seite"
 
+msgctxt "#30074"
+msgid "RTS on YouTube"
+msgstr "RTS auf YouTube"
+
 msgctxt "#30100"
 msgid "Failed to open URL."
 msgstr "Konnte URL nicht öffnen."

--- a/plugin.video.rtsplaytv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.rtsplaytv/resources/language/resource.language.en_gb/strings.po
@@ -139,6 +139,10 @@ msgctxt "#30073"
 msgid ">> Next page"
 msgstr ""
 
+msgctxt "#30074"
+msgid "RTS on YouTube"
+msgstr ""
+
 msgctxt "#30100"
 msgid "Failed to open URL."
 msgstr ""

--- a/plugin.video.rtsplaytv/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.rtsplaytv/resources/language/resource.language.fr_fr/strings.po
@@ -139,6 +139,10 @@ msgctxt "#30073"
 msgid ">> Next page"
 msgstr ">> Page suivante"
 
+msgctxt "#30074"
+msgid "RTS on YouTube"
+msgstr "RTS sur YouTube"
+
 msgctxt "#30100"
 msgid "Failed to open URL."
 msgstr "Erreur lors de l'ouverture de l'URL"

--- a/plugin.video.rtsplaytv/resources/lib/rtsplaytv.py
+++ b/plugin.video.rtsplaytv/resources/lib/rtsplaytv.py
@@ -84,6 +84,9 @@ WEEKDAYS = (LANGUAGE(30060), LANGUAGE(30061), LANGUAGE(30062), LANGUAGE(30063),
             LANGUAGE(30064), LANGUAGE(30065), LANGUAGE(30066))
 IDREGEX = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|\d+'
 
+DATA_URI = 'special://home/addons/%s/resources/data' % ADDON_ID
+YOUTUBE_CHANNELS_FILENAME = 'youtube_channels.json'
+
 socket.setdefaulttimeout(TIMEOUT)
 
 
@@ -611,6 +614,13 @@ class RTSPlayTV(object):
                 'mode': 18,
                 'isFolder': True,
                 'displayItem': get_boolean_setting('RTS_Live')
+            }, {
+                # RTS on YouTube
+                'identifier': 'RTS_YouTube',
+                'name': LANGUAGE(30074),
+                'mode': 30,
+                'isFolder': True,
+                'displayItem': get_boolean_setting('RTS_YouTube')
             }
         ]
         for menu_item in main_menu_list:
@@ -1314,6 +1324,20 @@ class RTSPlayTV(object):
         play_item = xbmcgui.ListItem(video_id, path=auth_url)
         xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, play_item)
 
+    @staticmethod
+    def build_youtube_menu():
+        data_file = os.path.join(xbmc.translatePath(DATA_URI),
+                                 YOUTUBE_CHANNELS_FILENAME)
+        with open(data_file, 'r') as f:
+            ch_content = json.load(f)
+            for elem in ch_content.get('channels', []):
+                name = elem.get('name')
+                channel_id = elem.get('channel')
+                list_item = xbmcgui.ListItem(label=name)
+                url = 'plugin://plugin.video.youtube/channel/%s/' % channel_id
+                xbmcplugin.addDirectoryItem(
+                    int(sys.argv[1]), url, list_item, isFolder=True)
+
 
 def run():
     """
@@ -1377,6 +1401,8 @@ def run():
         RTSPlayTV().pick_date()
     elif mode == 26:
         RTSPlayTV().build_tv_menu()
+    elif mode == 30:
+        RTSPlayTV().build_youtube_menu()
     elif mode == 50:
         RTSPlayTV().play_video(name)
     elif mode == 51:

--- a/plugin.video.rtsplaytv/resources/settings.xml
+++ b/plugin.video.rtsplaytv/resources/settings.xml
@@ -16,6 +16,7 @@
         <setting id="Most_Clicked_Shows" type="bool" label="30055" default="true" />
         <setting id="Shows_By_Date" type="bool" label="30057" default="true" />
         <setting id="Live_TV" type="bool" label="30070" default="true" />
+        <setting id="RTS_YouTube" type="bool" label="30074" default="true" />
     </category>
     <category label="30011">
         <setting label="30005" type="action" action="RunPlugin(plugin://plugin.video.rtsplaytv?mode=19)" />        


### PR DESCRIPTION
### Description
New release of `plugin.video.rtsplaytv` (version 1.1.0).

Changes:
 - Add support to browse and watch the official RTS YouTube channels.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
