### PR TITLE
Make git work again with CRLF files in repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # This ensures that all files that git considers to be text will have
 # normalized (LF) line endings in the repository
-* text=auto
+# * text=auto
 
 # Make sure those files will not be modified
 *.png binary


### PR DESCRIPTION
### Description
This doesn't do what it promises to do. Various files are being checked-in using CRLF line-endings and it isn't enforced. And as long as we don't enforce this through CI checks, this only hurts developers that do have a Git client that honors `.gitattributes`.
https://stackoverflow.com/questions/19151789/git-complains-about-randomly-changed-files-when-switching-branches