### PR TITLE
[plugin.video.roosterteeth] 1.4.1

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.3.10"
+       version="1.4.1"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -9,6 +9,7 @@
     <import addon="script.module.requests"          version="2.4.3"/>
     <import addon="script.module.future"            version="0.0.1"/>
   	<import addon="script.module.html5lib"          version="0.999.0"/>
+  	<import addon="inputstream.adaptive"            version="2.3.17"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>
@@ -24,12 +25,12 @@
     <website>http://roosterteeth.com</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.roosterteeth</source>
-    <news>1.3.10 (2019-03-13)
-    - fixed videos
-    - removed the know channel
-    - added inside gaming channel
-    - added kinda funny channel
-    - removed youtube dependency
+    <news>1.4.1 (2019-06-09)
+    - added adapted inputstream addon switch. When on: video quality is chosen by that addon.
+    - for when the adapted inputstream addon switch is off: if a video of the desired video is not found, look for a video of lower quality
+    - fixed inside-gaming section
+    - added pages instead of only listing the first 30 items
+    - removed game attack
     </news>
   </extension>
 </addon>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,14 @@
+1.4.1 (2019-06-09)
+- added adapted inputstream switch. When this is on, the videoplayer inputstream addon 'Inputstream Adaptive'
+(kudo's to peak3d) is used. The addon 'Inputstream Adaptive' determines what resolution it will display based upon the
+available bandwidth and the settings of the addon 'Inputstream Adaptive'.
+When the adapted inputstream switch is off, the roosterteeth addon will try and play the video based upon the
+maximum video resolution in the roosterteeth settings.
+- for when the adapted inputstream switch is off: if a video of the desired video is not found, look for a video of lower quality
+- fixed inside-gaming section
+- added pages instead of only listing the first 30 items
+- removed game attack
+
 1.3.10 (2019-03-13)
 - fixed videos
 - removed the know channel

--- a/plugin.video.roosterteeth/resources/language/English/strings.po
+++ b/plugin.video.roosterteeth/resources/language/English/strings.po
@@ -39,6 +39,10 @@ msgctxt "#30017"
 msgid "Password"
 msgstr ""
 
+msgctxt "#30018"
+msgid "Use Adaptive Inputstream (Video Quality chosen by that Addon)"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Maximum Video Quality"
 msgstr ""

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -18,30 +18,50 @@ IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'reso
 KODI_ROOSTERTEETH_ADDON_CLIENT_ID = '4338d2b4bdc8db1239360f28e72f0d9ddb1fd01e7a38fbb07b4b1f4ba4564cc5'
 ROOSTERTEETH_AUTHORIZATION_URL = 'https://auth.roosterteeth.com/oauth/token'
 ROOSTERTEETH_BASE_URL = 'https://svod-be.roosterteeth.com'
+
+# Keep pagenumbers 3 digits
+ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART = '?per_page=1000&filter=all&page=001'
+NUMBER_OF_EPISODES_PER_PAGE = '24'
+ROOSTERTEETH_PAGE_URL_PART = '?per_page=' + NUMBER_OF_EPISODES_PER_PAGE + '&filter=all&page=001'
+ROOSTERTEETH_ORDER_URL_PART = '&order=desc'
+
+# Shows
 ROOSTERTEETH_SERIES_BASE_URL = 'https://svod-be.roosterteeth.com/api/v1/shows'
-ROOSTERTEETH_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/shows?per_page=1000&order=desc'
-NUMBER_OF_EPISODES_PER_PAGE = '30'
-ROOSTERTEETH_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/rooster-teeth/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-ACHIEVEMENTHUNTER_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/achievement-hunter/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-FUNHAUS_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/funhaus/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-INSIDE_GAMING_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/funhaus/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-SCREWATTACK__RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/screwattack/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-SUGARPINE7__RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/sugar-pine-7/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/cow-chop/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-GAMEATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/game-attack/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/jt-music/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
-KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/channels/kinda-funny/episodes?per_page=' + NUMBER_OF_EPISODES_PER_PAGE
+ROOSTERTEETH_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/shows' + ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART
+
+# Recent video's per channel
+ROOSTERTEETH_CHANNEL_BASE_URL = "https://svod-be.roosterteeth.com/api/v1/episodes"
+ROOSTERTEETH_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                              + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=rooster-teeth"
+ACHIEVEMENTHUNTER_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                                   + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=achievement-hunter"
+FUNHAUS_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=funhaus"
+INSIDE_GAMING_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                               + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=inside-gaming"
+SCREWATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                             + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=screwattack"
+SUGARPINE7_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                            + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=sugar-pine-7"
+COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=cow-chop"
+JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=jt-music"
+KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
+                                            + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=kinda-funny"
+
 SPONSOR_ONLY_VIDEO_TITLE_PREFIX = '* '
+INDEX_DOT_M3U8 = "index.m3u8"
 VQ4K = '4k'
 VQ1080P = '1080p'
 VQ720P = '720p'
 VQ480P = '480p'
 VQ360P = '360p'
 VQ240P = '240p'
-HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2019-03-13"
-VERSION = "1.3.10"
-
+HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+DATE = "2019-06-09"
+VERSION = "1.4.1"
 
 if sys.version_info[0] > 2:
     unicode = str
@@ -88,7 +108,8 @@ def find_all(string_to_be_searched_for, string_to_be_searched_in):
     start_pos_array = []
     # exit loop when kodi gets an abort-request
     while not monitor.abortRequested():
-        found_start_pos = string_to_be_searched_in.find(string_to_be_searched_for, start_pos_in_string_to_be_searched_in)
+        found_start_pos = string_to_be_searched_in.find(string_to_be_searched_for,
+                                                        start_pos_in_string_to_be_searched_in)
         if found_start_pos == -1:
             # exit the loop
             break

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_episodes.py
@@ -37,9 +37,32 @@ class Main(object):
         self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][0]
         self.show_serie_name = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['show_serie_name'][0]
 
-        # log("self.url", self.url)
+        log("self.url", self.url)
 
-        # log("self.show_serie_name", self.show_serie_name)
+        # log("self.next_page_possible", self.next_page_possible)
+
+        # Make the next page url
+        if self.next_page_possible == 'True':
+            # Determine current item number, next item number, next_url
+            pos_of_page = self.url.rfind('page=')
+
+            # log("pos_of_page", pos_of_page)
+
+            if pos_of_page >= 0:
+                page_number_str = str(
+                    self.url[pos_of_page + len('page='):pos_of_page + len('page=') + len('000')])
+                page_number = int(page_number_str)
+                self.page_number_next = page_number + 1
+                if self.page_number_next >= 100:
+                    page_number_next_str = str(self.page_number_next)
+                elif self.page_number_next >= 10:
+                    page_number_next_str = '0' + str(self.page_number_next)
+                else:
+                    page_number_next_str = '00' + str(self.page_number_next)
+
+                self.next_url = self.url.replace('page=' + page_number_str, 'page=' + page_number_next_str)
+
+                log("self.next_url", self.next_url)
 
         #
         # Get the videos...
@@ -153,6 +176,24 @@ class Main(object):
             list_item.addContextMenuItems([('Refresh', 'Container.Refresh')])
             # Add our item to the listing as a 3-element tuple.
             listing.append((plugin_url_with_parms, list_item, is_folder))
+
+        # Make a next page item, if a next page is possible
+        total_pages_str = json_data['total_pages']
+        total_pages = int(total_pages_str)
+        if self.page_number_next <= total_pages:
+            # Next page entry
+            if self.next_page_possible == 'True':
+                list_item = xbmcgui.ListItem(LANGUAGE(30200), thumbnailImage=os.path.join(IMAGES_PATH, 'next-page.png'))
+                list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
+                list_item.setProperty('IsPlayable', 'false')
+                parameters = {"action": "list-episodes", "url": str(self.next_url),
+                              "next_page_possible": self.next_page_possible, "show_serie_name": self.show_serie_name}
+                url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
+                is_folder = True
+                # Add refresh option to context menu
+                list_item.addContextMenuItems([('Refresh', 'Container.Refresh')])
+                # Add our item to the listing as a 3-element tuple.
+                listing.append((url, list_item, is_folder))
 
         # Add our listing to Kodi.
         # Large lists and/or slower systems benefit from adding all items at once via addDirectoryItems

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_series.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_series.py
@@ -16,7 +16,8 @@ import xbmcgui
 import xbmcplugin
 import json
 
-from roosterteeth_const import IMAGES_PATH, HEADERS, LANGUAGE, convertToUnicodeString, log, ROOSTERTEETH_SERIES_BASE_URL
+from roosterteeth_const import IMAGES_PATH, HEADERS, LANGUAGE, convertToUnicodeString, log, \
+    ROOSTERTEETH_SERIES_BASE_URL, ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART, ROOSTERTEETH_ORDER_URL_PART
 
 
 #
@@ -35,7 +36,8 @@ class Main(object):
         # Parse parameters...
         self.plugin_category = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['plugin_category'][0]
         self.video_list_page_url = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['url'][0]
-        self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][0]
+        self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][
+            0]
 
         # log("self.url", self.video_list_page_url)
 
@@ -79,12 +81,17 @@ class Main(object):
         for item in json_data['data']:
             serie_title = item['attributes']['title']
 
+            # this part looks like this f.e.: /series/nature-town
             serie_url_middle_part = item['canonical_links']['self']
-            # the serie url should something like this:
-            # https://svod-be.roosterteeth.com/api/v1/shows/always-open/seasons
-            serie_url = ROOSTERTEETH_SERIES_BASE_URL + serie_url_middle_part + '/seasons'
-            # remove '/series/' from the url
-            serie_url = serie_url.replace('/series/', '/')
+            serie_name = serie_url_middle_part.replace('/series/', '')
+
+            # log("serie_url_middle_part", serie_url_middle_part)
+            # log("serie_name", serie_name)
+
+            # the serie url should become something like this:
+            # https://svod-be.roosterteeth.com/api/v1/shows/nature-town/seasons?order=desc
+            serie_url = ROOSTERTEETH_SERIES_BASE_URL + '/' + serie_name + '/' + 'seasons' \
+                        + ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART + ROOSTERTEETH_ORDER_URL_PART
 
             thumb = item['included']['images'][0]['attributes']['thumb']
 
@@ -104,7 +111,7 @@ class Main(object):
             # of the parameters
             title = title.encode('ascii', 'ignore')
 
-            parameters = {"action": "list-serie-seasons", "url": url, "title": title, "thumbnail_url": thumbnail_url ,
+            parameters = {"action": "list-serie-seasons", "url": url, "title": title, "thumbnail_url": thumbnail_url,
                           "next_page_possible": "False"}
             plugin_url_with_parms = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
             is_folder = True

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_main.py
@@ -5,6 +5,7 @@
 # Imports
 #
 from future import standard_library
+
 standard_library.install_aliases()
 from builtins import object
 import sys
@@ -16,9 +17,11 @@ import os
 from roosterteeth_const import LANGUAGE, IMAGES_PATH, ROOSTERTEETH_SERIES_URL, \
     ROOSTERTEETH_RECENTLY_ADDED_VIDEOS_SERIES_URL, ACHIEVEMENTHUNTER_RECENTLY_ADDED_VIDEOS_SERIES_URL, \
     FUNHAUS_RECENTLY_ADDED_VIDEOS_SERIES_URL, INSIDE_GAMING_RECENTLY_ADDED_VIDEOS_SERIES_URL, \
-    SCREWATTACK__RECENTLY_ADDED_VIDEOS_SERIES_URL, SUGARPINE7__RECENTLY_ADDED_VIDEOS_SERIES_URL, \
-    COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL, GAMEATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL, \
-    JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL, KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL
+    SCREWATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL, SUGARPINE7_RECENTLY_ADDED_VIDEOS_SERIES_URL, \
+    COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL, JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL, \
+    KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL, ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART, \
+    ROOSTERTEETH_ORDER_URL_PART
+
 
 #
 # Main class
@@ -36,7 +39,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30301),
                       "url": ROOSTERTEETH_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30301))
         is_folder = True
@@ -47,7 +50,9 @@ class Main(object):
         #
         # Series
         #
-        parameters = {"action": "list-series", "plugin_category": LANGUAGE(30302), "url": ROOSTERTEETH_SERIES_URL,
+        parameters = {"action": "list-series", "plugin_category": LANGUAGE(30302),
+                      "url": ROOSTERTEETH_SERIES_URL + ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART +
+                             ROOSTERTEETH_ORDER_URL_PART,
                       "show_serie_name": "True", "next_page_possible": "False"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30302))
@@ -61,7 +66,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30303),
                       "url": ACHIEVEMENTHUNTER_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30303))
         is_folder = True
@@ -74,7 +79,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30305),
                       "url": FUNHAUS_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30305))
         is_folder = True
@@ -87,7 +92,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30315),
                       "url": INSIDE_GAMING_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30315))
         is_folder = True
@@ -99,8 +104,8 @@ class Main(object):
         # Screw Attack Recently Added Episodes
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30307),
-                      "url": SCREWATTACK__RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "url": SCREWATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL,
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30307))
         is_folder = True
@@ -112,8 +117,8 @@ class Main(object):
         # Sugar Pine 7 Recently Added Episodes
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30311),
-                      "url": SUGARPINE7__RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "url": SUGARPINE7_RECENTLY_ADDED_VIDEOS_SERIES_URL,
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30311))
         is_folder = True
@@ -126,22 +131,9 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30309),
                       "url": COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30309))
-        is_folder = True
-        list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
-        list_item.setProperty('IsPlayable', 'false')
-        xbmcplugin.addDirectoryItem(handle=self.plugin_handle, url=url, listitem=list_item, isFolder=is_folder)
-
-        #
-        # Game Attack Recently Added Episodes
-        #
-        parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30313),
-                      "url": GAMEATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
-        url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
-        list_item = xbmcgui.ListItem(LANGUAGE(30313))
         is_folder = True
         list_item.setArt({'fanart': os.path.join(IMAGES_PATH, 'fanart-blur.jpg')})
         list_item.setProperty('IsPlayable', 'false')
@@ -152,7 +144,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30317),
                       "url": JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30317))
         is_folder = True
@@ -165,7 +157,7 @@ class Main(object):
         #
         parameters = {"action": "list-episodes", "plugin_category": LANGUAGE(30319),
                       "url": KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL,
-                      "show_serie_name": "True", "next_page_possible": "False"}
+                      "show_serie_name": "True", "next_page_possible": "True"}
         url = self.plugin_url + '?' + urllib.parse.urlencode(parameters)
         list_item = xbmcgui.ListItem(LANGUAGE(30319))
         is_folder = True

--- a/plugin.video.roosterteeth/resources/settings.xml
+++ b/plugin.video.roosterteeth/resources/settings.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="General">
-    <setting id="quality" 	    	  type="enum"   label="30020" lvalues="30026|30025|30024|30023|30022|30021"     default="4"/>
-    <setting id="is_sponsor" 	      type="bool"   label="30015" 											        default="false"/>
-    <setting id="username" 	     	  type="text"   label="30016" 											        default="" 							  enable="eq(-1,true)"/>
-    <setting id="password" 		      type="text"   label="30017" 											        default="" 			option="hidden"   enable="eq(-2,true)"/>
+    <setting id="quality" 	    	        type="enum" label="30020" lvalues="30026|30025|30024|30023|30022|30021"   default="4"/>
+    <setting id="use_adaptive_inputstream" 	type="bool" label="30018" 											      default="false"/>
+    <setting id="is_sponsor" 	            type="bool" label="30015" 											      default="false"/>
+    <setting id="username" 	     	        type="text" label="30016" 											      default=""                   enable="eq(-1,true)"/>
+    <setting id="password" 		            type="text" label="30017" 											      default="" option="hidden"   enable="eq(-2,true)"/>
   </category>
 </settings>


### PR DESCRIPTION
### Description
1.4.1 (2019-06-09)
- added adapted inputstream switch. When this is on, the videoplayer inputstream addon 'Inputstream Adaptive'
(kudo's to peak3d) is used. The addon 'Inputstream Adaptive' determines what resolution it will display based upon the
available bandwidth and the settings of the addon 'Inputstream Adaptive'.
When the adapted inputstream switch is off, the roosterteeth addon will try and play the video based upon the
maximum video resolution in the roosterteeth settings.
- for when the adapted inputstream switch is off: if a video of the desired video is not found, look for a video of lower quality
- fixed inside-gaming section
- added pages instead of only listing the first 30 items
- removed game attack
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0