### PR TITLE
[plugin.video.rtpplay@matrix] 5.0.7+matrix.1

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.6+matrix.1" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.7+matrix.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(ADDON.getAddonInfo('id'))
 kodilogging.config()
 plugin = routing.Plugin()
 
+HEADERS_VOD = {
+    "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.113 Mobile Safari/537.36",
+    "Cookie": "rtp_cookie_privacy=permit 1,2,3,4;"
+}
+
 @plugin.route('/')
 def index():
     direto = ListItem("[B]{}[/B]".format(kodiutils.get_string(32004)))
@@ -50,7 +55,7 @@ def search():
     input_text = Dialog().input(kodiutils.get_string(32007), "", INPUT_ALPHANUM)
 
     try:
-        req = requests.get("https://www.rtp.pt/play/pesquisa?q={}".format(input_text), headers=HEADERS).text
+        req = requests.get("https://www.rtp.pt/play/pesquisa?q={}".format(input_text), headers=HEADERS_VOD).text
     except:
         raise_notification()
 
@@ -276,7 +281,7 @@ def programs_episodes():
     try:
         req = requests.get("https://www.rtp.pt/play/bg_l_ep/?listProgram={}&page={}".format(
             prog_id,
-            page), headers=HEADERS)
+            page), headers=HEADERS_VOD)
         req.encoding = "latin-1"
         req = req.text
     except:
@@ -346,7 +351,10 @@ def programs_play():
     except:
         raise_notification()
 
-    liz = ListItem("{} ({})".format(title, ep))
+    liz = ListItem("{} ({})".format(
+        kodiutils.compat_py23str(title),
+        kodiutils.compat_py23str(ep))
+    )
     liz.setArt({"thumb": img, "icon": img})
     liz.setProperty('IsPlayable', 'true')
     liz.setPath("{}|{}".format(stream, urlencode(HEADERS)))


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live emissions from the RTP Play website

### Description of changes:


            - Addon is now supported in matrix
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
