### PR TITLE
[plugin.library.node.editor] 1.0.11

### DIFF
--- a/plugin.library.node.editor/addon.xml
+++ b/plugin.library.node.editor/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.library.node.editor" name="Library Node Editor" version="1.0.10" provider-name="Unfledged, Team-Kodi">
+<addon id="plugin.library.node.editor" name="Library Node Editor" version="1.0.11" provider-name="Unfledged, Team-Kodi">
     <requires>
 		<import addon="xbmc.python" version="2.25.0"/>
 		<import addon="script.module.unidecode" version="0.4.16"/>
@@ -41,7 +41,7 @@
 			<icon>icon.png</icon>
 		</assets>
 		<news>
-			1.0.10 (5/1/2020)
+			1.0.11 (7/1/2020)
 				- Fixes parent nodes
 		</news>
 	</extension>

--- a/plugin.library.node.editor/resources/lib/rules.py
+++ b/plugin.library.node.editor/resources/lib/rules.py
@@ -523,7 +523,7 @@ class RuleFunctions():
 
     #def editNodeRule( self, actionPath, originalRule, newRule ):
     def editNodeRule( self, actionPath, ruleNum, match, operator, value ):
-        ( filePath, fileName ) = os.path.split( actionPath )
+        ( filePath, fileName ) = os.path.split( unquote(actionPath) )
         # Update the rule in the rules file
         if self.ltype.startswith('video'):
             rulesfile = 'videorules.xml'


### PR DESCRIPTION
A small miss on the last update. Fixes operators and matches in parent nodes.