### PR TITLE
[plugin.video.vrt.nu] V1.5.2

### DIFF
--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.5.1"
+       version="1.5.2"
        provider-name="Martijn Moreel">
 
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.requests" version="2.19.1"/>
         <import addon="script.module.beautifulsoup4" version="4.5.3"/>
-        <import addon="inputstream.adaptive" version="2.0.19" />
+        <import addon="script.module.inputstreamhelper" version="0.3.3"/>
     </requires>
 
     <extension point="xbmc.python.pluginsource" library="addon.py">
         <provides>video</provides>
     </extension>
-
+    <extension point="xbmc.service" library="service.py" start="startup" />
     <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Addon to watch vrt.nu</summary>
     <description lang="en_GB">This addon can be used to watch all streams from vrt.nu. And also offers livestreams from Een, Canvas and Ketnet!</description>
@@ -24,6 +24,10 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.5.2 (28-01-2019)
+- Bug fix where the vrt token would be stored in a wrong format
+- Inputstream helper for easier widevine installation
+- Token resets when settings are being changed
 v1.5.1 (20-01-2019)
 - Fixed subtitle issue where subtitles would always be visible (Thanks mediaminister)
 - Fixed categories (Thanks mediaminister)

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -24,6 +24,10 @@ msgctxt "#32002"
 msgid "Password"
 msgstr "Password"
 
+msgctxt "#32003"
+msgid "Delete cookies"
+msgstr "Delete cookies"
+
 msgctxt "#32010"
 msgid "Subtitles"
 msgstr "Subtitles"

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/apidata.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/apidata.py
@@ -12,33 +12,17 @@ class ApiData:
     def client(self):
         return self._client
 
-    @client.setter
-    def client(self, value):
-        self._client = value
-
     @property
     def media_api_url(self):
         return self._media_api_url
-
-    @media_api_url.setter
-    def media_api_url(self, value):
-        self._media_api_url = value
 
     @property
     def video_id(self):
         return self._video_id
 
-    @video_id.setter
-    def video_id(self, value):
-        self._video_id = value
-
     @property
     def publication_id(self):
         return self._publication_id
-
-    @publication_id.setter
-    def publication_id(self, value):
-        self._publication_id = value
 
     @property
     def xvrttoken(self):
@@ -51,7 +35,3 @@ class ApiData:
     @property
     def is_live_stream(self):
         return self.is_live_stream
-
-    @is_live_stream.setter
-    def is_live_stream(self, value):
-        self.is_live_stream = value

--- a/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
+++ b/plugin.video.vrt.nu/resources/lib/helperobjects/streamurls.py
@@ -1,6 +1,27 @@
 class StreamURLS:
 
-    def __init__(self, stream_url, subtitle_url=None, license_key=None):
-        self.stream_url = stream_url
-        self.subtitle_url = subtitle_url
-        self.license_key = license_key
+    def __init__(self, stream_url, subtitle_url=None, license_key=None, use_inputstream_adaptive = False):
+        self._stream_url = stream_url
+        self._subtitle_url = subtitle_url
+        self._license_key = license_key
+        self._use_inputstream_adaptive = use_inputstream_adaptive
+
+    @property
+    def stream_url(self):
+        return self._stream_url
+
+    @property
+    def subtitle_url(self):
+        return self._subtitle_url
+
+    @property
+    def video_id(self):
+        return self._video_id
+
+    @property
+    def license_key(self):
+        return self._license_key
+
+    @property
+    def _use_inputstream_adaptive(self):
+        return self._use_inputstream_adaptive

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/actions.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/actions.py
@@ -7,3 +7,4 @@ LISTING_CATEGORY_VIDEOS = 'listingcategoryvideos'
 LISTING_EPISODES = 'listingepisodes'
 
 PLAY = 'play'
+CREDENTIALS = 'credentials'

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/urltostreamservice.py
@@ -21,7 +21,7 @@ class UrlToStreamService:
         self._vrt_base = vrt_base
         self._vrtnu_base_url = vrtnu_base_url
         self._create_settings_dir()
-        self._can_play_drm = self._kodi_wrapper.has_widevine_installed() and self._kodi_wrapper.has_inputstream_adaptive_installed()
+        self._can_play_drm = self._kodi_wrapper.can_play_widevine() and self._kodi_wrapper.has_inputstream_adaptive_installed()
         self._license_url = self._get_license_url()
 
     def _get_license_url(self):
@@ -145,16 +145,20 @@ class UrlToStreamService:
     def _try_get_drm_stream(self, stream_dict, vudrm_token):
         encryption_json = '{{"token":"{0}","drm_info":[D{{SSM}}],"kid":"{{KID}}"}}'.format(vudrm_token)
         license_key = self._get_license_key(key_url=self._license_url, key_type='D', key_value=encryption_json, key_headers={'Content-Type': 'text/plain;charset=UTF-8'})
-        return streamurls.StreamURLS(stream_dict['mpeg_dash'], license_key=license_key)
+        return streamurls.StreamURLS(stream_dict['mpeg_dash'], license_key=license_key, use_inputstream_adaptive=True)
         
     def _select_stream(self, stream_dict, vudrm_token):
         if vudrm_token and self._can_play_drm and self._kodi_wrapper.get_setting('usedrm') == 'true':
+            self._kodi_wrapper.log_notice('protocol: usedrm')
             return self._try_get_drm_stream(stream_dict, vudrm_token)
         elif vudrm_token:
+            self._kodi_wrapper.log_notice('protocol: hls_aes')
             return streamurls.StreamURLS(*self._select_hls_substreams(stream_dict['hls_aes']))
         elif self._kodi_wrapper.has_inputstream_adaptive_installed():
-            return streamurls.StreamURLS(stream_dict['mpeg_dash']) #non drm stream
+            self._kodi_wrapper.log_notice('protocol: mpeg_dash')
+            return streamurls.StreamURLS(stream_dict['mpeg_dash'], use_inputstream_adaptive=True) #non drm stream
         else:
+            self._kodi_wrapper.log_notice('protocol: hls')
             return streamurls.StreamURLS(*self._select_hls_substreams(stream_dict['hls'])) #last resort, non drm hls stream, only applies if people uninstalled inputstream adaptive while vrt nu addon was disabled
 
     #speed up hls selection, workaround for slower kodi selection

--- a/plugin.video.vrt.nu/resources/settings.xml
+++ b/plugin.video.vrt.nu/resources/settings.xml
@@ -9,5 +9,5 @@
     </category>
     <category label="32020">
         <setting label="32021" type="bool" id="usedrm" default="false" />
-    </category>
+    </category>  
 </settings>

--- a/plugin.video.vrt.nu/service.py
+++ b/plugin.video.vrt.nu/service.py
@@ -1,0 +1,26 @@
+import xbmc
+import xbmcaddon
+from resources.lib.kodiwrappers import kodiwrapper
+from resources.lib.vrtplayer import tokenresolver
+
+
+class VrtMonitor(xbmc.Monitor):
+
+    def __init__(self):
+       xbmc.Monitor.__init__(self)
+
+    def onSettingsChanged(self):
+       addon = xbmcaddon.Addon(id='plugin.video.vrt.nu')
+       kodi_wrapper = kodiwrapper.KodiWrapper(None, None, addon)
+       kodi_wrapper.log_notice('VRT NU Addon: settings changed')
+       token_resolver = tokenresolver.TokenResolver(kodi_wrapper)
+       token_resolver.reset_cookies()
+       
+
+if __name__ == '__main__':
+
+    monitor = VrtMonitor()
+
+    while not monitor.abortRequested():
+       if monitor.waitForAbort(10):
+           break


### PR DESCRIPTION
### Description
- Bug fix where the vrt token would be stored in a wrong format
- Inputstream helper for easier widevine installation (thanks for tip kodi team)
- Token resets when settings are being changed
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
