### PR TITLE
[plugin.video.mediathekview] 0.6.2

### DIFF
--- a/plugin.video.mediathekview/addon.xml
+++ b/plugin.video.mediathekview/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.mediathekview"
 	name="MediathekView"
-	version="0.6.1"
+	version="0.6.2"
 	provider-name="MediathekView.de, Leo Moll">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0"/>
@@ -26,17 +26,22 @@
 		<description lang="de_DE">Ermöglicht den Zugriff auf fast alle deutschen Mediatheken der öffentlich Rechtlichen basierend auf der Datenbank von MediathekView.de</description>
 		<description lang="en_GB">Gives access to most video-platforms from German public service broadcasters using the database of MediathekView.de</description>
 		<description lang="it_IT">Fornisce l'accesso a gran parte delle piattaforme video operate dalle emittenti pubbliche tedesche usando la banca dati di MediathekView.de</description>
-		<news>v.0.6.1 (2019-03-08):
-- Bugfix: Fixed module exception due to case error
+		<news>v.0.6.2 (2019-03-10):
+- [fix] Implemented Workaround for broken gzip module support in Kodi 18 running on Android
+- [fix] Fixed crash in mvupdate tool when invoked with MySQL support
+- [new] Improved compatibility with future Kodi versions with Python 3 support
+v.0.6.1 (2019-03-08):
+- [fix] Fixed module exception due to case error
 v0.6.0 (2019-03-01):
-- Feature: Cache der Anfragen für lokale Datenbanken
-- Feature: Natives ultraschnelles Update für SQLite
-- Bugfix: Live Streams konnten heruntergeladen werden
-- Bugfix: Auf Kodi 18 hat der automatische Aktualisierungsmodus nicht mehr funktioniert
-- Feature: Neue option --full um ein vollstndiges Update zu erzwingen
-- Feature: Neue Aktualisierungsmethode "Zeitgesteuert"
-- Bugfix: Es war nicht möglich, den Aktualisierungsintervall bei der Methode "Automatisch" einzustellen
-- Feature: Passende Symbole für alle Menü-Einträge
+- [new] Query Cache for slow systems
+- [new] Native SQLite fast update
+- [fix] It was possible to "download" the live stream
+- [fix] Automatic DB update did not work any more on Kodi 18
+- [new] Possibility to force a full update from the command line
+- [new] New database update mode "Continously"
+- [fix] Implemented some improvements suggested by Kodi Team in xbmc/repo-plugins#1979 (comment)
+- [new] New Menu Icons
+- [new] Source code now complies to PEP8 specification
 </news>
 		<platform>all</platform>
 		<language>de fr</language>

--- a/plugin.video.mediathekview/resources/lib/kodi/kodiaddon.py
+++ b/plugin.video.mediathekview/resources/lib/kodi/kodiaddon.py
@@ -2,19 +2,26 @@
 """
 The Kodi addons module
 
-Copyright 2017-2018, Leo Moll and Dominik Schlösser
+Copyright 2017-2019, Leo Moll and Dominik Schlösser
 Licensed under MIT License
 """
 import os
 import sys
-import urllib
-import urlparse
 
 # pylint: disable=import-error
 import xbmc
 import xbmcgui
 import xbmcaddon
 import xbmcplugin
+
+try:
+    # Python 3.x
+    from urllib.parse import urlencode
+    from urllib.parse import parse_qs
+except ImportError:
+    # Python 2.x
+    from urllib import urlencode
+    from urlparse import parse_qs
 
 from resources.lib.kodi.kodilogger import KodiLogger
 
@@ -96,7 +103,7 @@ class KodiPlugin(KodiAddon):
 
     def __init__(self):
         KodiAddon.__init__(self)
-        self.args = urlparse.parse_qs(sys.argv[2][1:])
+        self.args = parse_qs(sys.argv[2][1:])
         self.base_url = sys.argv[0]
         self.addon_handle = int(sys.argv[1])
 
@@ -141,7 +148,7 @@ class KodiPlugin(KodiAddon):
         Args:
             params(object): an object containing parameters
         """
-        return self.base_url + '?' + urllib.urlencode(params)
+        return self.base_url + '?' + urlencode(params)
 
     def run_plugin(self, params):
         """

--- a/plugin.video.mediathekview/resources/lib/mvupdate.py
+++ b/plugin.video.mediathekview/resources/lib/mvupdate.py
@@ -25,7 +25,9 @@ class Settings(object):
     def __init__(self, args):
         self.datapath = args.path if args.dbtype == 'sqlite' else './'
         self.type = {'sqlite': 0, 'mysql': 1}.get(args.dbtype, 0)
-        if self.type == 1:
+        if self.type == 0:
+            self.updnative = args.native
+        elif self.type == 1:
             self.host = args.host
             self.port = int(args.port)
             self.user = args.user
@@ -38,7 +40,6 @@ class Settings(object):
         self.recentmode = 0
         self.groupshows = False
         self.updmode = 3
-        self.updnative = args.native
         self.updinterval = args.intervall
 
     @staticmethod


### PR DESCRIPTION
### Description
- Implemented Workaround for broken `gzip` module support in Kodi 18 running on Android
- Fixed crash in `mvupdate` tool when invoked with MySQL support
- Improved compatibility with future Kodi versions with Python 3 support
- Fixed module exception due to case error
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
