### PR TITLE
[plugin.audio.radio_de@matrix] 3.0.3+matrix.6

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.3+matrix.5">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.3+matrix.6">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.xbmcswift2" version="19.0.0" />
@@ -12,7 +12,7 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>v3.0.3+matrix.5 (13/4/2020)
+        <news>v3.0.3+matrix.6 (1/5/2020)
             [fix] Custom stations if the url is not a playlist
             [new] Spanish website radio.es and improved translations
             [new] screenshot support for addon-website

--- a/plugin.audio.radio_de/changelog.txt
+++ b/plugin.audio.radio_de/changelog.txt
@@ -1,4 +1,4 @@
-v3.0.3+matrix.5 (13/4/2020)
+v3.0.3+matrix.6 (1/5/2020)
     - [fix] Custom stations if the url is not a playlist
     - [new] Spanish website radio.es and improved translations
     - [new] screenshot support for addon-website


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 3.0.3+matrix.6
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.radio_de
  
Music plugin to access over 30000 international radio broadcasts from rad.io, radio.de, radio.fr, radio.pt and radio.es[CR]Currently features[CR]- English, german, french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

v3.0.3+matrix.6 (1/5/2020)
            [fix] Custom stations if the url is not a playlist
            [new] Spanish website radio.es and improved translations
            [new] screenshot support for addon-website
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
