### PR TITLE
[plugin.video.tyt] 3.0.5

### DIFF
--- a/plugin.video.tyt/addon.xml
+++ b/plugin.video.tyt/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.tyt"
-version="3.0.4"
+version="3.0.5"
 name="TYT Network - The Young Turks"
 provider-name="Brian P. Soucy">
 <requires>

--- a/plugin.video.tyt/changelog.txt
+++ b/plugin.video.tyt/changelog.txt
@@ -1,3 +1,5 @@
+[B]3.0.5[/B]
+- Changed method of playback due to lack of TYT.com website QC.
 [B]3.0.4[/B]
 - Fixed Crashing Info due to TYT.com changing their underlying code
 [B]3.0.3[/B]

--- a/plugin.video.tyt/main.py
+++ b/plugin.video.tyt/main.py
@@ -77,8 +77,8 @@ def list_episodes(page, showurl, pagenum):
     is_folder = False
     listing.append((url, list_item, is_folder))
 
-  xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_DATE)
-  xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+#  xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_DATE)
+#  xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
   xbmcplugin.addSortMethod(_handle, xbmcplugin.SORT_METHOD_NONE)
 
   list_item = xbmcgui.ListItem(label='Next')

--- a/plugin.video.tyt/resources/lib/modules/scrape.py
+++ b/plugin.video.tyt/resources/lib/modules/scrape.py
@@ -12,8 +12,8 @@ def Get_Show_Episodes(page):
 #  with open('show.html', 'w') as f:
 #    f.write(page)
   hosts = {}
-#  episodes = re.compile('id="tag">(.+?)</div></tyt-feed-tag><!----><!.+?href="(.+?)".+?data-image-id="(.+?)".+?underbox"><.+?"">(.+?)</h1>.+?Hosts:(.+?)</span></span>.+?<!----><!----><!----><!---->.+?href=".+?"> (.+?)</a>',re.DOTALL).findall(page)
   episodes = re.compile('id="tag">(.+?)</div></tyt-feed-tag><!----><!.+?href="(.+?)".+?data-image-id="(.+?)".+?underbox"><.+?Hosts:(.+?)</span></span>.+?<!----><!----><!----><!---->.+?href=".+?"> (.+?)</a>',re.DOTALL).findall(page)
+#  episodes = re.compile('id="tag">(.+?)</div></tyt-feed-tag><!----><!.+?href="(.+?)".+?data-image-id="(.+?)".+?underbox"><.+?"">(.+?)<.+?Hosts:(.+?)</span></span>.+?<!----><!----><!----><!---->.+?href=".+?"> (.+?)</a>',re.DOTALL).findall(page)
   i = 0
 #  for date, link, image_id, title, allhosts, description in episodes:
   for date, link, image_id, allhosts, description in episodes:
@@ -43,7 +43,8 @@ def Watch_Episode(page, show):
 #  page = sendResponse(cookie, page) # main show episode list
 #  with open('main_show_episode.html', 'w') as f:
 #    f.write(page)
-  return re.search('tytapp-state.+?%s.+?hd_video_download_url.+?:\\\&q;(.+?)\\\&q' % show, page, re.MULTILINE | re.DOTALL).group(1)
+#  return re.search('tytapp-state.+?%s.+?hd_video_download_url.+?:\\\&q;(.+?)\\\&q' % show, page, re.MULTILINE | re.DOTALL).group(1) This works Too, Faster, but tyt.com always screws up
+  return re.search('tytapp-state.+?%s.+?\\[JW\\].+?url\\\&q;:\\\&q;(.+?)\\\&q' % show, page, re.MULTILINE | re.DOTALL).group(1)
 #  episode = re.compile('tap to download" href="(.+?)">.+?tap to download" href="(.+?)">',re.DOTALL).findall(page)
 #  for link in episode: return link
 


### PR DESCRIPTION
Changed playback reference. This method relies on JW player reference which is consistent.  Relying on download links was unstable due to poor website QC.