### PR TITLE
[plugin.video.glwiz] v1.1.4 deprecated, no longer maintained.

### DIFF
--- a/plugin.video.glwiz/addon.xml
+++ b/plugin.video.glwiz/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.glwiz"
        name="GLWiZ"
-       version="1.1.3"
+       version="1.1.4"
        provider-name="babak">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
@@ -16,5 +16,6 @@
     <description>GLWiZ Addon for XBMC</description>
     <platform>all</platform>
     <language>fa az hy tr</language>
+    <broken>deprecated, no longer maintained</broken>
   </extension>
 </addon>


### PR DESCRIPTION
### Description
Marking the plugin as broken as I can no longer maintain it.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
