### PR TITLE
[plugin.audio.radio_de] 2.4.2

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="2.4.1">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="2.4.2">
     <requires>
         <import addon="xbmc.python" version="2.14.0" />
         <import addon="script.module.xbmcswift2" version="2.5.0" />
@@ -12,8 +12,10 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>v2.4.1 (31/12/2019)
-            [fix] Custom radio tracks
+        <news>v2.4.2 (9/2/2020)
+            [add] sort methods for categories
+            [add] setting to prefer http connections over https if http streams are available
+            [fix] use sys.version_info[0] for compatibility with python2.6
         </news>
         <summary lang="be">Access &gt;7000 radio broadcasts</summary>
         <summary lang="ca">accedeix a mes de 7000 emissores de radio</summary>

--- a/plugin.audio.radio_de/changelog.txt
+++ b/plugin.audio.radio_de/changelog.txt
@@ -1,3 +1,11 @@
+v2.4.2 (9/2/2020)
+    - [add] sort methods for categories
+    - [add] setting to prefer http connections over https if http streams are available
+    - [fix] use sys.version_info[0] for compatibility with python2.6
+
+v2.4.1 (31/12/2019)
+    - [fix] Custom radio tracks
+
 v2.4.0 (29/12/2019)
     - [new] Use radio API v2
     - [fix] Remove dead code

--- a/plugin.audio.radio_de/resources/language/English/strings.po
+++ b/plugin.audio.radio_de/resources/language/English/strings.po
@@ -139,3 +139,7 @@ msgstr ""
 msgctxt "#30606"
 msgid "By country"
 msgstr ""
+
+msgctxt "#30607"
+msgid "Prefer HTTP streams over HTTS"
+msgstr ""

--- a/plugin.audio.radio_de/resources/lib/plugin.py
+++ b/plugin.audio.radio_de/resources/lib/plugin.py
@@ -216,7 +216,12 @@ def show_genres():
                 value=__encode(genre["systemEnglish"])
             ),
         })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/stations/topics')
 def show_topics():
@@ -233,7 +238,12 @@ def show_topics():
                 value=__encode(topic["systemEnglish"])
             ),
         })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/stations/countries')
 def show_countries():
@@ -250,7 +260,12 @@ def show_countries():
                 value=__encode(country["systemEnglish"])
             ),
         })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/menu/languages')
 def show_languages():
@@ -267,7 +282,12 @@ def show_languages():
                 value=__encode(lang["systemEnglish"])
             ),
         })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/menu/cities')
 def show_cities_submenu():
@@ -283,7 +303,12 @@ def show_cities_submenu():
              'show_cities_list',
              option = 'az')}
     )
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/menu/cities/select/<option>')
 def show_cities_list(option):
@@ -313,7 +338,12 @@ def show_cities_list(option):
                     value = __encode(city["systemEnglish"]),
                 ),
             })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/menu/cities/list/<country>')
 def show_cities_by_country(country):
@@ -330,7 +360,12 @@ def show_cities_by_country(country):
                 value = __encode(city["systemEnglish"]),
             )
         })
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 
 @plugin.route('/menu/<category>/<value>')
@@ -353,7 +388,12 @@ def show_popular_and_az(category, value):
              value = value,
              page=1)}
     )
-    return plugin.finish(items)
+    finish_kwargs = {
+        'sort_methods': [
+            ('LABEL', '%X'),
+        ],
+    }
+    return plugin.finish(items, **finish_kwargs)
 
 @plugin.route('/stations/city/<city>/<option>/<page>')
 def list_stations_by_city(city, option, page=1):
@@ -439,20 +479,25 @@ def get_stream_url(station_id):
         stream_url = station['stream_url']
         current_track = ''
     else:
-        station = radio_api.get_station_by_station_id(station_id)
-        stream_url = station['stream_url']
-        current_track = station['current_track']
-    __log('get_stream_url result: %s' % stream_url)
-    return plugin.set_resolved_url(
-        listitem.ListItem(
-            label=station['name'],
-            label2=current_track,
-            path=stream_url,
-            icon=station['thumbnail'],
-            thumbnail=station['thumbnail'],
-            fanart=__get_plugin_fanart(),
+        station = radio_api.get_station_by_station_id(
+            station_id,
+            force_http=plugin.get_setting('prefer-http', bool)
         )
-    )
+        if station:
+            stream_url = station['stream_url']
+            current_track = station['current_track']
+    if station:
+        __log('get_stream_url result: %s' % stream_url)
+        return plugin.set_resolved_url(
+            listitem.ListItem(
+                label=station['name'],
+                label2=current_track,
+                path=stream_url,
+                icon=station['thumbnail'],
+                thumbnail=station['thumbnail'],
+                fanart=__get_plugin_fanart(),
+            )
+        )
 
 
 def __add_stations(stations, add_custom=False, browse_more=None):

--- a/plugin.audio.radio_de/resources/settings.xml
+++ b/plugin.audio.radio_de/resources/settings.xml
@@ -3,5 +3,6 @@
 	<category label="30601">
 		<setting id="language" type="enum" label="30300" lvalues="30301|30302|30303|30304" default="0" />
 		<setting id="hide-fanart" type="bool" label="30602" default="false"/>
+		<setting id="prefer-http" type="bool" label="30607" default="true"/>
 	</category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 2.4.2
  - Kodi/repository version: gotham

- **Code location**
  - URL: 
  
Music plugin to access over 7000 international radio broadcasts from rad.io, radio.de, radio.fr and radio.pt[CR]Currently features[CR]- English, german and french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

v2.4.2 (9/2/2020)
            [add] sort methods for categories
            [add] setting to prefer http connections over https if http streams are available
            [fix] use sys.version_info[0] for compatibility with python2.6
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
