### PR TITLE
[plugin.video.gamekings] 1.2.14

### DIFF
--- a/plugin.video.gamekings/addon.xml
+++ b/plugin.video.gamekings/addon.xml
@@ -2,17 +2,15 @@
 <addon 
 	id="plugin.video.gamekings" 
 	name="GameKings" 
-	version="1.2.13"
+	version="1.2.14"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
-    <import addon="script.module.beautifulsoup4"    version="4.5.3"/>
+    <import addon="script.module.beautifulsoup4"    version="4.3.2"/>
     <import addon="script.module.requests"          version="2.4.3"/>
     <import addon="script.module.future"            version="0.0.1"/>
   	<import addon="script.module.html5lib"          version="0.999.0"/>
     <import addon="plugin.video.youtube" 		    version="5.1.7" />
-    <import addon="plugin.video.twitch"             version="1.4.5"/>
-    <import addon="plugin.video.vimeo"              version="4.1.4"/>
   </requires>
   <extension point="xbmc.python.pluginsource" 	library="addon.py">
     <provides>video</provides>
@@ -32,9 +30,8 @@
     <website>https://www.gamekings.tv</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.gamekings</source>
-    <news>v1.2.13 (2018-05-18)
-    - prefix the titles of premium-only videos with an asterisk
-    - using news-tag in addon.xml
-    - showing a popup when it's a twitch live stream</news>
+    <news>v1.2.14 (2019-02-23)
+    - since vimeo disabled oauth1, the vimeo addon broke. Therefore not using that addon anymore
+    - improved detecting if the video is a twitch live-stream</news>
   </extension>
 </addon>

--- a/plugin.video.gamekings/changelog.txt
+++ b/plugin.video.gamekings/changelog.txt
@@ -1,3 +1,7 @@
+v1.2.14 (2019-02-23)
+- since vimeo disabled oauth1, the vimeo addon broke. Therefore not using that addon anymore
+- improved detecting if the video is a twitch live-stream
+
 v1.2.13 (2018-05-18)
 - prefix the titles of premium-only videos with an asterisk
 - using news-tag in addon.xml

--- a/plugin.video.gamekings/resources/lib/gamekings_const.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_const.py
@@ -16,10 +16,11 @@ SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
 BASE_URL_GAMEKINGS_TV = "https://www.gamekings.tv/"
+TWITCH_URL_GAMEKINGS_TV = "https://player.twitch.tv/?channel=gamekings"
 PREMIUM_ONLY_VIDEO_TITLE_PREFIX = '* '
 LOGIN_URL = 'https://www.gamekings.tv/wp-login.php'
-DATE = "2018-05-18"
-VERSION = "1.2.13"
+DATE = "2018-05-23"
+VERSION = "1.2.14-SNAPSHOT"
 
 
 if sys.version_info[0] > 2:

--- a/plugin.video.gamekings/resources/lib/gamekings_play.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_play.py
@@ -15,7 +15,7 @@ import xbmc
 import xbmcgui
 import xbmcplugin
 
-from gamekings_const import SETTINGS, LANGUAGE, LOGIN_URL, convertToUnicodeString, log
+from gamekings_const import SETTINGS, LANGUAGE, LOGIN_URL, convertToUnicodeString, log, TWITCH_URL_GAMEKINGS_TV
 
 #
 # Main class
@@ -240,24 +240,12 @@ class Main(object):
         if have_valid_url:
             # regular gamekings video's on vimeo look like this: https://player.vimeo.com/external/166503498.hd.mp4?s=c44264eced6082c0789371cb5209af96bc44035b
             if video_url.find("player.vimeo.com/external/") > 0:
-                vimeo_id = str(video_url)
-                vimeo_id = vimeo_id.replace("http://player.vimeo.com/external/", "")
-                vimeo_id = vimeo_id.replace("https://player.vimeo.com/external/", "")
-                vimeo_id = vimeo_id[0:vimeo_id.find(".")]
-
-                log("vimeo_id1", vimeo_id)
-
-                video_url = 'plugin://plugin.video.vimeo/play/?video_id=%s' % vimeo_id
+                # no need to do anything with the vimeo addon, we can use the video_url directly
+                pass
             # premium video's on vimeo look like this: https://player.vimeo.com/video/190106340?title=0&autoplay=1&portrait=0&badge=0&color=C7152F
             if video_url.find("player.vimeo.com/video/") > 0:
-                vimeo_id = str(video_url)
-                vimeo_id = vimeo_id.replace("http://player.vimeo.com/video/", "")
-                vimeo_id = vimeo_id.replace("https://player.vimeo.com/video/", "")
-                vimeo_id = vimeo_id[0:vimeo_id.find("?")]
-
-                log("vimeo_id2", vimeo_id)
-
-                video_url = 'plugin://plugin.video.vimeo/play/?video_id=%s' % vimeo_id
+                # no need to do anything with the vimeo addon, we can use the video_url directly
+                pass
             elif video_url.find("youtube") > 0:
                 youtube_id = str(video_url)
                 youtube_id = youtube_id.replace("http://www.youtube.com/embed/", "")
@@ -274,12 +262,15 @@ class Main(object):
 
                 video_url = 'plugin://plugin.video.youtube/play/?video_id=%s' % youtube_id
 
+            log("final video_url", video_url)
+
             list_item = xbmcgui.ListItem(path=video_url)
             xbmcplugin.setResolvedUrl(self.plugin_handle, True, list_item)
+
         #
         # Check if it's a twitch live stream
         #
-        elif str(html_source).find("twitch") > 0:
+        elif str(html_source).find(TWITCH_URL_GAMEKINGS_TV) > 0:
             #example of a live stream: video_url = 'plugin://plugin.video.twitch/?channel_id=57330659&amp;mode=play;'
             xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30611))
         #


### PR DESCRIPTION
### Description
v1.2.14 (2019-02-23)
- since vimeo disabled oauth1, the vimeo addon broke. Therefore not using that addon anymore
- improved detecting if the video is a twitch live-stream
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0