### PR TITLE
[plugin.video.vimcasts@gotham] 1.3.0

### DIFF
--- a/plugin.video.vimcasts/addon.xml
+++ b/plugin.video.vimcasts/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.vimcasts" name="VimCasts" provider-name="Jonathan Beluch (jbel), enen92" version="1.2.0">
+<addon id="plugin.video.vimcasts" name="VimCasts" provider-name="Jonathan Beluch (jbel), enen92" version="1.3.0">
   <requires>
     <import addon="xbmc.python" version="2.14.0" />
     <import addon="script.module.xbmcswift2" version="2.5.0" />
@@ -12,12 +12,8 @@
     <license>GPL-3.0-only</license>
     <source>https://github.com/XBMC-Addons/plugin.video.vimcasts</source>
     <news>
-      Version 1.2.0
-        * Update to python3
-        * Update to new xbmcswift2
-        * Add duration
-        * Remove unplayable items
-        * New addon requirements
+      Version 1.3.0
+      - Automated submissions for gotham
     </news>
     <summary lang="en">Watch screencasts about Vim, the text editor, from http://vimcasts.org</summary>
     <description lang="en">Vimcasts publishes free screencasts about Vim, the text editor. Vim has been around in one form or another for over 20 years. The learning curve is famously difficult, but those who manage to climb it insist that nothing can match Vim's modal editing model for speed and efficiency.[CR][CR]The patterns of use that make a Vim master productive are not easily discovered. Trial and error will get you so far, but the best way to learn is to watch an experienced Vim user at work. By providing short videos with digestible advice, Vimcasts gives you something you can take away and use immediately to improve your productivity. Vimcasts aims to be the expert Vim colleague you never had.[CR][CR]Vimcasts is produced by Drew Neil (aka nelstrom), who came to Vim from TextMate. He made the switch when starting work at a company that uses Linux workstations. His choice of text editor was influenced by colleagues.</description>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VimCasts
  - Add-on ID: plugin.video.vimcasts
  - Version number: 1.3.0
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.video.vimcasts
  
Vimcasts publishes free screencasts about Vim, the text editor. Vim has been around in one form or another for over 20 years. The learning curve is famously difficult, but those who manage to climb it insist that nothing can match Vim's modal editing model for speed and efficiency.[CR][CR]The patterns of use that make a Vim master productive are not easily discovered. Trial and error will get you so far, but the best way to learn is to watch an experienced Vim user at work. By providing short videos with digestible advice, Vimcasts gives you something you can take away and use immediately to improve your productivity. Vimcasts aims to be the expert Vim colleague you never had.[CR][CR]Vimcasts is produced by Drew Neil (aka nelstrom), who came to Vim from TextMate. He made the switch when starting work at a company that uses Linux workstations. His choice of text editor was influenced by colleagues.

### Description of changes:


      Version 1.3.0
      - Automated submissions for gotham
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
