### PR TITLE
[plugin.video.rtpplay] 5.0.5

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.4" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.5" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -21,7 +21,7 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Fix for some on-demand streams
+            - Fix live and ondemand
         </news>
         <disclaimer lang="en_GB">The plugin is unnoficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <assets>

--- a/plugin.video.rtpplay/resources/lib/channels.py
+++ b/plugin.video.rtpplay/resources/lib/channels.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Mobile Safari/537.36"
-    #"Referer": "http://www.rtp.pt/play/"
+    "User-Agent": "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Mobile Safari/537.36",
+    "Referer": "https://www.rtp.pt/play/direto/",
 }
 
 RTP_CHANNELS = [

--- a/plugin.video.rtpplay/resources/lib/kodiutils.py
+++ b/plugin.video.rtpplay/resources/lib/kodiutils.py
@@ -10,6 +10,12 @@ import json as json
 
 PY3 =  sys.version_info > (3, 0)
 
+if PY3:
+    from html.parser import HTMLParser
+else:
+    from HTMLParser import HTMLParser
+
+
 # read settings
 ADDON = xbmcaddon.Addon()
 ICON = xbmc.translatePath(ADDON.getAddonInfo("icon"))
@@ -17,13 +23,31 @@ FANART = xbmc.translatePath(ADDON.getAddonInfo("fanart"))
 
 logger = logging.getLogger(__name__)
 
+
+class HTMLStripper(HTMLParser):
+    def __init__(self):
+        self.reset()
+        if PY3:
+            self.strict = False
+            self.convert_charrefs = True
+        self.fed = []
+    def handle_data(self, d):
+        self.fed.append(d)
+    def get_data(self):
+        return ''.join(self.fed)
+
+def strip_html_tags(html):
+    s = HTMLStripper()
+    s.feed(html)
+    return s.get_data()
+
 def compat_py23str(x):
     if PY3:
         return str(x)
     else:
         if isinstance(x, unicode):
             try:
-                return unicode(x).encode("latin-1")
+                return unicode(x).encode("utf-8")
             except UnicodeEncodeError:
                 try:
                     return unicode(x).encode("utf-8")

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -70,7 +70,7 @@ def search():
         liz.setArt({"thumb": img,
                     "icon": img,
                     "fanart": kodiutils.FANART})
-        liz.setInfo("Video", infoLabels={"plot": kodiutils.compat_py23str(description), "title": kodiutils.compat_py23str(title)})
+        liz.setInfo("Video", infoLabels={"plot": kodiutils.strip_html_tags(kodiutils.compat_py23str(description)), "title": kodiutils.compat_py23str(title)})
 
         addDirectoryItem(
             plugin.handle,
@@ -111,14 +111,14 @@ def live():
 
         liz = ListItem("[B][COLOR blue]{}[/COLOR][/B] ({}) [B]{}%[/B]".format(
             kodiutils.compat_py23str(rtp_channel["name"]),
-            kodiutils.compat_py23str(dvr),
+            kodiutils.strip_html_tags(kodiutils.compat_py23str(dvr)),
             kodiutils.compat_py23str(progpercent))
         )
         liz.setArt({"thumb": progimg,
                     "icon": progimg,
                     "fanart": kodiutils.FANART})
         liz.setProperty('IsPlayable', 'true')
-        liz.setInfo("Video", infoLabels={"plot": kodiutils.compat_py23str(dvr)})
+        liz.setInfo("Video", infoLabels={"plot": kodiutils.strip_html_tags(kodiutils.compat_py23str(dvr))})
         addDirectoryItem(
             plugin.handle,
             plugin.url_for(
@@ -242,7 +242,7 @@ def programs_category():
         liz.setArt({"thumb": img,
                     "icon": img,
                     "fanart": kodiutils.FANART})
-        liz.setInfo("Video", infoLabels={"plot": kodiutils.compat_py23str(description), "title": kodiutils.compat_py23str(title)})
+        liz.setInfo("Video", infoLabels={"plot": kodiutils.strip_html_tags(kodiutils.compat_py23str(description)), "title": kodiutils.compat_py23str(title)})
 
         addDirectoryItem(
             plugin.handle,
@@ -302,7 +302,7 @@ def programs_episodes():
         liz.setArt({"thumb": img,
                     "icon": img,
                     "fanart": kodiutils.FANART})
-        liz.setInfo("Video", infoLabels={"plot": kodiutils.compat_py23str(description), "title": kodiutils.compat_py23str(ep)})
+        liz.setInfo("Video", infoLabels={"plot": kodiutils.strip_html_tags(kodiutils.compat_py23str(description)) + "...", "title": kodiutils.compat_py23str(ep)})
         liz.setProperty('IsPlayable', 'true')
 
         addDirectoryItem(


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.5
  - Kodi/repository version: krypton

- **Code location**
  - URL: 
  
Play live emissions from the RTP Play website

### Description of changes:


            - Fix live and ondemand
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
