### PR TITLE
[plugin.audio.radio_de@gotham] 3.0.0

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="2.4.2">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.0">
     <requires>
         <import addon="xbmc.python" version="2.14.0" />
         <import addon="script.module.xbmcswift2" version="2.5.0" />
@@ -12,10 +12,11 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>v2.4.2 (9/2/2020)
-            [add] sort methods for categories
-            [add] setting to prefer http connections over https if http streams are available
-            [fix] use sys.version_info[0] for compatibility with python2.6
+        <news>3.0.0 (12/4/2020)
+            [fix] playlist based stations (backport)
+            [fix] ratings (backport)
+            [new] removed python3 compatibility
+            [new] automated submissions to repository
         </news>
         <summary lang="be">Access &gt;7000 radio broadcasts</summary>
         <summary lang="ca">accedeix a mes de 7000 emissores de radio</summary>

--- a/plugin.audio.radio_de/changelog.txt
+++ b/plugin.audio.radio_de/changelog.txt
@@ -1,3 +1,9 @@
+3.0.0 (12/4/2020)
+    - [fix] playlist based stations (backport)
+    - [fix] ratings (backport)
+    - [new] removed python3 compatibility
+    - [new] automated submissions to repository
+
 v2.4.2 (9/2/2020)
     - [add] sort methods for categories
     - [add] setting to prefer http connections over https if http streams are available

--- a/plugin.audio.radio_de/resources/lib/api.py
+++ b/plugin.audio.radio_de/resources/lib/api.py
@@ -258,7 +258,7 @@ class RadioApi():
         self.log('__resolve_playlist started with station=%s'
                  % station['id'])
         servers = []
-        stream_url = station['streamURL']
+        stream_url = station['streamUrl']
         if stream_url.lower().endswith('m3u'):
             response = self.__urlopen(stream_url)
             self.log('__resolve_playlist found .m3u file')

--- a/plugin.audio.radio_de/resources/lib/plugin.py
+++ b/plugin.audio.radio_de/resources/lib/plugin.py
@@ -530,7 +530,7 @@ def __add_stations(stations, add_custom=False, browse_more=None):
             'fanart': __get_plugin_fanart(),
             'info': {
                 'title': station.get('name', ''),
-                'rating': str(station.get('rating', '0.0')),
+                'rating': (10.0 - 0.0)*((float(station.get('rating', 0.0))-30.000)/(1.0-30.000)), # linear interpolation
                 'genre': station.get('genre', ''),
                 'size': int(station.get('bitrate', 0)),
                 'comment': station.get('description', ''),


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 3.0.0
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.radio_de
  
Music plugin to access over 7000 international radio broadcasts from rad.io, radio.de, radio.fr and radio.pt[CR]Currently features[CR]- English, german and french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

3.0.0 (12/4/2020)
            [fix] playlist based stations (backport)
            [fix] ratings (backport)
            [new] removed python3 compatibility
            [new] automated submissions to repository
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
