### PR TITLE
[plugin.video.jafc] 1.1.0

### DIFF
--- a/plugin.video.jafc/addon.xml
+++ b/plugin.video.jafc/addon.xml
@@ -1,29 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.jafc" name="Japanese Animated Film Classics" version="1.0.0" provider-name="fraser">
+<addon id="plugin.video.jafc" name="Japanese Animated Film Classics" version="1.1.0" provider-name="fraser">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
         <import addon="script.module.beautifulsoup4" version="4.3.2"/>
         <import addon="script.module.requests" version="2.12.4"/>
+        <import addon="script.module.inputstreamhelper" version="0.3.4"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
     </extension>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en_GB">Search and play free movies from the Japanese Animated Film Classics website</summary>
-        <description lang="en_GB">This add-on enables playing of videos and movies from the Japanese Animated Film Classics. It is not created, maintained or in any way affiliated with the National Film Archive of Japan. The add-on only provides an interface to access the free content on the Japanese Animated Film Classics website from Kodi.
+        <summary lang="en_GB">Search and play works from the Japanese Animated Film Classics website</summary>
+        <description lang="en_GB">Play videos from the "Japanese Animated Film Classics" website.
+            To mark a century of Japanese animation, the Film Center at Tokyo's National Museum of Modern Art digitised
+            a number of classic works.
+            These are made available here, with the option of hardcoded English subtitles, categorised by genre, theme
+            and artist.
         </description>
-        <language>en</language>
+        <language>ja en</language>
         <platform>all</platform>
         <license>MIT</license>
         <forum>https://forum.kodi.tv/showthread.php?tid=331943</forum>
         <website>https://animation.filmarchives.jp/</website>
         <email>fraser.chapman@gmail.com</email>
         <source>https://github.com/FraserChapman/plugin.video.jafc</source>
-        <news>v1.0.0 (25-4-18)
-            - Inital Version
-        </news>
-        <disclaimer>Neither this addon nor its author are in anyway affiliated with the National Film Archive of Japan</disclaimer>
+        <news>v1.2.0 (31-5-19) - Python 3 compatible</news>
+        <disclaimer lang="en_GB">Neither this addon nor its author are in anyway affiliated with the National Film
+            Archive of Japan.
+        </disclaimer>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/plugin.video.jafc/changelog.txt
+++ b/plugin.video.jafc/changelog.txt
@@ -1,2 +1,8 @@
+v1.1.0
+- Python 3 compatible
+- Added setting for hardcoded English subtitles
+- Removed all special:// uris
+- Changed streamed from M3U8 to MPD
+
 v1.0.0
 - Initial version

--- a/plugin.video.jafc/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.jafc/resources/language/resource.language.en_gb/strings.po
@@ -1,6 +1,6 @@
 # Kodi Media Center language file
-# Addon Name: BFI Player
-# Addon id: plugin.video.bfi
+# Addon Name: Japanese Animated Film Classics
+# Addon id: plugin.video.jafc
 # Addon Provider: fraser
 msgid ""
 msgstr ""
@@ -16,7 +16,6 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#This is a comment
 
 msgctxt "#32000"
 msgid "General"
@@ -51,7 +50,7 @@ msgid "Search"
 msgstr ""
 
 msgctxt "#32008"
-msgid "Error playing"
+msgid "Error"
 msgstr ""
 
 msgctxt "#32009"
@@ -102,3 +101,18 @@ msgctxt "#32023"
 msgid "Experts Choice"
 msgstr ""
 
+msgctxt "#32024"
+msgid "Subtitles"
+msgstr ""
+
+msgctxt "#32025"
+msgid "English (hardcoded)"
+msgstr ""
+
+msgctxt "#32026"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#32027"
+msgid "Clear Recent"
+msgstr ""

--- a/plugin.video.jafc/resources/lib/kodilogging.py
+++ b/plugin.video.jafc/resources/lib/kodilogging.py
@@ -13,8 +13,7 @@ class KodiLogHandler(logging.StreamHandler):
     def __init__(self):
         logging.StreamHandler.__init__(self)
         addon_id = xbmcaddon.Addon().getAddonInfo("id")
-        prefix = b"[%s] " % addon_id
-        formatter = logging.Formatter(prefix + b'%(name)s: %(message)s')
+        formatter = logging.Formatter("[{}] %(name)s %(message)s".format(addon_id))
         self.setFormatter(formatter)
 
     def emit(self, record):

--- a/plugin.video.jafc/resources/lib/plugin.py
+++ b/plugin.video.jafc/resources/lib/plugin.py
@@ -1,49 +1,30 @@
 # -*- coding: utf-8 -*-
+
 """Main plugin file - Handles the various routes"""
 
 __author__ = "fraser"
 
+import logging
+
+import inputstreamhelper
 import routing
 import xbmc
-import xbmcaddon as xa
-import xbmcplugin as xp
+import xbmcaddon
+import xbmcplugin
 from xbmcgui import ListItem
 
+import kodilogging
 from resources.lib import kodiutils as ku
 from resources.lib import search as jafc
 
+kodilogging.config()
+logger = logging.getLogger(__name__)
 plugin = routing.Plugin()
-ADDON = xa.Addon()
-ADDON_ID = ADDON.getAddonInfo("id")  # plugin.video.jafc
-ADDON_NAME = ADDON.getAddonInfo("name")  # East Anglian Film Archive
-MEDIA_URI = "special://home/addons/{}/resources/media/".format(ADDON_ID)
 
-PLAYBACK_RESOLUTION = "480"
-
-
-def add_menu_item(method, label, args=None, art=None, info=None, directory=True):
-    # type (Callable, str, dict, dict, dict, bool) -> None
-    """wrapper for xbmcplugin.addDirectoryItem"""
-    info = {} if info is None else info
-    art = {} if art is None else art
-    args = {} if args is None else args
-    label = ku.get_string(label) if isinstance(label, int) else label
-    list_item = ListItem(label)
-    list_item.setArt(art)
-    list_item.setInfo("video", info)
-    if method == search and "q" in args:
-        # saved search menu items can be removed via context menu
-        list_item.addContextMenuItems([(
-            ku.get_string(32019),
-            "XBMC.RunPlugin({})".format(plugin.url_for(search, delete=True, q=label))
-        )])
-    if not directory and method == play_film:
-        list_item.setProperty("IsPlayable", "true")
-    xp.addDirectoryItem(
-        plugin.handle,
-        plugin.url_for(method, **args),
-        list_item,
-        directory)
+ADDON_NAME = xbmcaddon.Addon().getAddonInfo("name")  # Japanese Animated Film Classics
+STREAM_ADDON = "inputstream.adaptive"
+STREAM_FORMAT = "mpd"
+STREAM_MIME_TYPE = "application/dash+xml"
 
 
 def get_arg(key, default=None):
@@ -54,17 +35,29 @@ def get_arg(key, default=None):
     return plugin.args.get(key, [default])[0]
 
 
-def get_info(href):
-    idx = jafc.text_to_int(href)
-    data = jafc.get_html("{}{}".format(jafc.JAFC_INFO_URI, idx))
-    return {
-        "plot": jafc.get_table_data(data, "Plot"),
-        "title": jafc.get_table_data(data, "English Title"),
-        "originaltitle": jafc.get_table_data(data, "Japanese kana Rendering"),  # Original Title
-        "year": jafc.text_to_int(jafc.get_table_data(data, "Production Date")),
-        "director": jafc.get_table_data(data, "Credits: Director"),
-        "duration": jafc.text_to_int(jafc.get_table_data(data, "Duration (minutes)")) * 60
-    }
+def add_menu_item(method, label, args=None, art=None, info=None, directory=True):
+    # type (Callable, str, dict, dict, dict, bool) -> None
+    """wrapper for xbmcplugin.addDirectoryItem"""
+    info = {} if info is None else info
+    art = {} if art is None else art
+    args = {} if args is None else args
+    label = ku.localize(label) if isinstance(label, int) else label
+    list_item = ListItem(label)
+    list_item.setArt(art)
+    list_item.setInfo("video", info)
+    if method == search and "q" in args:
+        # saved search menu items can be removed via context menu
+        list_item.addContextMenuItems([(
+            ku.localize(32019),
+            "XBMC.RunPlugin({})".format(plugin.url_for(search, delete=True, q=label))
+        )])
+    if not directory and method == play_film:
+        list_item.setProperty("IsPlayable", "true")
+    xbmcplugin.addDirectoryItem(
+        plugin.handle,
+        plugin.url_for(method, **args),
+        list_item,
+        directory)
 
 
 def paginate(data, method):
@@ -76,45 +69,45 @@ def paginate(data, method):
         if "class" in item.attrs and any(x in item.attrs["class"] for x in ["disabled", "active", "prev", "next"]):
             continue
         action = item.find("a")
-        add_menu_item(method, "[{} {}]".format(ku.get_string(32011), item.text), {  # [Page n]
+        add_menu_item(method, "[{} {}]".format(ku.localize(32011), item.text), {  # [Page n]
             "href": action["href"]
         })
-    add_menu_item(index, "[{}]".format(ku.get_string(32012)))  # [Menu]
+    add_menu_item(index, "[{}]".format(ku.localize(32012)))  # [Menu]
 
 
 @plugin.route("/")
 def index():
     """Main menu"""
     if ku.get_setting_as_bool("show_genres"):
-        add_menu_item(themes, 32005, {
+        add_menu_item(themes, 32005, args={
             "href": "en/categories/stories",
-            "title": ku.get_string(32005)
-        }, ku.icon("genres.png"))
+            "title": ku.localize(32005)
+        }, art=ku.icon("genres.png"))
     if ku.get_setting_as_bool("show_motions"):
-        add_menu_item(themes, 32002, {
+        add_menu_item(themes, 32002, args={
             "href": "en/categories/motions",
-            "title": ku.get_string(32002)
-        }, ku.icon("techniques.png"))
+            "title": ku.localize(32002)
+        }, art=ku.icon("techniques.png"))
     if ku.get_setting_as_bool("show_characters"):
-        add_menu_item(themes, 32003, {
+        add_menu_item(themes, 32003, args={
             "href": "en/categories/characters",
-            "title": ku.get_string(32003)
-        }, ku.icon("characters.png"))
+            "title": ku.localize(32003)
+        }, art=ku.icon("characters.png"))
     if ku.get_setting_as_bool("show_authors"):
         add_menu_item(authors, 32004, art=ku.icon("authors.png"))
     if ku.get_setting_as_bool("show_experts"):
         add_menu_item(experts, 32023, art=ku.icon("experts.png"))
     if ku.get_setting_as_bool("show_techniques"):
-        add_menu_item(themes, 32006, {
-            "href": "en/categories/techniques",
-            "title": ku.get_string(32006)
-        }, ku.icon("techniques.png"))
+        add_menu_item(themes, 32006, args={"href": "en/categories/techniques", "title": ku.localize(32006)},
+                      art=ku.icon("techniques.png"))
     if ku.get_setting_as_bool("show_search"):
-        add_menu_item(search, 32007, {"menu": True}, ku.icon("search.png"))
+        add_menu_item(search, 32007, args={"menu": True}, art=ku.icon("search.png"))
+    if ku.get_setting_as_bool("show_recent"):
+        add_menu_item(recent, 32026, art=ku.icon("saved.png"))
     if ku.get_setting_as_bool("show_settings"):
         add_menu_item(settings, 32010, art=ku.icon("settings.png"), directory=False)
-    xp.setPluginCategory(plugin.handle, ADDON_NAME)
-    xp.endOfDirectory(plugin.handle)
+    xbmcplugin.setPluginCategory(plugin.handle, ADDON_NAME)
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/settings")
@@ -128,15 +121,45 @@ def play_film():
     href = get_arg("href", False)
     if not href:
         return
-    url = jafc.get_player_url(jafc.text_to_int(href))
-    list_item = ListItem(path=url)
-    xp.setResolvedUrl(plugin.handle, True, list_item)
+    url = jafc.get_mpd_url(jafc.text_to_int(href))
+    is_helper = inputstreamhelper.Helper(STREAM_FORMAT)
+    if is_helper.check_inputstream():
+        list_item = ListItem(path=url)
+        list_item.setProperty("inputstreamaddon", STREAM_ADDON)
+        list_item.setProperty("inputstream.adaptive.manifest_type", STREAM_FORMAT)
+        list_item.setMimeType(STREAM_MIME_TYPE)
+        list_item.setContentLookup(False)
+        xbmcplugin.setResolvedUrl(plugin.handle, True, list_item)
+    else:
+        logger.debug("play_film error: {}".format(url))
+
+
+@plugin.route("/recent")
+def recent():
+    """Show recently viewed films"""
+    data = jafc.get_recent()
+    for item in data:
+        token = jafc.pluck(item["uri"], "nfc/", "_en")
+        info = jafc.get_info(token)
+        if info is None:
+            continue
+        add_menu_item(
+            play_film,
+            info["title"],
+            args={"href": token},
+            info=info,
+            art=ku.art(jafc.get_url(jafc.get_image(token))),
+            directory=False)
+    xbmcplugin.setPluginCategory(plugin.handle, ku.localize(32026))  # Recently Viewed
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/clear/<token>")
 def clear(token):
     if token == "cache" and ku.confirm():
         jafc.cache_clear()
+    if token == "recent" and ku.confirm():
+        jafc.recent_clear()
 
 
 @plugin.route("/search")
@@ -152,12 +175,15 @@ def search():
 
     # View saved search menu
     if bool(get_arg("menu", False)):
-        add_menu_item(search, "[{}]".format(ku.get_string(32016)), {"new": True})  # [New Search]
+        add_menu_item(search, "[{}]".format(ku.localize(32016)), {"new": True})  # [New Search]
         for item in jafc.retrieve():
             text = item.encode("utf-8")
-            add_menu_item(search, text, {"q": text})
-        xp.setPluginCategory(plugin.handle, ku.get_string(32007))  # Search
-        xp.endOfDirectory(plugin.handle)
+            add_menu_item(
+                search,
+                text,
+                args={"q": text})
+        xbmcplugin.setPluginCategory(plugin.handle, ku.localize(32007))  # Search
+        xbmcplugin.endOfDirectory(plugin.handle)
         return True
 
     # look-up
@@ -167,7 +193,7 @@ def search():
         if not query:
             return False
 
-    url = jafc.get_page_url(href) if href else jafc.get_search_url(query)
+    url = jafc.get_url(href) if href else jafc.get_search_url(query)
     data = jafc.get_html(url)
     results = data.find("ul", "work-results")
     if not results:
@@ -179,18 +205,18 @@ def search():
         img = item.find("img", "thumbnail")
         add_menu_item(play_film,
                       item.find("h2").text,
-                      {"href": action["href"]},
-                      info=get_info(action["href"]),
-                      art=ku.art(jafc.get_page_url(img["src"])),
+                      args={"href": action["href"]},
+                      info=jafc.get_info(action["href"]),
+                      art=ku.art(jafc.get_url(img["src"])),
                       directory=False)
-    xp.setPluginCategory(plugin.handle, "{} '{}'".format(ku.get_string(32016), query))
-    xp.endOfDirectory(plugin.handle)
+    xbmcplugin.setPluginCategory(plugin.handle, "{} '{}'".format(ku.localize(32016), query))
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/themes")
 def themes():
     """List of directory menu items for each theme"""
-    url = jafc.get_page_url(get_arg("href"))
+    url = jafc.get_url(get_arg("href"))
     data = jafc.get_html(url)
     element = data.find("ul", {
         "class": ["category-condition-keyword", "work-favorites-condition-keyword"]
@@ -200,39 +226,42 @@ def themes():
         span = action.find("span")
         if span:
             span.extract()
-        title = action.text
-        add_menu_item(films, title, {"href": action["href"], "title": title})
-    xp.setPluginCategory(plugin.handle, get_arg("title"))
-    xp.endOfDirectory(plugin.handle)
+        add_menu_item(
+            films,
+            action.text,
+            args={"href": action["href"], "title": action.text})
+    xbmcplugin.setPluginCategory(plugin.handle, get_arg("title"))
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/films")
 def films():
     """Playable movie items"""
-    url = jafc.get_page_url(get_arg("href"))
+    url = jafc.get_url(get_arg("href"))
     data = jafc.get_html(url)
     paginate(data.find("ul", "pager-menu"), films)
     container = data.find(True, {"class": ["categories", "characters", "writer-works"]})
+    if container is None:
+        ku.notification(ku.localize(32008), ku.localize(32009))  # Error - No playable items found
+        return
     for item in container.find_all("li"):
-        title = item.find(True, {"class": ["category-title", "character-serif", "writer-work-heading"]}).text
         action = item.find("a")
         if action is None:
             continue
-        img = item.find("img", "thumbnail")
         add_menu_item(
             play_film,
-            title,
-            {"href": action["href"]},
-            info=get_info(action["href"]),
-            art=ku.art(jafc.get_page_url(img["src"])),
+            item.find(True, {"class": ["category-title", "character-serif", "writer-work-heading"]}).text,
+            args={"href": action["href"]},
+            info=jafc.get_info(action["href"]),
+            art=ku.art(jafc.get_url(item.find("img", "thumbnail")["src"])),
             directory=False)
-    xp.setPluginCategory(plugin.handle, get_arg("title"))
-    xp.setContent(plugin.handle, "videos")
-    xp.addSortMethod(plugin.handle, xp.SORT_METHOD_LABEL_IGNORE_THE)
-    xp.addSortMethod(plugin.handle, xp.SORT_METHOD_GENRE)
-    xp.addSortMethod(plugin.handle, xp.SORT_METHOD_VIDEO_YEAR)
-    xp.addSortMethod(plugin.handle, xp.SORT_METHOD_DURATION)
-    xp.endOfDirectory(plugin.handle)
+    xbmcplugin.setContent(plugin.handle, "videos")
+    xbmcplugin.setPluginCategory(plugin.handle, get_arg("title"))
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_GENRE)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_DURATION)
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/experts")
@@ -240,60 +269,50 @@ def experts():
     """Lists experts, and their choices"""
     href = get_arg("href", False)
     if not href:
-        url = jafc.get_page_url("en/works-favorites.html")
+        url = jafc.get_url("en/works-favorites.html")
         data = jafc.get_html(url)
         container = data.find("div", "work-favorites")
         for item in container.find_all("div", "work-favorite"):
-            action = item.find("a")
-            img = item.find("img", "thumbnail")
-            title = img["alt"]
-            ku.log(action)
+            author = item.find("strong").text
             add_menu_item(experts,
-                          title,
-                          args={"href": "en/" + action["href"], "title": title},
+                          author,
+                          args={"href": "en/" + item.find("a")["href"], "title": item.find("strong").text},
                           info={"plot": item.find("div", "work-favorite-summary").text},
-                          art=ku.art(jafc.get_page_url(img["src"])))
+                          art=ku.art(jafc.get_url(item.find("img", "thumbnail")["src"])))
+            xbmcplugin.setPluginCategory(plugin.handle, ku.localize(32023))  # Experts Choice
     else:
-        url = jafc.get_page_url(href)
+        url = jafc.get_url(href)
         data = jafc.get_html(url)
         for item in data.find_all("div", "favorite-work"):
-            img = item.find("img", "thumbnail")
             action = item.find("h2").find("a")
-            title = action.text
             add_menu_item(play_film,
-                          title,
+                          action.text,
                           args={"href": action["href"]},
                           info={"plot": item.find("dd").text},
-                          art=ku.art(jafc.get_page_url(img["src"])),
+                          art=ku.art(jafc.get_url(item.find("img", "thumbnail")["src"])),
                           directory=False)
-    xp.setPluginCategory(plugin.handle, get_arg("title"))
-    xp.endOfDirectory(plugin.handle)
+            xbmcplugin.setPluginCategory(plugin.handle, get_arg("title"))  # Experts name
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 @plugin.route("/authors")
 def authors():
     """List of authors"""
-    url = jafc.get_page_url("en/writer.html")
+    url = jafc.get_url("en/writer.html")
     data = jafc.get_html(url)
     container = data.find("ul", "writer-results")
     for item in container.find_all("li"):
-        img = item.find("img", "thumbnail")
         action = item.find("a")
         if action is None:
             continue
-        add_menu_item(films, action.text, args={
-            "href": "en/{}".format(action["href"]),
-            "title": action.text
-        }, info={
-            "plot": item.find("div", "writer-result-description").text
-        }, art=ku.art(jafc.get_page_url(img["src"])))
-    xp.addSortMethod(plugin.handle, xp.SORT_METHOD_LABEL)
-    xp.endOfDirectory(plugin.handle)
-
-
-@plugin.route("/highlights")
-def highlights():
-    """"""
+        add_menu_item(films,
+                      action.text,
+                      args={"href": "en/{}".format(action["href"]), "title": action.text},
+                      info={"plot": item.find("div", "writer-result-description").text},
+                      art=ku.art(jafc.get_url(item.find("img", "thumbnail")["src"])))
+    xbmcplugin.addSortMethod(plugin.handle, xbmcplugin.SORT_METHOD_LABEL)
+    xbmcplugin.setPluginCategory(plugin.handle, ku.localize(32004))  # Authors
+    xbmcplugin.endOfDirectory(plugin.handle)
 
 
 def run():

--- a/plugin.video.jafc/resources/settings.xml
+++ b/plugin.video.jafc/resources/settings.xml
@@ -6,7 +6,11 @@
         <setting id="cache_use" type="bool" label="32017" default="true"/>
         <setting type="sep"/>
         <setting id="cache_clear" label="32018" type="action"
-                 action="RunPlugin(plugin://plugin.video.bfi/clear/cache)"/>
+                 action="RunPlugin(plugin://plugin.video.jafc/clear/cache)"/>
+        <setting id="recent_clear" label="32027" type="action"
+                 action="RunPlugin(plugin://plugin.video.jafc/clear/recent)"/>
+        <setting label="32024" type="lsep"/>
+        <setting id="english_subtitles" type="bool" label="32025" default="true"/>
     </category>
     <category label="32007">
         <setting id="search_saved" type="bool" label="32020" default="true"/>
@@ -19,6 +23,7 @@
         <setting id="show_techniques" type="bool" label="32006" default="true"/>
         <setting id="show_experts" type="bool" label="32023" default="true"/>
         <setting id="show_search" type="bool" label="32007" default="true"/>
+        <setting id="show_recent" type="bool" label="32026" default="true"/>
         <setting id="show_settings" type="bool" label="32010" default="true"/>
     </category>
 </settings>


### PR DESCRIPTION
### Description

Updated to (hopefully) be Python 3 compatible 
Removed all special:// uris
Changed streams from M3U8 to MPD

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0