### PR TITLE
[plugin.video.mediathek] mark krypton version of plugin.video.mediathak as broken.

### DIFF
--- a/plugin.video.mediathek/addon.xml
+++ b/plugin.video.mediathek/addon.xml
@@ -2,7 +2,7 @@
 <addon
   id="plugin.video.mediathek"
   name="Mediathek"
-  version="0.9.3"
+  version="0.9.4"
   provider-name="Raptor 2101">
   <requires>
    <import addon="xbmc.python" version="2.25.0"/>
@@ -37,6 +37,7 @@ Al momento sono supportate le seguenti emittenti:
     <website>https://github.com/raptor2101/Mediathek</website>
     <source>https://github.com/raptor2101/Mediathek</source>
     <email>raptor2101@gmx.de</email>
+    <broken>For updates of Mediathek, please upgrade to leia or above</broken>
     <assets>
         <icon>resources/icon.png</icon>
     </assets>


### PR DESCRIPTION
### Description
The development for plugin.video.mediathek in python2.x will be stopped from now on. A pull request for the python3 version (leia based) will follow up to this PR.

No code changes!
### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0