### PR TITLE
[plugin.video.gamekings] 1.2.14

### DIFF
--- a/plugin.video.gamekings/addon.xml
+++ b/plugin.video.gamekings/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.gamekings" 
 	name="GameKings" 
-	version="1.2.13"
+	version="1.2.14"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -10,9 +10,6 @@
     <import addon="script.module.requests"          version="2.4.3"/>
     <import addon="script.module.future"            version="0.0.1"/>
   	<import addon="script.module.html5lib"          version="0.999.0"/>
-    <import addon="plugin.video.youtube" 		    version="5.1.7" />
-    <import addon="plugin.video.twitch"             version="1.4.5"/>
-    <import addon="plugin.video.vimeo"              version="4.1.4"/>
   </requires>
   <extension point="xbmc.python.pluginsource" 	library="addon.py">
     <provides>video</provides>
@@ -32,9 +29,9 @@
     <website>https://www.gamekings.tv</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.gamekings</source>
-    <news>v1.2.13 (2018-05-18)
-    - prefix the titles of premium-only videos with an asterisk
-    - using news-tag in addon.xml
-    - showing a popup when it's a twitch live stream</news>
+    <news>v1.2.14 (2019-02-23)
+	- marking the addon broken for gotham. A working version will be available in Leia (Kodi 18)
+	</news>
+	<broken>no more youtube addon in gotham</broken>	
   </extension>
 </addon>

--- a/plugin.video.gamekings/changelog.txt
+++ b/plugin.video.gamekings/changelog.txt
@@ -1,3 +1,6 @@
+v1.2.14 (2019-02-23)
+- marking the addon broken for gotham. A working version will be available in Leia (Kodi 18)
+
 v1.2.13 (2018-05-18)
 - prefix the titles of premium-only videos with an asterisk
 - using news-tag in addon.xml

--- a/plugin.video.gamekings/resources/lib/gamekings_const.py
+++ b/plugin.video.gamekings/resources/lib/gamekings_const.py
@@ -18,8 +18,8 @@ IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 
 BASE_URL_GAMEKINGS_TV = "https://www.gamekings.tv/"
 PREMIUM_ONLY_VIDEO_TITLE_PREFIX = '* '
 LOGIN_URL = 'https://www.gamekings.tv/wp-login.php'
-DATE = "2018-05-18"
-VERSION = "1.2.13"
+DATE = "2019-02-23"
+VERSION = "1.2.14"
 
 
 if sys.version_info[0] > 2:


### PR DESCRIPTION
### Description
v1.2.14 (2019-02-23)
- marking the addon broken for gotham. A working version (1.2.15) will be available in Leia (Kodi 18)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0