### PR TITLE
[plugin.video.svtplay] 5.1.4

### DIFF
--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.3">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.4">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="2.25.0" />
@@ -19,10 +19,7 @@
     <source>https://github.com/nilzen/xbmc-svtplay</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=67110</forum>
     <news>
-- "Go to show" is now available in the context menu for a video item in Popular, Last Chance
-Keyboard button "c" opens the context menu.
-Contribution by bohmandan
-- Better fanart images for episodes.
+- Movie items in "Programs A-Z" are now playable again
 - Please report any issues in the Github tracker
     </news>
     <assets>

--- a/plugin.video.svtplay/resources/lib/listing/router.py
+++ b/plugin.video.svtplay/resources/lib/listing/router.py
@@ -107,9 +107,11 @@ class Router:
                 continue
             folder = True
             mode = self.common.MODE_PROGRAM
+            info = {}
             if program["type"] == "video":
                 mode = self.common.MODE_VIDEO
                 folder = False
+                info["title"] = program["title"] # Needed for now to trigger xbmcgui.ListItem::setInfo which makes the video playable
             self.common.add_directory_item(
                 program["title"],
                 {
@@ -117,7 +119,8 @@ class Router:
                     "url": program["url"]
                 },
                 thumbnail=program["thumbnail"],
-                folder=folder
+                folder=folder,
+                info=info
             )
 
     def view_categories(self):


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Quick bug fix for unplayable items.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
