### PR TITLE
[plugin.video.roosterteeth] 1.3.11

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.3.10"
+       version="1.3.11"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.14.0"/>
@@ -23,13 +23,10 @@
     <forum>http://forum.kodi.tv/showthread.php?tid=235071</forum>
     <website>http://roosterteeth.com</website>
     <email></email>
+    <broken>making version 1.4.1 for leia. It uses adaptive inputstream and that is not available in gotham</broken>
     <source>https://github.com/skipmodea1/plugin.video.roosterteeth</source>
-    <news>1.3.10 (2019-03-13)
-    - fixed videos
-    - removed the know channel
-    - added inside gaming channel
-    - added kinda funny channel
-    - removed youtube dependency
+    <news>1.3.11 (2019-06-09)
+    - marking the addon broken for gotham. A working version will be available in Leia (Kodi 18)
     </news>
   </extension>
 </addon>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,6 @@
+1.3.11 (2019-06-09)
+- marking the addon broken for gotham. A working version will be available in Leia (Kodi 18)
+
 1.3.10 (2019-03-13)
 - fixed videos
 - removed the know channel

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -39,8 +39,8 @@ VQ480P = '480p'
 VQ360P = '360p'
 VQ240P = '240p'
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2019-03-13"
-VERSION = "1.3.10"
+DATE = "2019-06-09"
+VERSION = "1.3.11"
 
 
 if sys.version_info[0] > 2:


### PR DESCRIPTION
### Description
1.3.11 (2019-06-09)
- marking the addon broken for gotham. A working version will be available in Leia (Kodi 18)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0