### PR TITLE
[plugin.video.southpark_unofficial] 0.5.5

### DIFF
--- a/plugin.video.southpark_unofficial/addon.xml
+++ b/plugin.video.southpark_unofficial/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.5.4" provider-name="Deroad">
+<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.5.5" provider-name="Deroad">
     <requires>
         <import addon="xbmc.python" version="2.19.0"/>
     </requires>

--- a/plugin.video.southpark_unofficial/changelog.txt
+++ b/plugin.video.southpark_unofficial/changelog.txt
@@ -1,3 +1,5 @@
+0.5.5
+- fixed issue with Debian buster (Kodi 17.6) missing xbmcgui.ListItem.setIsFolder method. 
 0.5.4
 - Added southparkstudios.co.uk and fixed issue with season 23 on southparkstudios.nu and video playback on southpark.de
 0.5.3

--- a/plugin.video.southpark_unofficial/southpark.py
+++ b/plugin.video.southpark_unofficial/southpark.py
@@ -20,6 +20,8 @@ else:
 	from urllib2 import Request, urlopen
 	from urllib import unquote_plus, quote_plus
 
+KODI_VERSION_MAJOR = int(xbmc.getInfoLabel('System.BuildVersion')[0:2])
+
 USER_AGENT = 'Mozilla/5.0 (Windows NT 6.1; rv:25.0) Gecko/20100101 Firefox/25.0'
 WARNING_TIMEOUT_LONG  = 7000
 WARNING_TIMEOUT_SHORT = 3000
@@ -593,7 +595,8 @@ class SouthParkAddon(object):
 		u = self.argv[0]+"?url="+quote_plus(url)+"&mode="+str(mode)
 		ok = True
 		liz = xbmcgui.ListItem(name)
-		liz.setIsFolder(True)
+		if KODI_VERSION_MAJOR > 17:
+			liz.setIsFolder(True)
 		liz.setArt({'icon': iconimage, 'thumb': iconimage})
 		liz.setInfo(type="Video", infoLabels={"Title": name})
 		liz.setProperty("fanart_image", self.paths.DEFAULT_FANART)
@@ -610,7 +613,8 @@ class SouthParkAddon(object):
 		convdate  = _date(date)
 		is_folder = not is_playable
 		entry = xbmcgui.ListItem(name)
-		entry.setIsFolder(is_folder)
+		if KODI_VERSION_MAJOR > 17:
+			entry.setIsFolder(is_folder)
 		entry.setArt({'thumb': iconimage})
 		entry.setInfo(type="Video", infoLabels={"Title": name, "Plot": desc, "Season": season, "Episode": episode, "Aired": convdate})
 		entry.setProperty("fanart_image", self.paths.DEFAULT_FANART)


### PR DESCRIPTION
### Description
fixed issue with Debian buster (Kodi 17.6) missing xbmcgui.ListItem.setIsFolder method.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
