### PR TITLE
[plugin.video.vrt.nu] V1.6.0

### DIFF
--- a/plugin.video.vrt.nu/addon.py
+++ b/plugin.video.vrt.nu/addon.py
@@ -2,7 +2,7 @@ import sys
 import xbmcaddon
 from urlparse import parse_qsl
 from resources.lib.kodiwrappers import kodiwrapper, sortmethod
-from resources.lib.vrtplayer import vrtplayer, urltostreamservice, tokenresolver, actions
+from resources.lib.vrtplayer import vrtplayer, urltostreamservice, tokenresolver, actions, vrtapihelper
 
 _url = sys.argv[0]
 _handle = int(sys.argv[1])
@@ -15,7 +15,8 @@ def router(params_string):
     stream_service = urltostreamservice.UrlToStreamService(vrtplayer.VRTPlayer._VRT_BASE,
                                                            vrtplayer.VRTPlayer._VRTNU_BASE_URL,
                                                            kodi_wrapper, token_resolver)
-    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service)
+    api_helper = vrtapihelper.VRTApiHelper()
+    vrt_player = vrtplayer.VRTPlayer(addon.getAddonInfo('path'), kodi_wrapper, stream_service, api_helper)
     params = dict(parse_qsl(params_string))
     if params:
         if params['action'] == actions.LISTING_AZ:
@@ -25,7 +26,8 @@ def router(params_string):
         elif params['action'] == actions.LISTING_LIVE:
             vrt_player.show_livestream_items()
         elif params['action'] == actions.LISTING_VIDEOS:
-            vrt_player.show_videos(params['video'])
+            season = params['season'] if  'season' in params else None
+            vrt_player.show_videos(params['video'], season)
         elif params['action'] == actions.LISTING_CATEGORY_VIDEOS:
             vrt_player.show_video_category_episodes(params['video'])
         elif params['action'] == actions.PLAY:

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.vrt.nu"
        name="VRT Nu"
-       version="1.5.2"
+       version="1.6.0"
        provider-name="Martijn Moreel">
 
     <requires>
@@ -24,6 +24,10 @@
         <platform>all</platform>
         <license>GNU General Public License, v3</license>
         <news>
+v1.6.0 (07-03-2019)
+- Use Vrt search api (greatly improves stability)
+- Fix for users with Non ASCII compatible user path
+- Fix for roaming token
 v1.5.2 (28-01-2019)
 - Bug fix where the vrt token would be stored in a wrong format
 - Inputstream helper for easier widevine installation

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacollector.py
@@ -3,33 +3,7 @@ import time
 from resources.lib.vrtplayer import metadatacreator
 from resources.lib.vrtplayer import statichelper
 
-
 class MetadataCollector:
-
-    def __init__(self):
-        pass
-
-    def get_single_layout_episode_metadata(self, soup):
-        metadata_creator = metadatacreator.MetadataCreator()
-        metadata_creator.duration = self.__get_episode_duration(soup)
-        metadata_creator.plot = self.get_plot(soup)
-        metadata_creator.datetime = self.get_broadcast_datetime(soup)
-        return metadata_creator.get_video_dictionary()
-
-    def get_multiple_layout_episode_metadata(self, soup):
-        metadata_creator = metadatacreator.MetadataCreator()
-        metadata_creator.duration = self.__get_multiple_layout_episode_duration(soup)
-        return metadata_creator.get_video_dictionary()
-
-    @staticmethod
-    def __get_episode_duration(soup):
-        duration = None
-        duration_item = soup.find(class_='content__duration')
-        if duration_item is not None:
-            minutes = re.findall('\d+', duration_item.text)
-            if len(minutes) != 0:
-                duration = statichelper.minutes_string_to_seconds_int(minutes[0])
-        return duration
 
     @staticmethod
     def get_az_metadata(tile):
@@ -43,36 +17,3 @@ class MetadataCollector:
         metadata_creator.plot = description
         return metadata_creator.get_video_dictionary()
 
-    @staticmethod
-    def get_plot(soup):
-        description = ''
-        description_item = soup.find(class_='content__shortdescription')
-        if description_item is not None:
-            description = description_item.text
-        return description
-
-    @staticmethod
-    def get_broadcast_datetime(soup):
-        broadcast_datetime = None
-        broadcast_date_element = soup.find(class_='content__broadcastdate')
-        
-        if broadcast_date_element is None:
-            return broadcast_datetime
-
-        time_element = broadcast_date_element.find('time')
-
-        if time_element is None:
-            return broadcast_datetime
-        
-        broadcast_datetime = time.strptime(time_element['datetime'][:18], '%Y-%m-%dT%H:%M:%S')
-        return broadcast_datetime
-
-    @staticmethod
-    def __get_multiple_layout_episode_duration(soup):
-        seconds = None
-        minutes_element = soup.find('abbr', {'title': 'minuten'})
-        if minutes_element is not None and minutes_element.parent is not None:
-            minutes_with_mintext = minutes_element.parent.text.split('|')[-1];
-            stripped_minutes = re.findall('\d+', minutes_with_mintext)[0]
-            seconds = statichelper.minutes_string_to_seconds_int(stripped_minutes)
-        return seconds

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacreator.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/metadatacreator.py
@@ -1,12 +1,20 @@
 import time
 
-
 class MetadataCreator:
 
     def __init__(self):
         self._duration = None
         self._plot = None
+        self._plotoutline = None
         self._datetime = None
+
+    @property
+    def title(self):
+        return self._title
+
+    @title.setter
+    def title(self, value):
+        self._title = value
 
     @property
     def duration(self):
@@ -25,12 +33,24 @@ class MetadataCreator:
         self._plot = value.strip()
 
     @property
+    def plotoutline(self):
+        return self._plotoutline
+
+    @plotoutline.setter
+    def plotoutline(self, value):
+        self._plotoutline = value.strip()
+
+    @property
     def datetime(self):
         return self._datetime
 
     @datetime.setter
     def datetime(self, value):
         self._datetime = value
+   
+    @property
+    def datetime_as_short_date(self):
+        return time.strftime('%d/%m', self.datetime)
 
     def get_video_dictionary(self):
         video_dictionary = dict()
@@ -38,11 +58,14 @@ class MetadataCreator:
         if self.plot is not None:
             video_dictionary['plot'] = self.plot
 
+        if self.plotoutline is not None:
+            video_dictionary['plotoutline'] = self.plotoutline
+
         if self.duration is not None:
-            video_dictionary['duration'] = self.duration
+            video_dictionary['duration'] = (self.duration * 60) #minutes to seconds
 
         if self.datetime is not None:
             video_dictionary['date'] = time.strftime('%d.%m.%Y', self.datetime)
-            video_dictionary['shortdate'] = time.strftime('%d/%m', self.datetime)
-
+            video_dictionary['shortdate'] = self.datetime_as_short_date
+            
         return video_dictionary

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/statichelper.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/statichelper.py
@@ -1,13 +1,14 @@
-def minutes_string_to_seconds_int(minutes):
-    try:
-        return int(minutes) * 60
-    except ValueError:
-        return None
-
-
 def replace_newlines_and_strip(text):
     return text.replace('\n', '').strip()
 
 
 def replace_double_slashes_with_https(url):
     return url.replace('//', 'https://')
+
+
+def distinct(sequence):
+    seen = set()
+    for s in sequence:
+        if not s in seen:
+            seen.add(s)
+            yield s

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/tokenresolver.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/tokenresolver.py
@@ -58,9 +58,10 @@ class TokenResolver:
             now = datetime.datetime.utcnow()
             exp = datetime.datetime(*(time.strptime(token['expirationDate'], '%Y-%m-%dT%H:%M:%S.%fZ')[0:6]))
             if exp > now:
-                self._kodi_wrapper.log_notice(path)
+                self._kodi_wrapper.log_notice('Got cached token')
                 cached_token = token[token.keys()[0]]
             else:
+                self._kodi_wrapper.log_notice('Cached token deleted')
                 self._kodi_wrapper.delete_path(path)
         return cached_token
 
@@ -105,7 +106,7 @@ class TokenResolver:
         roaming_xvrttoken = None
         if url is not None:
             cookie_jar = requests.get(url, headers=headers).cookies
-            roaming_xvrttoken = TokenResolver._create_token_dictionary_from_cookie_jar(cookie_jar)
+            roaming_xvrttoken = TokenResolver._create_token_dictionary(cookie_jar)
         return roaming_xvrttoken
 
     @staticmethod

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtapihelper.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer/vrtapihelper.py
@@ -1,0 +1,68 @@
+import requests
+from resources.lib.vrtplayer import statichelper, metadatacreator, actions
+from resources.lib.helperobjects import helperobjects
+from bs4 import BeautifulSoup
+import time
+
+class VRTApiHelper:
+    
+    _API_URL = 'https://search.vrt.be/search?size=150&facets[programUrl]=//www.vrt.be'
+
+
+
+    def get_video_items(self, relevant_url, season):
+        joined_url = self._API_URL + relevant_url.replace(".relevant" ,"")
+        response = (requests.get(joined_url)).json()
+        result_list = response['results']
+        items = None
+        if not season:
+            items = VRTApiHelper.__get_seasons_if_multiple_seasons_present(result_list, relevant_url)
+
+        if not items : #if no seasons present get regular video items
+           items = VRTApiHelper.__map_to_title_items(result_list, season)
+        return items
+
+    @staticmethod
+    def __get_seasons_if_multiple_seasons_present( result_list, relevant_url):
+        seasons = list(statichelper.distinct(list(map(lambda x: VRTApiHelper.__get_season(x), result_list))))
+        items = None
+        if len(seasons) > 1:
+            items = list(map(lambda x: VRTApiHelper.__map_to_season_title_item(x, relevant_url), seasons))
+        return items
+
+    @staticmethod
+    def __get_season(result):
+        metadata_creator = metadatacreator.MetadataCreator()
+        return result['seasonName']
+
+    @staticmethod
+    def __map_to_season_title_item(season, url):
+        return helperobjects.TitleItem('Seizoen ' +season, {'action': actions.LISTING_VIDEOS, 'season': season,'video': url}, False)
+    
+    @staticmethod
+    def __map_to_title_items(results, season):
+        title_items = []
+        for result in results:
+            season_name = result['seasonName']
+            if (season is None) or (season is not None and season_name == season):
+                metadata_creator = metadatacreator.MetadataCreator()
+                json_broadcast_date = result['broadcastDate']
+                title = ''
+                if json_broadcast_date != -1 :
+                    epoch_in_seconds = result['broadcastDate']/1000
+                    metadata_creator.datetime = time.localtime(epoch_in_seconds)
+                    title = metadata_creator.datetime_as_short_date + ' '
+                description = BeautifulSoup(result['shortDescription'], 'html.parser').text
+                metadata_creator.duration = result['duration']
+                metadata_creator.plot = BeautifulSoup(result['description'], 'html.parser').text
+                metadata_creator.plotoutline = result['shortDescription']
+                thumb_url = result['videoThumbnailUrl']
+                thumb = statichelper.replace_double_slashes_with_https(thumb_url) if thumb_url.startswith("//") else thumb_url
+                
+                #sometimes shortdescription is empty if that's the case use title => always prepend date
+                title = title +  (description if description != '' else result['title'])
+                title_items.append(helperobjects.TitleItem(title, {'action': actions.PLAY, 'video': result['url']}, True, thumb, metadata_creator.get_video_dictionary()))
+
+        return title_items
+
+


### PR DESCRIPTION
### Description
Fixed error for people who are roaming, also using the vrt nu api to get video's which will greatly improve stability. Also implemented fall back mechanism for stream selection
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
