### PR TITLE
[plugin.audio.shoutcast@gotham] 2.5.0

### DIFF
--- a/plugin.audio.shoutcast/addon.xml
+++ b/plugin.audio.shoutcast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.shoutcast" name="SHOUTcast" version="2.4.1" provider-name="Tristan Fischer (sphere@dersphere.de), enen92">
+<addon id="plugin.audio.shoutcast" name="SHOUTcast" version="2.5.0" provider-name="Tristan Fischer (sphere@dersphere.de), enen92">
     <requires>
         <import addon="xbmc.python" version="2.14.0"/>
         <import addon="script.module.simplejson" version="3.16.1"/>
@@ -12,8 +12,8 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <website>https://www.shoutcast.com/</website>
-        <source>https://github.com/dersphere/plugin.audio.shoutcast</source>
-        <forum>https://forum.xbmc.org/showthread.php?tid=143678</forum>
+        <source>https://github.com/XBMC-Addons/plugin.audio.shoutcast</source>
+        <forum>https://forum.kodi.tv/showthread.php?tid=143678</forum>
         <license>GPL-2.0-only</license>
         <summary lang="ar">وجود اكثر من 50.000 محطة اذاعية مجانية على الانترنت </summary>
         <summary lang="be">more than 50.000 free internet radio stations</summary>
@@ -81,8 +81,9 @@
         <description lang="ta_IN">இந்த துணை பயன் மூலம் நீங்கள் 50.000 மேற்பட்ட இலவச இணைய வானொலி நிலையங்களை உலாவ முடியும். தற்போதய சிறப்பியல்:[CR]- உச்சி 500 நிலையங்கள்[CR]- வகைபடி உலாவு (துணை வகைப்படி சேர்க்கவும் - அமைப்புகளில் தேர்வு செய்யவும்)[CR]- பெயர்படி நிலையத்தனி தேடுக[CR]- பெயர்படி நிலையத்தனி தேடுக[CR]- "என்னுடைய நிலையங்கள்" பட்டியலை நீங்கள் நிர்வகிக்க முடியும்[CR]- பிட்வீதம் மற்றும் கேட்போர் அளவுகளை பார்க்கவும் மற்றும் வரிசைபடுத்தவும்[CR]- ஒரு பக்கத்தில் 500 நிலையங்கள் (அமைப்புகளில் மாற்ற இயலும்)[CR]- தேக்கத்தை பயன்படுத்தவும் (24 மணிநேர வகை, 1 மணிநேர நிலைய பட்டியல்)</description>
         <description lang="zh">你可以使用本插件浏览超过50.000免费网络电台。当前功能：[CR]- 500强电台[CR]- 按类别浏览（可设置子类）[CR]- 按名字搜索电台[CR]- 按当前播放曲目搜索电台[CR]- 管理“我的电台”-列表[CR]- 按比特率和收听人数排序[CR]- 每页500个电台（可设置）[CR]- 使用缓存（24小时类别，1小时站点列表）</description>
         <news>
-            2.4.1 (29.3.2020)
-            - Fix requests
+            2.5.0 (12.4.2020)
+            - Automated submissions to gotham branch
+            - Addon.xml cosmetics
         </news>
     </extension>
 </addon>

--- a/plugin.audio.shoutcast/changelog.txt
+++ b/plugin.audio.shoutcast/changelog.txt
@@ -1,3 +1,7 @@
+2.5.0 (12.4.2020)
+ - Automated submissions to gotham branch
+ - Addon.xml cosmetics
+
 2.4.1 (29.3.2020)
  - Fix requests
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SHOUTcast
  - Add-on ID: plugin.audio.shoutcast
  - Version number: 2.5.0
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.shoutcast
  
With this Add-on you can browse more than 50.000 free internet radio stations. Current Features:[CR]- Top 500 Stations[CR]- Browse by genre (and subgenre if enabled in settings)[CR]- Search Station by name[CR]- Search Stations by current playing track[CR]- You can manage a "My Stations"-list[CR]- bitrate and amount of listeners visible and sortable[CR]- 500 Stations on each Page (can be changed in the settings)[CR]- uses cache (24h genre, 1h station listings)

### Description of changes:


            2.5.0 (12.4.2020)
            - Automated submissions to gotham branch
            - Addon.xml cosmetics
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
