### PR TITLE
[plugin.video.mdrmediathek] 1.1.2

### DIFF
--- a/plugin.video.mdrmediathek/addon.xml
+++ b/plugin.video.mdrmediathek/addon.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.mdrmediathek" name="MDR Mediathek" version="1.0.0" provider-name="membrane">
+<addon id="plugin.video.mdrmediathek" name="MDR Mediathek" version="1.1.2" provider-name="sarbes">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
-		<import addon="script.module.libmdr" version="1.0.0"/>
+		<import addon="script.module.libmdr" version="1.1.2"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>
     </extension>
     <extension point="xbmc.addon.metadata">
+        <broken>Content mirgrated to the ARD Mediathek.</broken>
         <platform>all</platform>
 		<language>de</language>
 		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>


### PR DESCRIPTION
### Description
The PR marks the add-on as broken. The content is now included in the ARD Mediathek.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
