### PR TITLE
[plugin.audio.deejayIt.reloaded] 1.6.3 - broken

### DIFF
--- a/plugin.audio.deejayIt.reloaded/addon.xml
+++ b/plugin.audio.deejayIt.reloaded/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.deejayIt.reloaded" name="DeeJay reloaded" version="1.6.2" provider-name="Filippo Carra">
+<addon id="plugin.audio.deejayIt.reloaded" name="DeeJay reloaded" version="1.6.3" provider-name="Filippo Carra">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.beautifulsoup" version="3.2.1"/>
@@ -23,5 +23,6 @@
         <website>https://github.com/karrukola/plugin.audio.deejayIt.reloaded</website>
         <email>Filippo dot Carra at gMail dot com</email>
         <source>https://github.com/karrukola/plugin.audio.deejayIt.reloaded.git</source>
+        <broken>Website has substantially changed.</broken>
     </extension>
 </addon>

--- a/plugin.audio.deejayIt.reloaded/changelog.txt
+++ b/plugin.audio.deejayIt.reloaded/changelog.txt
@@ -1,3 +1,5 @@
+[B]1.6.3[/B]
+- Deprecating
 [B]1.6.2[/B]
 - Fixing issue #16
 - Code cleanup


### PR DESCRIPTION
### Description
Plugin update: marking as broken, to be then removed from repository. A new version will come from a different repository.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
