### PR TITLE
[plugin.video.dumpert] 1.1.7

### DIFF
--- a/plugin.video.dumpert/addon.xml
+++ b/plugin.video.dumpert/addon.xml
@@ -2,15 +2,10 @@
 <addon 
 	id="plugin.video.dumpert" 
 	name="Dumpert" 
-	version="1.1.6"
+	version="1.1.7"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
-	<import addon="script.module.beautifulsoup4"    version="4.5.3"/>
-    <import addon="script.module.requests"          version="2.4.3"/>
-    <import addon="script.module.future"            version="0.0.1"/>
-  	<import addon="script.module.html5lib"          version="0.999.0"/>
-	<import addon="plugin.video.youtube" 		    version="5.1.7" />
   </requires>
   <extension point="xbmc.python.pluginsource" 	library="addon.py">
     <provides>video</provides>
@@ -29,5 +24,6 @@
     <website>http://dumpert.nl</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.dumpert</source>
+    <broken>youtube addon not available on gotham branch</broken>
   </extension>
 </addon>

--- a/plugin.video.dumpert/changelog.txt
+++ b/plugin.video.dumpert/changelog.txt
@@ -1,3 +1,6 @@
+v1.1.7 (2018-12-28)
+- marking addon broken for gotham branch
+
 v1.1.6 (2018-02-21)
 - added 'videos' to icon
 - for json now using plugin://-url instead of http-url

--- a/plugin.video.dumpert/resources/lib/dumpert_const.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_const.py
@@ -14,8 +14,8 @@ ADDON = "plugin.video.dumpert"
 SETTINGS = xbmcaddon.Addon(id=ADDON)
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
-DATE = "2018-02-21"
-VERSION = "1.1.6"
+DATE = "2018-12-28"
+VERSION = "1.1.7"
 
 
 if sys.version_info[0] > 2:


### PR DESCRIPTION
### Description
v1.1.7 (2018-12-28)
- marked addon broken for gotham
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0