### PR TITLE
[plugin.video.conversasabenfica] 1.1.0

### DIFF
--- a/plugin.video.conversasabenfica/README.md
+++ b/plugin.video.conversasabenfica/README.md
@@ -1,0 +1,18 @@
+# plugin.video.conversasabenfica
+
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/f01123e9b0984c39bfe7bb68fc0dd031)](https://www.codacy.com/app/92enen/plugin.video.conversasabenfica?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=enen92/plugin.video.conversasabenfica&amp;utm_campaign=Badge_Grade)
+
+![logo](https://s1.postimg.org/6lp9ovlq7/conversasbenfica.png)
+
+Watch Conversas à Benfica, a youtube podcast made by Benfica fans for Benfica fans
+
+### Screenshots
+
+![screen1](https://github.com/enen92/plugin.video.conversasabenfica/raw/master/resources/images/screenshot-1.png)
+
+![screen2](https://github.com/enen92/plugin.video.conversasabenfica/raw/master/resources/images/screenshot-2.png)
+
+![screen3](https://github.com/enen92/plugin.video.conversasabenfica/raw/master/resources/images/screenshot-3.png)
+
+![screen4](https://github.com/enen92/plugin.video.conversasabenfica/raw/master/resources/images/screenshot-4.png)
+

--- a/plugin.video.conversasabenfica/addon.xml
+++ b/plugin.video.conversasabenfica/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.conversasabenfica" name="Conversas à Benfica" version="1.0.0" provider-name="enen92">
+<addon id="plugin.video.conversasabenfica" name="Conversas à Benfica" version="1.1.0" provider-name="enen92">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="script.module.requests" version="2.12.4"/>
+        <import addon="script.module.requests" version="2.22.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
@@ -20,8 +20,7 @@
         <website>https://www.youtube.com/channel/UCpWxnp_Pe3PlJYBFeMIvitA</website>
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.conversasabenfica</source>
-        <news>The first version of the addon</news>
-        <disclaimer></disclaimer>
+        <news>Support for python3</news>
         <assets>
             <icon>resources/images/icon.png</icon>
             <fanart>resources/images/fanart.jpg</fanart>

--- a/plugin.video.conversasabenfica/changelog.txt
+++ b/plugin.video.conversasabenfica/changelog.txt
@@ -1,2 +1,0 @@
-v1.0.0
-- The first version of the addon

--- a/plugin.video.conversasabenfica/resources/language/README.md
+++ b/plugin.video.conversasabenfica/resources/language/README.md
@@ -1,0 +1,1 @@
+This folder will be the home of your translations

--- a/plugin.video.conversasabenfica/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.conversasabenfica/resources/language/resource.language.en_gb/strings.po
@@ -16,8 +16,6 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#This is a comment
-
 msgctxt "#32000"
 msgid "All videos"
 msgstr ""
@@ -52,4 +50,8 @@ msgstr ""
 
 msgctxt "#32008"
 msgid "Next page"
+msgstr ""
+
+msgctxt "#32009"
+msgid "General"
 msgstr ""

--- a/plugin.video.conversasabenfica/resources/language/resource.language.pt_pt/strings.po
+++ b/plugin.video.conversasabenfica/resources/language/resource.language.pt_pt/strings.po
@@ -16,8 +16,6 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#This is a comment
-
 msgctxt "#32000"
 msgid "All videos"
 msgstr "Todos os vídeos"
@@ -54,4 +52,6 @@ msgctxt "#32008"
 msgid "Next page"
 msgstr "Próxima página"
 
-
+msgctxt "#32009"
+msgid "General"
+msgstr "Geral"

--- a/plugin.video.conversasabenfica/resources/lib/kodiutils.py
+++ b/plugin.video.conversasabenfica/resources/lib/kodiutils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import sys
 import xbmc
 import xbmcaddon
 import xbmcgui
@@ -9,6 +10,7 @@ import json as json
 ADDON = xbmcaddon.Addon()
 ADDON_ID = ADDON.getAddonInfo("id")
 
+PY3 = sys.version_info.major >= 3
 
 def notification(header, message, time=5000, icon=ADDON.getAddonInfo('icon'), sound=True):
     xbmcgui.Dialog().notification(header, message, icon, time, sound)
@@ -29,6 +31,8 @@ def log(message,level):
 
 
 def get_setting(setting):
+    if PY3:
+        return ADDON.getSetting(setting).strip()
     return ADDON.getSetting(setting).strip().decode('utf-8')
 
 
@@ -55,6 +59,8 @@ def get_setting_as_int(setting):
 
 
 def get_string(string_id):
+    if PY3:
+        return ADDON.getLocalizedString(string_id)
     return ADDON.getLocalizedString(string_id).encode('utf-8', 'ignore')
 
 

--- a/plugin.video.conversasabenfica/resources/lib/plugin.py
+++ b/plugin.video.conversasabenfica/resources/lib/plugin.py
@@ -32,9 +32,9 @@ def index():
 @plugin.route('/videos')
 def all_videos():
     #grab kwargs
-    page_num = int(plugin.args["page"][0]) if "page" in plugin.args.keys() else 1
-    token = plugin.args["token"][0] if "token" in plugin.args.keys() else ""
-    playlist = plugin.args["playlist"][0] if "playlist" in plugin.args.keys() else "all"
+    page_num = int(plugin.args["page"][0]) if "page" in list(plugin.args.keys()) else 1
+    token = plugin.args["token"][0] if "token" in list(plugin.args.keys()) else ""
+    playlist = plugin.args["playlist"][0] if "playlist" in list(plugin.args.keys()) else "all"
     upload_playlist = youtubelib.get_upload_playlist() if playlist == "all" else playlist
 
     for liz in youtubelib.get_videos(playlist, upload_playlist, token, page_num):

--- a/plugin.video.conversasabenfica/resources/lib/youtubelib.py
+++ b/plugin.video.conversasabenfica/resources/lib/youtubelib.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import requests
-import kodiutils
-import addonutils
 import xbmc
 import math
 import re
 import xbmcaddon
 from xbmcgui import ListItem
+
+from resources.lib import kodiutils, addonutils
 
 CHANNEL_ID = kodiutils.get_setting("channel_id")
 YOUTUBE_API_KEY = kodiutils.get_setting("api_key")
@@ -21,7 +21,7 @@ def get_playlists():
         resp = requests.get(api_endpoint).json()
     except ValueError:
         kodiutils.log(kodiutils.get_string(32003), xbmc.LOGERROR)
-    if "items" in resp.keys():
+    if "items" in list(resp.keys()):
         for playlist in resp["items"]:
             liz = ListItem(playlist["snippet"]["title"])
             infolabels = {"plot": playlist["snippet"]["localized"]["description"]}
@@ -39,7 +39,7 @@ def get_upload_playlist():
     except ValueError:
         kodiutils.log(kodiutils.get_string(32004), xbmc.LOGERROR)
         return None
-    if "items" in resp.keys():
+    if "items" in list(resp.keys()):
         uploads_playlist = resp["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
         return uploads_playlist
 
@@ -57,8 +57,8 @@ def get_videos(name,playlist_id,token="",page_num=1):
         resp = None
 
     if resp:
-        nextpagetoken = resp["nextPageToken"] if "nextPageToken" in resp.keys() else ""
-        availablevideos = resp["pageInfo"]["totalResults"] if "pageInfo" in resp.keys() and "totalResults" in resp["pageInfo"].keys() else 1
+        nextpagetoken = resp["nextPageToken"] if "nextPageToken" in list(resp.keys()) else ""
+        availablevideos = resp["pageInfo"]["totalResults"] if "pageInfo" in list(resp.keys()) and "totalResults" in list(resp["pageInfo"].keys()) else 1
 
         returnedVideos = resp["items"]
         totalpages = int(math.ceil((float(availablevideos) / items_per_page)))

--- a/plugin.video.conversasabenfica/resources/settings.xml
+++ b/plugin.video.conversasabenfica/resources/settings.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <setting id="enter_all_videos" type="bool" label="32007" default="false" />
-    <setting id="items_per_page" type="slider" label="32006" default="25" range="0,50" />
-    <setting id="api_key" type="text" default="AIzaSyAxaHJTQ5zgh86wk7geOwm-y0YyNMcEkSc" visible="false"/>
-    <setting id="channel_id" type="text" default="UCpWxnp_Pe3PlJYBFeMIvitA" visible="false"/>
+    <category label="32009">
+        <setting id="enter_all_videos" type="bool" label="32007" default="false" />
+        <setting id="items_per_page" type="slider" label="32006" default="25" range="0,50" />
+        <setting id="api_key" type="text" default="AIzaSyAxaHJTQ5zgh86wk7geOwm-y0YyNMcEkSc" visible="false"/>
+        <setting id="channel_id" type="text" default="UCpWxnp_Pe3PlJYBFeMIvitA" visible="false"/>
+    </category>
 </settings>
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Conversas à Benfica
  - Add-on ID: plugin.video.conversasabenfica
  - Version number: 1.1.0
  - Kodi/repository version: krypton

- **Code location**
  - URL: 
  
Conversas à Benfica... Easy![CR]For the ones who love Benfica and (almost) everything around it.[CR]Everything related with the played football and the stands.[CR]History, laughs and beers![CR]ONE LIFE, ONE GAME!

### Description of changes:

Support for python3

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
