### PR TITLE
[plugin.video.rtpplay] 5.0.4

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.3" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.4" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -21,7 +21,7 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Fix live
+            - Fix for some on-demand streams
         </news>
         <disclaimer lang="en_GB">The plugin is unnoficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <assets>

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -340,8 +340,8 @@ def programs_play():
 
     try:
         req = requests.get("https://www.rtp.pt" + url, headers=HEADERS)
-        req.encoding = "utf-8"
-        stream = re.search(r'"https://(.+?)ondemand.rtp.pt(.*)"', req.text)
+        req.encoding = "latin-1"
+        stream = re.search(r'"https://(.+?)ondemand.rtp.pt(.*?)"', req.text)
         stream = "https://" + stream.group(1) + "ondemand.rtp.pt" + stream.group(2)
     except:
         raise_notification()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.4
  - Kodi/repository version: krypton

- **Code location**
  - URL: 
  
Play live emissions from the RTP Play website

### Description of changes:


            - Fix for some on-demand streams
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
