### PR TITLE
[plugin.video.hbogoeu] 2.3.10

### DIFF
--- a/plugin.video.hbogoeu/README.md
+++ b/plugin.video.hbogoeu/README.md
@@ -2,10 +2,10 @@
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/arvvoid/plugin.video.hbogoeu)](https://github.com/arvvoid/plugin.video.hbogoeu/blob/master/README.md#install-instructions) 
 [![Python Version](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue)](https://kodi.tv/article/attention-addon-developers-migration-python-3)
 [![Kodi Version](https://img.shields.io/badge/kodi-18%20or%20%2B-blue)](https://kodi.tv/)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/9ba05a937e1f498581ac06c2f23d2178)](https://www.codacy.com/manual/arvvoid/plugin.video.hbogoeu?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=arvvoid/plugin.video.hbogoeu&amp;utm_campaign=Badge_Grade)
 [![GitHub](https://img.shields.io/github/license/arvvoid/plugin.video.hbogoeu?style=flat)](https://opensource.org/licenses/gpl-2.0.php)
 [![Contributors](https://img.shields.io/github/contributors/arvvoid/plugin.video.hbogoeu.svg)](https://github.com/arvvoid/plugin.video.hbogoeu/graphs/contributors)
 [![All Contributors](https://img.shields.io/badge/all_contributors-29-orange.svg?style=flat-square)](#contributors-)
+[![HitCount](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu.svg)](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu)
 
 
 # Disclaimer

--- a/plugin.video.hbogoeu/addon.xml
+++ b/plugin.video.hbogoeu/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.3.9">
+<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.3.10">
   <requires>
     <import addon="xbmc.python" version="2.26.0" />
     <import addon="script.module.kodi-six" version="0.1.0" />
@@ -44,12 +44,7 @@ If an official app is available for your platform, use it instead of this.
     <source>https://github.com/arvvoid/plugin.video.hbogoeu</source>
     <website>https://arvvoid.github.io/plugin.video.hbogoeu</website>
     <news>
-- Update to hr_hr translation (by @arvvoid)
-- Update to hu_hu translation (by @Ajnasz)
-- Update to es_es translation (by @boblo1)
-- Update to ro_ro translation (by @tmihai20)
-- Update to fi_fi translation (by @jumakki)
-- Minor fixes
+- Fixed encoding error on opening search category
     </news>
     <assets>
      <icon>resources/icon.png</icon>

--- a/plugin.video.hbogoeu/hbogolib/handler.py
+++ b/plugin.video.hbogoeu/hbogolib/handler.py
@@ -527,8 +527,8 @@ class HbogoHandler(object):
         except ImportError:
             from urllib.parse import quote_plus as quote, urlencode  # noqa: F401
         self.reset_media_type_counters()
-        self.addCat(self.language(30734), "INTERNAL_SEARCH", self.get_media_resource('search.png'), HbogoConstants.ACTION_SEARCH)
-        self.addCat(self.language(30735), "DEL_SEARCH_HISTORY", self.get_media_resource('remove.png'), HbogoConstants.ACTION_SEARCH_CLEAR_HISTORY)
+        self.addCat(py2_encode(self.language(30734)), "INTERNAL_SEARCH", self.get_media_resource('search.png'), HbogoConstants.ACTION_SEARCH)
+        self.addCat(py2_encode(self.language(30735)), "DEL_SEARCH_HISTORY", self.get_media_resource('remove.png'), HbogoConstants.ACTION_SEARCH_CLEAR_HISTORY)
         history_items = self.get_search_history()
         for history_itm in history_items:
             tmp_url = '%s?%s' % (self.base_url, urlencode({


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: hGO EU
  - Add-on ID: plugin.video.hbogoeu
  - Version number: 2.3.10
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/arvvoid/plugin.video.hbogoeu
  

Simple, Kodi add-on to access HBO® Go EU content. (This add-on is not officially commissioned/supported by HBO®.)

Important, HBO® Go must be paid for!!!  You need a valid account!
Register on the official HBO® Go website for your region.

Read the disclaimer!

Curently support: Bosnia and Herzegovina, Bulgaria, Croatia, Czech Republic, Hungary, Macedonia, Montenegro, Polonia, Portugal, Romania, Serbia, Slovakia, Slovenija, Spain, Norway, Denmark, Sweden, Finland

To report bugs or request assistence with the add-on go to: https://github.com/arvvoid/plugin.video.hbogoeu
    

### Description of changes:


- Fixed encoding error on opening search category
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
