### PR TITLE
[plugin.video.pcloud-video-streaming] 1.3.2

### DIFF
--- a/plugin.video.pcloud-video-streaming/addon.xml
+++ b/plugin.video.pcloud-video-streaming/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.3.1" provider-name="Guido Domenici">
+<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.3.2" provider-name="Guido Domenici">
   <requires>
     <import addon="xbmc.python" version="2.19.0"/>
   </requires>

--- a/plugin.video.pcloud-video-streaming/changelog.txt
+++ b/plugin.video.pcloud-video-streaming/changelog.txt
@@ -1,3 +1,6 @@
+v1.3.2 -- 26-Nov-2019
+- Fixed issue #23: fixed crash on Android and Mac when performing first network operation, on Kodi 18.
+
 v1.3.1 -- 24-Nov-2019
 - Removed superfluous files.
 

--- a/plugin.video.pcloud-video-streaming/resources/lib/pcloudapi.py
+++ b/plugin.video.pcloud-video-streaming/resources/lib/pcloudapi.py
@@ -78,10 +78,18 @@ class PCloudApi:
 		if data is not None:
 			requestData = data.encode('utf-8')
 			method = 'POST'
-		httpRequest = Request(
-			url,
-			data=requestData,
-			method=method)
+		if sys.version_info.major >= 3:
+			# Python 3 stuff
+			httpRequest = Request(
+				url,
+				data=requestData,
+				method=method)
+		else:
+			# Python 2 stuff. Request for Python 2 (at least on Android) does not
+			# support the "method" keyword.
+			httpRequest = Request(
+				url,
+				data=requestData)			
 		response = self.HttpHandler.open(httpRequest)
 		responseStr = response.read().decode('utf-8')
 		self.HttpHandler.close()


### PR DESCRIPTION
### Description
Fixed issue #23: fixed crash on Android and Mac when performing first network operation, on Kodi 18.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
