### PR TITLE
[plugin.video.zoneminder] 2.0.1

### DIFF
--- a/plugin.video.zoneminder/README.md
+++ b/plugin.video.zoneminder/README.md
@@ -3,5 +3,5 @@ plugin.video.zoneminder
 
 - ZoneMinder plugin for Kodi 17+
 - View live stream of cameras
-- Requires Zoneminder API
+- Requires Zoneminder API 1.32+
 - Supports username/password authentication

--- a/plugin.video.zoneminder/addon.xml
+++ b/plugin.video.zoneminder/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.zoneminder" name="ZoneMinder" version="2.0.0" provider-name="Peter Gallagher">
+<addon id="plugin.video.zoneminder" name="ZoneMinder" version="2.0.1" provider-name="Peter Gallagher">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.3.0"/>

--- a/plugin.video.zoneminder/changelog.txt
+++ b/plugin.video.zoneminder/changelog.txt
@@ -1,0 +1,6 @@
+v2.0.1 (2019-11-04)
+- Allow modification of cgi-bin path, requires change to base URL
+- Support ZM v1.34 API
+
+v2.0.0 (2019-01-17)
+- initial version

--- a/plugin.video.zoneminder/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.zoneminder/resources/language/resource.language.en_gb/strings.po
@@ -42,7 +42,11 @@ msgid "Frames per second (max)"
 msgstr ""
 
 msgctxt "#31006"
-msgid "Default View"
+msgid "ZM path"
+msgstr ""
+
+msgctxt "#31007"
+msgid "CGI Path"
 msgstr ""
 
 #

--- a/plugin.video.zoneminder/resources/settings.xml
+++ b/plugin.video.zoneminder/resources/settings.xml
@@ -1,10 +1,11 @@
 <settings>
  <category label="31000">
-  <setting id="base_url" type="text" label="31001" default="http://zmhost:8080/zm"/>
+  <setting id="base_url" type="text" label="31001" default="http://zmhost:8080"/>
+  <setting id="zm_path" type="text" label="31006" default="zm" />
+  <setting id="cgi_path" type="text" label="31007" default="zm/cgi-bin" />
   <setting id="is_authenticated" type="bool" label="31002" default="false"/>
   <setting id="username" type="text" label="31003" default="admin" enable="eq(-1,true)"/>
   <setting id="password" type="text" label="31004" default="admin" enable="eq(-2,true)" option="hidden" />
   <setting id="fps" type="labelenum" label="31005" default="30" values="1|2|5|10|15|20|25|30|50"/>
-  <!-- <setting id="default_view" type="labelenum" label="31006"  lvalues="32000|32001|32002"/> -->
  </category>
 </settings>

--- a/plugin.video.zoneminder/zoneminder.py
+++ b/plugin.video.zoneminder/zoneminder.py
@@ -23,6 +23,8 @@ _handle = int(sys.argv[1])
 _addon = xbmcaddon.Addon()
 _language = _addon.getLocalizedString
 _base_url = _addon.getSetting('base_url').strip()
+_zm_path = _addon.getSetting('zm_path').strip()
+_cgi_path = _addon.getSetting('cgi_path').strip()
 _auth_token = None
 _auth_cookies = None
 
@@ -56,10 +58,11 @@ def error_message(message, title='Error'):
     xbmcgui.Dialog().ok(title, message)
 
 def login ():
-    login_url = '{base_url}/api/host/login.json'.format(base_url=_base_url)
+    login_url = '{base_url}/{zm_path}/api/host/login.json'.format(base_url=_base_url, zm_path=_zm_path)
     creds = {
                 'user': _addon.getSetting('username').strip(),
-                'pass': _addon.getSetting('password').strip()
+                'pass': _addon.getSetting('password').strip(),
+                'stateful': 1
             }
     try:
         r = requests.post(login_url, data=creds)
@@ -78,7 +81,7 @@ def login ():
 
 def get_active_monitors ():
     # Get monitors from Zoneminder API
-    monitors_url = '{base_url}/api/monitors.json'.format(base_url=_base_url)
+    monitors_url = '{base_url}/{zm_path}/api/monitors.json'.format(base_url=_base_url, zm_path=_zm_path)
     r = requests.get(monitors_url, cookies=_auth_cookies)
     # Parse JSON response
     j = json.loads(r.text)
@@ -94,8 +97,9 @@ def get_active_monitors ():
         active_monitor = dict()
         active_monitor['id'] = monitor['Id']
         active_monitor['name'] = monitor['Name']
-        active_monitor['video'] = '{base_url}/cgi-bin/nph-zms?scale=auto&width={width}&height={height}&mode=jpeg&maxfps={fps}&monitor={monitor_id}&{auth}'.format( 
+        active_monitor['video'] = '{base_url}/{cgi_path}/nph-zms?scale=auto&width={width}&height={height}&mode=jpeg&maxfps={fps}&monitor={monitor_id}&{auth}'.format( 
             base_url=_base_url,
+            cgi_path=_cgi_path,
             width=monitor['Width'],
             height=monitor['Height'],
             fps=_addon.getSetting('fps'),
@@ -103,8 +107,9 @@ def get_active_monitors ():
             auth=_auth_token
             )
         
-        active_monitor['thumb'] = '{base_url}/cgi-bin/nph-zms?scale=auto&width={width}&height={height}&mode=single&maxfps={fps}&monitor={monitor_id}&{auth}'.format( 
+        active_monitor['thumb'] = '{base_url}/{cgi_path}/nph-zms?scale=auto&width={width}&height={height}&mode=single&maxfps={fps}&monitor={monitor_id}&{auth}'.format( 
             base_url=_addon.getSetting('base_url'),
+            cgi_path=_cgi_path,
             width=monitor['Width'],
             height=monitor['Height'],
             fps=_addon.getSetting('fps'),


### PR DESCRIPTION
### Description
Update ZoneMinder plugin to allow users to modify the cgi-bin path. The RedHat version of ZoneMinder uses a different path from other distros so we need to make an option for this.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
