### PR TITLE
[plugin.video.vimeo] 5.1.4

### DIFF
--- a/plugin.video.vimeo/addon.xml
+++ b/plugin.video.vimeo/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vimeo" name="Vimeo" version="5.1.3" provider-name="jaylinski">
+<addon id="plugin.video.vimeo" name="Vimeo" version="5.1.4" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.future" version="0.16.0"/>
@@ -17,13 +17,16 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=220437</forum>
         <website>https://vimeo.com</website>
         <source>https://github.com/jaylinski/kodi-addon-vimeo</source>
-        <news>5.1.3 (2020-03-29)
+        <news>5.1.4 (2020-04-09)
+FIX: Videos in HLS format can now be played on macOS
+
+5.1.3 (2020-03-29)
 FIX: Use H264 fallback if video resolution is not available
 FIX: Videos are now marked as watched again
 FIX: Plugin now works with live video streams
 
 5.1.2 (2020-03-02)
-FIX: Add fallback for videos without a HLS stream
+FIX: Added fallback for videos without a HLS stream
 FIX: Use correct localization in info view
 
 5.1.1 (2020-02-27)


### PR DESCRIPTION
### Description

Fixed a playback issue with HLS streams on macOS.

Details: https://github.com/jaylinski/kodi-addon-vimeo/issues/31

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
