### PR TITLE
[plugin.video.zdf_de_2016] 1.0.15

### DIFF
--- a/plugin.video.zdf_de_2016/addon.py
+++ b/plugin.video.zdf_de_2016/addon.py
@@ -90,7 +90,7 @@ class XbmcResponse(Response):
         infoLabels['sorttitle'] = title
         infoLabels['genre'] = item.genre
         infoLabels['plot'] = item.text
-        if item.genre is not None:
+        if item.genre is not None and infoLabels['plot'] is not None:
             infoLabels['plot'] = item.genre + '\n' + infoLabels['plot']
 
         date = item.date

--- a/plugin.video.zdf_de_2016/addon.xml
+++ b/plugin.video.zdf_de_2016/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.14" provider-name="Generia">
+<addon id="plugin.video.zdf_de_2016" name="ZDF Mediathek 2016" version="1.0.15" provider-name="Generia">
   <requires>
     <import addon="xbmc.python" version="2.14.0"/>
   </requires>
@@ -24,6 +24,9 @@ Siehe auch https://github.com/generia/plugin.video.zdf_de_2016
 	<website>http://www.zdf.de</website>
     <platform>all</platform>
     <news>
+1.0.15 (2019-02-11)
+- fix 'Live TV' and 'Sendungen A-Z' (github issue #16)
+
 1.0.14 (2019-01-29)
 - fix for missing play icon
 - added duration display

--- a/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
+++ b/plugin.video.zdf_de_2016/de/generia/kodi/plugin/backend/zdf/Teaser.py
@@ -63,6 +63,7 @@ class Teaser(object):
     playable = False
     contentName = None
     apiToken = None
+    duration = None
     
     def __init__(self):
         pass


### PR DESCRIPTION
### Description
1.0.15 (2019-02-11)
- fix 'Live TV' and 'Sendungen A-Z' (github issue #16)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
