### PR TITLE
[plugin.video.pcloud-video-streaming] 1.4.0

### DIFF
--- a/plugin.video.pcloud-video-streaming/addon.py
+++ b/plugin.video.pcloud-video-streaming/addon.py
@@ -208,6 +208,8 @@ if mode[0] in ("folder", "myshares"):
 				[(deleteActionMenuText, "RunPlugin(" + deleteActionUrl + ")"),
 				(markAsWatchedMenuText, "Action(ToggleWatched)")]
 				)
+			# Set the date from what's stored in PCloud
+			li.setInfo('video', { 'date': pcloud.translateDate(oneFileOrFolderItem["modified"]) })
 			# Finally add the list item to the directory
 			if contentType[:6] == "image/":
 				fileUrl += "&isPicture=1" # We will need this info later on
@@ -239,6 +241,10 @@ if mode[0] in ("folder", "myshares"):
 		parentFolderText = "[I]{0}[/I]".format(myAddon.getLocalizedString(30123))
 		li = xbmcgui.ListItem(parentFolderText, iconImage="DefaultFolder.png")
 		xbmcplugin.addDirectoryItem(handle=addon_handle, url=url, listitem=li, isFolder=True)
+
+	# Add various sort methods
+	xbmcplugin.addSortMethod(handle=addon_handle, sortMethod=xbmcplugin.SORT_METHOD_LABEL)
+	xbmcplugin.addSortMethod(handle=addon_handle, sortMethod=xbmcplugin.SORT_METHOD_DATE)
 
 	xbmcplugin.endOfDirectory(addon_handle)
 	myAddon.setSetting("lastUsedFolderID", str(folderID))

--- a/plugin.video.pcloud-video-streaming/addon.xml
+++ b/plugin.video.pcloud-video-streaming/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.3.2" provider-name="Guido Domenici">
+<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.4.0" provider-name="Guido Domenici">
   <requires>
     <import addon="xbmc.python" version="2.19.0"/>
   </requires>

--- a/plugin.video.pcloud-video-streaming/changelog.txt
+++ b/plugin.video.pcloud-video-streaming/changelog.txt
@@ -1,3 +1,6 @@
+v1.4.0 -- 30-Jan-2020
+- Fixed issue #24: it is now possible to also sort by date.
+
 v1.3.2 -- 26-Nov-2019
 - Fixed issue #23: fixed crash on Android and Mac when performing first network operation, on Kodi 18.
 

--- a/plugin.video.pcloud-video-streaming/resources/lib/pcloudapi.py
+++ b/plugin.video.pcloud-video-streaming/resources/lib/pcloudapi.py
@@ -7,6 +7,8 @@ from .loginfailedexception import LoginFailedException
 import os
 import operator # it's for use sort with operator
 import sys
+import re
+from datetime import date
 if sys.version_info.major >= 3:
 	# Python 3 stuff
 	from urllib.parse import urlparse, urlencode
@@ -200,6 +202,21 @@ class PCloudApi:
 		if response["result"] != 0:
 			errorMessage = self.GetErrorMessage(response["result"])
 			raise Exception("Error calling deletefolderrecursive: " + errorMessage)
+
+	def translateDate(self, dateInPCloudFormat):
+		""" Translates a date from the PCloud format ("Thu, 19 Sep 2013 07:31:46 +0000") to
+		the Kodi format ("19.09.2013")
+		"""
+		match = re.search("^[A-Za-z]{3}, (\d{1,2}) ([A-Za-z]{3}) (\d{4})", dateInPCloudFormat)
+		if match is None or match.lastindex < 3:
+			return date.today().strftime("%d.%m.%Y")
+		# Group 1 is the day, group 2 is the month abbreviation, group 3 is the year
+		day = int(match.group(1))
+		monthDict = { "Jan": 1, "Feb": 2, "Mar": 3, "Apr": 4, "May": 5, "Jun": 6,
+			"Jul": 7, "Aug": 8, "Sep": 9, "Oct": 10, "Nov": 11, "Dec": 12  }
+		month = monthDict[match.group(2)]
+		year = int(match.group(3))
+		return date(year, month, day).strftime("%d.%m.%Y")
 
 #auth = PerformLogon("username@example.com", "password")
 #ListFolderContents("/Vcast")


### PR DESCRIPTION
### Description
* Fixed issue #24: it is now possible to also sort by date.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
