### PR TITLE
[plugin.audio.radio_de@gotham] 3.0.1

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.0">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.1">
     <requires>
         <import addon="xbmc.python" version="2.14.0" />
         <import addon="script.module.xbmcswift2" version="2.5.0" />
@@ -12,11 +12,8 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>3.0.0 (12/4/2020)
-            [fix] playlist based stations (backport)
-            [fix] ratings (backport)
-            [new] removed python3 compatibility
-            [new] automated submissions to repository
+        <news>3.0.1 (13/4/2020)
+            - [new] Use internal playlist resolver also in custom stations (backport)
         </news>
         <summary lang="be">Access &gt;7000 radio broadcasts</summary>
         <summary lang="ca">accedeix a mes de 7000 emissores de radio</summary>

--- a/plugin.audio.radio_de/changelog.txt
+++ b/plugin.audio.radio_de/changelog.txt
@@ -1,3 +1,6 @@
+3.0.1 (13/4/2020)
+    - [new] Use internal playlist resolver also in custom stations
+
 3.0.0 (12/4/2020)
     - [fix] playlist based stations (backport)
     - [fix] ratings (backport)

--- a/plugin.audio.radio_de/resources/lib/api.py
+++ b/plugin.audio.radio_de/resources/lib/api.py
@@ -138,6 +138,17 @@ class RadioApi():
         stations = (station, )
         return self.__format_stations_v2(stations)[0]
 
+    def internal_resolver(self, station, ):
+        if station.get('is_custom', False):
+            stream_url = station['stream_url']
+        else:
+            stream_url = station['streamUrl']
+
+        if self.__check_paylist(stream_url):
+            return self.__resolve_playlist(station)
+        else:
+            return station
+
     def get_top_stations(self, sizeperpage, pageindex):
         self.log(('get_top_stations started with '
                   'sizeperpage=%s, pageindex=%s') % (
@@ -258,7 +269,13 @@ class RadioApi():
         self.log('__resolve_playlist started with station=%s'
                  % station['id'])
         servers = []
-        stream_url = station['streamUrl']
+
+        # Check if it is a custom station
+        if station.get('is_custom', False):
+            stream_url = station['stream_url']
+        else:
+            stream_url = station['streamUrl']
+
         if stream_url.lower().endswith('m3u'):
             response = self.__urlopen(stream_url)
             self.log('__resolve_playlist found .m3u file')

--- a/plugin.audio.radio_de/resources/lib/plugin.py
+++ b/plugin.audio.radio_de/resources/lib/plugin.py
@@ -476,7 +476,7 @@ def sub_menu_entry(option, category, value, page=1):
 def get_stream_url(station_id):
     if my_stations.get(station_id, {}).get('is_custom', False):
         station = my_stations[station_id]
-        stream_url = station['stream_url']
+        stream_url = radio_api.internal_resolver(station)
         current_track = ''
     else:
         station = radio_api.get_station_by_station_id(


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 3.0.1
  - Kodi/repository version: gotham

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.radio_de
  
Music plugin to access over 7000 international radio broadcasts from rad.io, radio.de, radio.fr and radio.pt[CR]Currently features[CR]- English, german and french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

3.0.1 (13/4/2020)
            - [new] Use internal playlist resolver also in custom stations (backport)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
