### PR TITLE
[plugin.video.dumpert] 1.1.10

### DIFF
--- a/plugin.video.dumpert/addon.xml
+++ b/plugin.video.dumpert/addon.xml
@@ -2,7 +2,7 @@
 <addon
 	id="plugin.video.dumpert"
 	name="Dumpert"
-	version="1.1.9"
+	version="1.1.10"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.20.0"/>

--- a/plugin.video.dumpert/changelog.txt
+++ b/plugin.video.dumpert/changelog.txt
@@ -1,3 +1,8 @@
+v1.1.10 (2019-12-12) (thanks for the help Nixxor)
+- Removed Top as it is basically the same as Daily Top
+- Using different url for DumpertTV so that most recent items are at the top of the list
+- Moved DumpertTV up in the main list
+
 v1.1.9 (2019-09-19) (thanks for the help NightFox89)
 - MAJOR changes in the addon due to redesigned website
 - updated logos

--- a/plugin.video.dumpert/resources/lib/dumpert_const.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_const.py
@@ -16,7 +16,7 @@ LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon(id=ADDON).getAddonInfo('path'), 'resources', 'images')
 LATEST_URL = "https://api-live.dumpert.nl/mobile_api/json/video/latest/0/"
 TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/toppers/0/"
-DUMPERT_TV_URL = "https://api-live.dumpert.nl/mobile_api/json/search/dumperttv/0/"
+DUMPERT_TV_URL = "https://api.dumpert.nl/mobile_api/json/dumperttv/0/"
 SEARCH_URL = "https://api-live.dumpert.nl/mobile_api/json/search/"
 DAY_TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/top5/dag/"
 WEEK_TOPPERS_URL = "https://api-live.dumpert.nl/mobile_api/json/video/top5/week/"
@@ -29,8 +29,8 @@ MONTH = "month"
 VIDEO_QUALITY_MOBILE = "mobile"
 VIDEO_QUALITY_TABLET = "tablet"
 VIDEO_QUALITY_720P = "720p"
-DATE = "2019-09-19"
-VERSION = "1.1.9"
+DATE = "2019-12-14"
+VERSION = "1.1.10"
 
 
 if sys.version_info[0] > 2:

--- a/plugin.video.dumpert/resources/lib/dumpert_main.py
+++ b/plugin.video.dumpert/resources/lib/dumpert_main.py
@@ -37,14 +37,13 @@ class Main(object):
                       "next_page_possible": "True"}
         self.add_dir(parameters, title)
 
-
         #
-        # Toppers
+        # Dumpert TV
         #
-        title = LANGUAGE(30000)
+        title = LANGUAGE(30007)
         parameters = {"action": "json",
                       "plugin_category": title,
-                      "url": TOPPERS_URL,
+                      "url": DUMPERT_TV_URL,
                       "next_page_possible": "True"}
         self.add_dir(parameters, title)
 
@@ -87,16 +86,6 @@ class Main(object):
         title = LANGUAGE(30005)
         parameters = {"action": "timemachine",
                       "plugin_category": title,
-                      "next_page_possible": "True"}
-        self.add_dir(parameters, title)
-
-        #
-        # Dumpert TV
-        #
-        title = LANGUAGE(30007)
-        parameters = {"action": "json",
-                      "plugin_category": title,
-                      "url": DUMPERT_TV_URL,
                       "next_page_possible": "True"}
         self.add_dir(parameters, title)
 


### PR DESCRIPTION
### Description
v1.1.10 (2019-12-12) (thanks for the help Nixxor)
- Removed Top as it is basically the same as Daily Top
- Using different url for DumpertTV so that most recent items are at the top of the list
- Moved DumpertTV up in the main list

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0