### PR TITLE
[plugin.video.hbogoeu] 2.5.5+matrix.1

### DIFF
--- a/plugin.video.hbogoeu/README.md
+++ b/plugin.video.hbogoeu/README.md
@@ -4,7 +4,7 @@
 [![Kodi Version](https://img.shields.io/badge/kodi-18%20or%20%2B-blue)](https://kodi.tv/)
 [![GitHub](https://img.shields.io/github/license/arvvoid/plugin.video.hbogoeu?style=flat)](https://opensource.org/licenses/gpl-2.0.php)
 [![Contributors](https://img.shields.io/github/contributors/arvvoid/plugin.video.hbogoeu.svg)](https://github.com/arvvoid/plugin.video.hbogoeu/graphs/contributors)
-[![All Contributors](https://img.shields.io/badge/all_contributors-31-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-32-orange.svg?style=flat-square)](#contributors-)
 [![HitCount](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu.svg)](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu)
 
 # Disclaimer
@@ -37,7 +37,7 @@ Simple Kodi add-on to access HBO® Go content from Kodi Media Center (http://kod
 
 Legend: ✔ - feature availible for the region and working in the add-on, ✖ - feature availible for the region but not implemented or broken in the add-on, ⛔ feature not availible for the region
 
-This add-on support 18 countries atm: 
+This add-on support 18 countries atm ([FULL OPERATOR LIST](https://github.com/arvvoid/plugin.video.hbogoeu/blob/master/operators.md)): 
 *  __Bosnia and Herzegovina__ *[EU]*
 *  __Bulgaria__ *[EU]*
 *  __Croatia__ *[EU]*
@@ -130,6 +130,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://marianfocsa.info"><img src="https://avatars3.githubusercontent.com/u/17079638?v=4" width="100px;" alt=""/><br /><sub><b>Marian FX</b></sub></a><br /><a href="https://github.com/arvvoid/plugin.video.hbogoeu/commits?author=marianfx" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/artemplaksiy"><img src="https://avatars0.githubusercontent.com/u/34888588?v=4" width="100px;" alt=""/><br /><sub><b>artemplaksiy</b></sub></a><br /><a href="https://github.com/arvvoid/plugin.video.hbogoeu/issues?q=author%3Aartemplaksiy" title="Bug reports">🐛</a> <a href="#ideas-artemplaksiy" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="http://dag.wiee.rs/blog/"><img src="https://avatars0.githubusercontent.com/u/388198?v=4" width="100px;" alt=""/><br /><sub><b>Dag Wieers</b></sub></a><br /><a href="https://github.com/arvvoid/plugin.video.hbogoeu/issues?q=author%3Adagwieers" title="Bug reports">🐛</a> <a href="#ideas-dagwieers" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/Buraddo23"><img src="https://avatars0.githubusercontent.com/u/28982082?v=4" width="100px;" alt=""/><br /><sub><b>vladsing</b></sub></a><br /><a href="https://github.com/arvvoid/plugin.video.hbogoeu/issues?q=author%3ABuraddo23" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 

--- a/plugin.video.hbogoeu/addon.xml
+++ b/plugin.video.hbogoeu/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.5.3+matrix.2">
+<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.5.5+matrix.1">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.kodi-six" version="0.1.0" />
@@ -44,16 +44,8 @@ If an official app is available for your platform, use it instead of this.
     <source>https://github.com/arvvoid/plugin.video.hbogoeu</source>
     <website>https://arvvoid.github.io/plugin.video.hbogoeu</website>
     <news>
-- Fix playing the same content twice with caching enabled for Spain/Nordic region
-- Minor code/style fixes
-- Update translations
-- Support for non  ascii username/password
-- Remove pycryptodomex dependency ,use a pure python aes implementation (pyaes)
-  [THIS VERSION WILL ASK TO RE-ENTER CREDENTIALS]
-  [THIS IMPROVE OUT OF THE BOX COMPATIBILITY WITH MORE DEVICES, NO NOTICEABLE PERFORMANCE DIFFERENCE]
-  [pycryptodomex had to be installed from command line on many Linux, macOS]
-
-NOTE: If the add-on fail after the update probably the required module didn't get loaded, simply restart Kodi and all should work.
+- Fix setup for operators with direct (affiliate) login. Fix setup and login for these operators: Bulgaria: Telekabel, NET1; Czech Republic: Vodafone Česká republika, Skylink CZ from 1.4.2020, UPC TV (from 1.4.2020); Montenegro: MTEL; Romania:  Telekom Romania; Serbia: Test RS 1, Supernova; Slovakia: Skylink SK from 1.4.2020; Portugal: Vodafone TV, Vodafone Móvel
+- Cache subtitles for the EU region if inject subtitles option is enabled (default), workaround to avoid the sometimes disappearing internal subtitles defined in the manifest
     </news>
     <assets>
      <icon>resources/icon.png</icon>

--- a/plugin.video.hbogoeu/hbogolib/constants.py
+++ b/plugin.video.hbogoeu/hbogolib/constants.py
@@ -8,15 +8,6 @@ from __future__ import absolute_import, division
 
 class HbogoConstants(object):
 
-    # supported countries:
-    #   0 name
-    #   1 national domain
-    #   2 country code short
-    #   3 country code long
-    #   4 default language code
-    #   5 special domain
-    #   6 hbogo region/handler to use
-
     HANDLER_EU = 0
     HANDLER_NORDIC = 1
     HANDLER_SPAIN = 1
@@ -45,6 +36,15 @@ class HbogoConstants(object):
     CONTEXT_MODE_MOVIE = 1
     CONTEXT_MODE_EPISODE = 2
 
+    # supported countries:
+    #   0 name
+    #   1 national domain
+    #   2 country code short
+    #   3 country code long
+    #   4 default language code
+    #   5 special domain
+    #   6 hbogo region/handler to use
+
     countries = [
         ['Bosnia and Herzegovina', 'ba', 'ba', 'BIH', 'HRV', '', HANDLER_EU],
         ['Bulgaria', 'bg', 'bg', 'BGR', 'BUL', '', HANDLER_EU],
@@ -65,6 +65,8 @@ class HbogoConstants(object):
         ['Spain', 'es', 'es', 'ESP', 'es_hboespana', 'https://es.hboespana.com', HANDLER_SPAIN],
         ['Sweden', 'se', 'se', 'SWE', 'sv_hbon', 'https://se.hbonordic.com/', HANDLER_NORDIC]
     ]
+
+    fallback_operator_icon_eu = 'https://www.hbo-europe.com/images/hbo_eu_logo.png'
 
     platforms = {
 

--- a/plugin.video.hbogoeu/hbogolib/handler.py
+++ b/plugin.video.hbogoeu/hbogolib/handler.py
@@ -37,7 +37,7 @@ class HbogoHandler(object):
         self.handle = handle
         self.DEBUG_ID_STRING = "[" + str(self.addon_id) + "] "
         self.SESSION_VALIDITY = 4  # stored session valid for 4 hours
-        self.max_comm_retry = 1  # if unauthorized del sessionrelogin and try again max times
+        self.max_comm_retry = 1  # if unauthorized del session and re-login and try again max times
         self.max_play_retry = 1  # max play retry on soft error
         self.db_version = 1
 

--- a/plugin.video.hbogoeu/hbogolib/handlersp.py
+++ b/plugin.video.hbogoeu/hbogolib/handlersp.py
@@ -431,7 +431,7 @@ class HbogoHandler_sp(HbogoHandler):
             folder = xbmc.translatePath(self.addon.getAddonInfo('profile'))
             folder = folder + 'subs' + os.sep + media_guid + os.sep
             if self.addon.getSetting('forcesubs') == 'true':
-                self.log("Force subtitles enabled, downloading and converting subtitles in: " + str(folder))
+                self.log("Cache subtitles enabled, downloading and converting subtitles in: " + str(folder))
                 if not os.path.exists(os.path.dirname(folder)):
                     try:
                         os.makedirs(os.path.dirname(folder))
@@ -454,7 +454,7 @@ class HbogoHandler_sp(HbogoHandler):
                         self.log("Subtitle added: " + srt_file)
                     self.log("Setting subtitles: " + str(subs_paths))
                     li.setSubtitles(subs_paths)
-                    self.log("Subtitles set")
+                    self.log("Local subtitles set")
                 except Exception:
                     self.log("Unexpected error in subtitles processing: " + traceback.format_exc())
 


### PR DESCRIPTION
This is the same as https://github.com/xbmc/repo-plugins/pull/2808 just for Matrix

### Add-on details:

- **General**
  - Add-on name: hGO EU
  - Add-on ID: plugin.video.hbogoeu
  - Version number: 2.5.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/arvvoid/plugin.video.hbogoeu
  

Simple, Kodi add-on to access HBO® Go EU content. (This add-on is not officially commissioned/supported by HBO®.)

Important, HBO® Go must be paid for!!!  You need a valid account!
Register on the official HBO® Go website for your region.

Read the disclaimer!

Curently support: Bosnia and Herzegovina, Bulgaria, Croatia, Czech Republic, Hungary, Macedonia, Montenegro, Polonia, Portugal, Romania, Serbia, Slovakia, Slovenija, Spain, Norway, Denmark, Sweden, Finland

To report bugs or request assistence with the add-on go to: https://github.com/arvvoid/plugin.video.hbogoeu
    

### Description of changes:


- Fix setup for operators with direct (affiliate) login. Fix setup and login for these operators: Bulgaria: Telekabel, NET1; Czech Republic: Vodafone Česká republika, Skylink CZ from 1.4.2020, UPC TV (from 1.4.2020); Montenegro: MTEL; Romania:  Telekom Romania; Serbia: Test RS 1, Supernova; Slovakia: Skylink SK from 1.4.2020; Portugal: Vodafone TV, Vodafone Móvel
- Cache subtitles for the EU region if inject subtitles option is enabled (default), workaround to avoid the sometimes disappearing internal subtitles defined in the manifest
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
