### PR TITLE
[plugin.video.southpark_unofficial] 0.5.6

### DIFF
--- a/plugin.video.southpark_unofficial/addon.xml
+++ b/plugin.video.southpark_unofficial/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.5.5" provider-name="Deroad">
+<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.5.6" provider-name="Deroad">
     <requires>
         <import addon="xbmc.python" version="2.19.0"/>
     </requires>

--- a/plugin.video.southpark_unofficial/changelog.txt
+++ b/plugin.video.southpark_unofficial/changelog.txt
@@ -1,3 +1,5 @@
+0.5.6
+- fixed issue with Kodi 16.
 0.5.5
 - fixed issue with Debian buster (Kodi 17.6) missing xbmcgui.ListItem.setIsFolder method. 
 0.5.4

--- a/plugin.video.southpark_unofficial/southpark.py
+++ b/plugin.video.southpark_unofficial/southpark.py
@@ -10,7 +10,8 @@ import xbmcgui
 import xbmcaddon
 import xml.etree.ElementTree as ET
 
-IS_PY3 = sys.version_info.major > 2
+# .major cannot be used in older versions, like kodi 16.
+IS_PY3 = sys.version_info[0] > 2
 
 if IS_PY3:
 	from urllib.request import Request
@@ -73,6 +74,8 @@ def _premier_timeout(premiere):
 	days = int(diff / 86400)
 	hours = int((diff % 86400) / 3600)
 	mins =  int((diff % 3600) / 60)
+	if KODI_VERSION_MAJOR < 17:
+		return "%02dd %02dh %02dm".format(days, hours, mins)
 	return "{:02d}d {:02d}h {:02d}m".format(days, hours, mins)
 
 def log_debug(message):


### PR DESCRIPTION
### Description

Fixed issue with Kodi 16 and Python 2.x

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
