### PR TITLE
[plugin.video.themoviedb.helper] 1.0.5

### DIFF
--- a/plugin.video.themoviedb.helper/addon.xml
+++ b/plugin.video.themoviedb.helper/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.themoviedb.helper"
-version="1.0.4"
+version="1.0.5"
 name="TheMovieDb Helper"
 provider-name="jurialmunkey">
 <requires>
@@ -23,5 +23,6 @@ provider-name="jurialmunkey">
     <screenshot>resources/screenshot-01.jpg</screenshot>
     <screenshot>resources/screenshot-02.jpg</screenshot>
   </assets>
+  <news>1.0.5 - Fix for python text encoding/decoding issues in both PY2 and PY3</news>
 </extension>
 </addon>

--- a/plugin.video.themoviedb.helper/resources/lib/container.py
+++ b/plugin.video.themoviedb.helper/resources/lib/container.py
@@ -33,7 +33,7 @@ _koditvshowdb = KodiLibrary(dbtype='tvshow')
 
 class Container(object):
     def __init__(self):
-        self.paramstring = sys.argv[2][1:]
+        self.paramstring = sys.argv[2][1:] if sys.version_info.major == 3 else sys.argv[2][1:].decode("utf-8")
         self.params = dict(parse_qsl(self.paramstring))
         self.plugincategory = 'TMDb Helper'
         self.containercontent = ''

--- a/plugin.video.themoviedb.helper/resources/lib/requestapi.py
+++ b/plugin.video.themoviedb.helper/resources/lib/requestapi.py
@@ -120,11 +120,11 @@ class RequestAPI(object):
         request = self.req_api_url
         for arg in args:
             if arg:  # Don't add empty args
-                request = '{0}/{1}'.format(request, arg)
-        request = '{0}{1}'.format(request, self.req_api_key)
+                request = u'{0}/{1}'.format(request, arg)
+        request = u'{0}{1}'.format(request, self.req_api_key)
         for key, value in kwargs.items():
             if value:  # Don't add empty kwargs
-                request = '{0}&{1}={2}'.format(request, key, value)
+                request = u'{0}&{1}={2}'.format(request, key, value)
         return request
 
     def get_request_sc(self, *args, **kwargs):

--- a/plugin.video.themoviedb.helper/resources/lib/utils.py
+++ b/plugin.video.themoviedb.helper/resources/lib/utils.py
@@ -1,3 +1,4 @@
+import sys
 import xbmc
 import xbmcgui
 import xbmcaddon
@@ -62,10 +63,11 @@ def age_difference(birthday, deathday=''):
 
 
 def kodi_log(value, level=0):
+    logvalue = u'{0}{1}'.format(_addonlogname, value) if sys.version_info.major == 3 else u'{0}{1}'.format(_addonlogname, value).encode('utf-8', 'ignore')
     if level == 1:
-        xbmc.log('{0}{1}'.format(_addonlogname, value), level=xbmc.LOGNOTICE)
+        xbmc.log(logvalue, level=xbmc.LOGNOTICE)
     else:
-        xbmc.log('{0}{1}'.format(_addonlogname, value), level=xbmc.LOGDEBUG)
+        xbmc.log(logvalue, level=xbmc.LOGDEBUG)
 
 
 def dictify(r, root=True):


### PR DESCRIPTION
### Description
Fixes some string encoding/decoding errors for diacritics in infolabels passed to plugin paramstring.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
