### PR TITLE
[plugin.video.rtpplay@krypton] 5.0.8

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.7" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.8" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -21,7 +21,7 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Addon is now supported in matrix
+            - Add #estudoemcasa (school classes during lockdown)
         </news>
         <disclaimer lang="en_GB">The plugin is unnoficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <assets>

--- a/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
@@ -55,3 +55,7 @@ msgstr ""
 msgctxt "#32009"
 msgid "Page"
 msgstr ""
+
+msgctxt "#32010"
+msgid "#EstudoEmCasa"
+msgstr ""

--- a/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
@@ -55,3 +55,7 @@ msgstr "Resultados para"
 msgctxt "#32009"
 msgid "Page"
 msgstr "Página"
+
+msgctxt "#32010"
+msgid "#EstudoEmCasa"
+msgstr "#EstudoEmCasa"

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -43,6 +43,9 @@ def index():
     programas = ListItem("[B]{}[/B]".format(kodiutils.get_string(32005)))
     addDirectoryItem(handle=plugin.handle, listitem=programas, isFolder=True, url=plugin.url_for(programs))
 
+    estudoemcasaitem = ListItem("[B]{}[/B]".format(kodiutils.get_string(32010)))
+    addDirectoryItem(handle=plugin.handle, listitem=estudoemcasaitem, isFolder=True, url=plugin.url_for(estudoemcasa))
+
     pesquisar = ListItem("[B]{}[/B]".format(kodiutils.get_string(32006)))
     addDirectoryItem(handle=plugin.handle, listitem=pesquisar, isFolder=True, url=plugin.url_for(search))
 
@@ -276,10 +279,16 @@ def programs_episodes():
     url = plugin.args["url"][0]
     page = plugin.args["page"][0]
 
-    prog_id = url.split("/")[2][1:]
+    if url.find("estudoemcasa") >= 0:
+        prog_id = url.split("/")[3][1:]
+        mainurl = "https://www.rtp.pt/play/estudoemcasa"
+    else:
+        prog_id = url.split("/")[2][1:]
+        mainurl = "https://www.rtp.pt/play"
 
     try:
-        req = requests.get("https://www.rtp.pt/play/bg_l_ep/?listProgram={}&page={}".format(
+        req = requests.get("{}/bg_l_ep/?listProgram={}&page={}".format(
+            mainurl,
             prog_id,
             page), headers=HEADERS_VOD)
         req.encoding = "latin-1"
@@ -349,7 +358,11 @@ def programs_play():
         stream = re.search(r'"https://(.+?)ondemand.rtp.pt(.*?)"', req.text)
         stream = "https://" + stream.group(1) + "ondemand.rtp.pt" + stream.group(2)
     except:
-        raise_notification()
+        try:
+            stream = re.search(r'"https://(.+?)streaming.rtp.pt(.*?)"', req.text)
+            stream = "https://" + stream.group(1) + "streaming.rtp.pt" + stream.group(2)
+        except:
+            raise_notification()
 
     liz = ListItem("{} ({})".format(
         kodiutils.compat_py23str(title),
@@ -359,6 +372,44 @@ def programs_play():
     liz.setProperty('IsPlayable', 'true')
     liz.setPath("{}|{}".format(stream, urlencode(HEADERS)))
     setResolvedUrl(plugin.handle, True, liz)
+
+
+@plugin.route('/estudoemcasa')
+def estudoemcasa():
+    try:
+        req = requests.get("https://www.rtp.pt/play/estudoemcasa/", headers=HEADERS)
+        req.encoding = "latin-1"
+        req = req.text
+    except:
+        raise_notification()
+
+    soup = BeautifulSoup(req, 'html.parser')
+
+    for a in soup.find_all('a', class_='item wide-169'):
+        url = a.get('href')
+        title = a.get('title')
+        img = a.find('img').get('data-src')
+
+        liz = ListItem("{}".format(
+            kodiutils.compat_py23str(title))
+        )
+        liz.setArt({"thumb": img,
+                    "icon": img,
+                    "fanart": kodiutils.FANART})
+        liz.setInfo("Video", infoLabels={"title": kodiutils.compat_py23str(title)})
+
+        addDirectoryItem(
+            plugin.handle,
+            plugin.url_for(
+                programs_episodes,
+                title=kodiutils.compat_py23str(title),
+                img=kodiutils.compat_py23str(img),
+                url=kodiutils.compat_py23str(url),
+                ep=kodiutils.compat_py23str(title),
+                page=1
+            ), liz, True)
+
+    endOfDirectory(plugin.handle)
 
 
 def raise_notification():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.8
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live emissions from the RTP Play website

### Description of changes:


            - Add #estudoemcasa (school classes during lockdown)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
