### PR TITLE
[plugin.video.roosterteeth] 1.5

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.4.1"
+       version="1.5.0"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="2.26.0"/>
@@ -20,17 +20,16 @@
       <disclaimer lang="en_GB">For bugs, requests or general questions visit the Roosterteeth.com thread on the Kodi forum</disclaimer>
     <language>en</language>
     <platform>all</platform>
-    <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
+    <license>GPL-2.0-or-later</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=235071</forum>
     <website>https://roosterteeth.com</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.roosterteeth</source>
-    <news>1.4.1 (2019-06-09)
-    - added adapted inputstream addon switch. When on: video quality is chosen by that addon.
-    - for when the adapted inputstream addon switch is off: if a video of the desired video is not found, look for a video of lower quality
-    - fixed inside-gaming section
-    - added pages instead of only listing the first 30 items
-    - removed game attack
+    <news>1.5.0 (2020-05-02)
+    - dynamic channels instead of hardcoded channels
+    - set initial sorting, changing the sort order in Kodi now seems to actually do something
+    - added channel shows
+    - changes due to sponsership to First membership change
     </news>
     <assets>
       <icon>resources/icon.png</icon>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,9 @@
+1.5.0 (2020-05-02)
+- dynamic channels instead of hardcoded channels
+- set initial sorting, changing the sort order in Kodi now seems to actually do something
+- added channel shows
+- changes due to sponsership to First membership change
+
 1.4.1 (2019-06-09)
 - added adapted inputstream switch. When this is on, the videoplayer inputstream addon 'Inputstream Adaptive'
 (kudo's to peak3d) is used. The addon 'Inputstream Adaptive' determines what resolution it will display based upon the

--- a/plugin.video.roosterteeth/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.roosterteeth/resources/language/resource.language.en_gb/strings.po
@@ -28,7 +28,7 @@ msgid "For bugs, requests or general questions visit the Roosterteeth.com thread
 msgstr ""
 
 msgctxt "#30015"
-msgid "Rooster Teeth Sponsor"
+msgid "Rooster Teeth First member"
 msgstr ""
 
 msgctxt "#30016"
@@ -76,7 +76,7 @@ msgid "Getting video location..."
 msgstr ""
 
 msgctxt "#30101"
-msgid "Login has failed for this Sponsored video. In settings enter"
+msgid "Login has failed for this First video. In settings enter"
 msgstr ""
 
 msgctxt "#30102"
@@ -84,15 +84,15 @@ msgid "the correct username and password. Or turn off the Rooster"
 msgstr ""
 
 msgctxt "#30103"
-msgid "Teeth Sponsor-switch if you aren't a Sponsor."
+msgid "Teeth First-switch if you haven't signed up to First membership."
 msgstr ""
 
 msgctxt "#30104"
-msgid "Login Failed: %s."
+msgid "Login Failed."
 msgstr ""
 
 msgctxt "#30105"
-msgid "Sorry. You must be a Sponsor to see this video."
+msgid "Sorry. You must be a First member to see this video."
 msgstr ""
 
 msgctxt "#30106"
@@ -112,89 +112,38 @@ msgid "Error loading Json file."
 msgstr ""
 
 msgctxt "#30110"
-msgid "Sorry. The video is not yet available for non-Sponsors."
+msgid "Sorry. The video is not yet available for non-First members."
+msgstr ""
+
+msgctxt "#30111"
+msgid "In settings enter the correct username and password."
+msgstr ""
+
+msgctxt "#30120"
+msgid "Sorry. The login was successful, but the video is not yet available to non-First members."
+msgstr ""
+
+msgctxt "#30130"
+msgid "Sorry. The login was successful, but the video is only available for First members."
 msgstr ""
 
 msgctxt "#30200"
 msgid "Next page"
 msgstr ""
 
-msgctxt "#30301"
-msgid "Roosterteeth Recently Added Episodes"
+msgctxt "#30318"
+msgid "First aired on"
+msgstr ""
+
+msgctxt "#30319"
+msgid "Latest episode date: "
 msgstr ""
 
 msgctxt "#30302"
 msgid "Series"
 msgstr ""
 
-msgctxt "#30303"
-msgid "Achievement Hunter Recently Added Episodes"
+msgctxt "#30321"
+msgid "Recently Added Episodes"
 msgstr ""
 
-msgctxt "#30304"
-msgid "Achievement Hunter Series"
-msgstr ""
-
-msgctxt "#30305"
-msgid "Fun Haus Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30306"
-msgid "Fun Haus Series"
-msgstr ""
-
-msgctxt "#30307"
-msgid "Screw Attack Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30308"
-msgid "Screw Attack Series"
-msgstr ""
-
-msgctxt "#30309"
-msgid "Cow Chop Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30310"
-msgid "Cow Chop Series"
-msgstr ""
-
-msgctxt "#30311"
-msgid "Sugar Pine 7 Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30312"
-msgid "Sugar Pine 7 Series"
-msgstr ""
-
-msgctxt "#30313"
-msgid "Game Attack Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30314"
-msgid "Game Attack Series"
-msgstr ""
-
-msgctxt "#30315"
-msgid "Inside Gaming Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30316"
-msgid "Inside Gaming Series"
-msgstr ""
-
-msgctxt "#30317"
-msgid "JT Music Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30318"
-msgid "JT Music Series"
-msgstr "
-
-msgctxt "#30319"
-msgid "Kinda Funny Recently Added Episodes"
-msgstr ""
-
-msgctxt "#30320"
-msgid "Kinda Funny Series"
-msgstr ""

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_const.py
@@ -24,33 +24,15 @@ ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART = '?per_page=1000&filter=all&pa
 NUMBER_OF_EPISODES_PER_PAGE = '24'
 ROOSTERTEETH_PAGE_URL_PART = '?per_page=' + NUMBER_OF_EPISODES_PER_PAGE + '&filter=all&page=001'
 ROOSTERTEETH_ORDER_URL_PART = '&order=desc'
-
+# Channels
+ROOSTERTEETH_CHANNELS_URL = 'https://svod-be.roosterteeth.com/api/v1/channels'
+# Channel
+ROOSTERTEETH_CHANNEL_URL_PART = "&channel_id="
 # Shows
 ROOSTERTEETH_SERIES_BASE_URL = 'https://svod-be.roosterteeth.com/api/v1/shows'
-ROOSTERTEETH_SERIES_URL = 'https://svod-be.roosterteeth.com/api/v1/shows' + ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART
+ROOSTERTEETH_SERIES_URL = ROOSTERTEETH_SERIES_BASE_URL + ROOSTERTEETH_GET_EVERYTHING_IN_ONE_PAGE_URL_PART
 
-# Recent video's per channel
-ROOSTERTEETH_CHANNEL_BASE_URL = "https://svod-be.roosterteeth.com/api/v1/episodes"
-ROOSTERTEETH_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                              + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=rooster-teeth"
-ACHIEVEMENTHUNTER_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                                   + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=achievement-hunter"
-FUNHAUS_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=funhaus"
-INSIDE_GAMING_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                               + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=inside-gaming"
-SCREWATTACK_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                             + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=screwattack"
-SUGARPINE7_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                            + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=sugar-pine-7"
-COWCHOP_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=cow-chop"
-JTMUSIC_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                         + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=jt-music"
-KINDAFUNNY_RECENTLY_ADDED_VIDEOS_SERIES_URL = ROOSTERTEETH_CHANNEL_BASE_URL + ROOSTERTEETH_PAGE_URL_PART \
-                                            + ROOSTERTEETH_ORDER_URL_PART + "&channel_id=kinda-funny"
-
-SPONSOR_ONLY_VIDEO_TITLE_PREFIX = '* '
+FIRST_MEMBER_ONLY_VIDEO_TITLE_PREFIX = '* '
 INDEX_DOT_M3U8 = "index.m3u8"
 VQ4K = '4k'
 VQ1080P = '1080p'
@@ -60,8 +42,8 @@ VQ360P = '360p'
 VQ240P = '240p'
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2019-06-09"
-VERSION = "1.4.1"
+DATE = "2020-05-02"
+VERSION = "1.5.0"
 
 if sys.version_info[0] > 2:
     unicode = str

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_serie_seasons.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_serie_seasons.py
@@ -39,7 +39,7 @@ class Main(object):
         self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][
             0]
 
-        # log("self.url", self.video_list_page_url)
+        log("self.url", self.video_list_page_url)
 
         #
         # Get the videos...
@@ -68,12 +68,6 @@ class Main(object):
 
         try:
             json_data = json.loads(html_source)
-
-            # for item in json_data['data']:
-            #     log("attribute1", item['canonical_links']['self'])
-            #     log("attribute2", item['attributes']['title'])
-            #     exit(1)
-
         except (ValueError, KeyError, TypeError):
             xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30109))
             exit(1)
@@ -93,7 +87,7 @@ class Main(object):
                 serie_url = serie_url[0: pos_of_questionmark]
                 serie_url = serie_url + ROOSTERTEETH_PAGE_URL_PART + ROOSTERTEETH_ORDER_URL_PART
 
-            log("serie_url", serie_url)
+            # log("serie_url", serie_url)
 
             thumb = self.thumbnail_url
 
@@ -126,7 +120,7 @@ class Main(object):
         # Large lists and/or slower systems benefit from adding all items at once via addDirectoryItems
         # instead of adding one by ove via addDirectoryItem.
         xbmcplugin.addDirectoryItems(self.plugin_handle, listing, len(listing))
-        # Disable sorting
-        xbmcplugin.addSortMethod(handle=self.plugin_handle, sortMethod=xbmcplugin.SORT_METHOD_NONE)
+        # Set initial sorting
+        xbmcplugin.addSortMethod(handle=self.plugin_handle, sortMethod=xbmcplugin.SORT_METHOD_DATEADDED)
         # Finish creating a virtual folder.
         xbmcplugin.endOfDirectory(self.plugin_handle)

--- a/plugin.video.roosterteeth/resources/lib/roosterteeth_list_series.py
+++ b/plugin.video.roosterteeth/resources/lib/roosterteeth_list_series.py
@@ -39,7 +39,7 @@ class Main(object):
         self.next_page_possible = urllib.parse.parse_qs(urllib.parse.urlparse(sys.argv[2]).query)['next_page_possible'][
             0]
 
-        # log("self.url", self.video_list_page_url)
+        log("self.url", self.video_list_page_url)
 
         #
         # Get the videos...
@@ -68,18 +68,16 @@ class Main(object):
 
         try:
             json_data = json.loads(html_source)
-
-            # for item in json_data['data']:
-            #     log("attribute1", item['canonical_links']['self'])
-            #     log("attribute2", item['attributes']['title'])
-            #     exit(1)
-
         except (ValueError, KeyError, TypeError):
             xbmcgui.Dialog().ok(LANGUAGE(30000), LANGUAGE(30109))
             exit(1)
 
         for item in json_data['data']:
             serie_title = item['attributes']['title']
+
+            summary = item['attributes']['summary']
+            last_episode_golive_at = item['attributes']['last_episode_golive_at']
+            last_episode_golive_at = last_episode_golive_at[0:10]
 
             # this part looks like this f.e.: /series/nature-town
             serie_url_middle_part = item['canonical_links']['self']
@@ -103,6 +101,9 @@ class Main(object):
 
             # Add to list...
             list_item = xbmcgui.ListItem(title)
+            list_item.setInfo("video",
+                             {"title": title, "mediatype": "video",
+                              "plot": summary + '\n' + LANGUAGE(30319) + ' ' + last_episode_golive_at})
             list_item.setArt({'thumb': thumbnail_url, 'icon': thumbnail_url,
                               'fanart': os.path.join(RESOURCES_PATH, 'fanart-blur.jpg')})
             list_item.setProperty('IsPlayable', 'false')
@@ -124,7 +125,7 @@ class Main(object):
         # Large lists and/or slower systems benefit from adding all items at once via addDirectoryItems
         # instead of adding one by ove via addDirectoryItem.
         xbmcplugin.addDirectoryItems(self.plugin_handle, listing, len(listing))
-        # Disable sorting
-        xbmcplugin.addSortMethod(handle=self.plugin_handle, sortMethod=xbmcplugin.SORT_METHOD_NONE)
+        # Set initial sorting
+        xbmcplugin.addSortMethod(handle=self.plugin_handle, sortMethod=xbmcplugin.SORT_METHOD_DATEADDED)
         # Finish creating a virtual folder.
         xbmcplugin.endOfDirectory(self.plugin_handle)

--- a/plugin.video.roosterteeth/resources/settings.xml
+++ b/plugin.video.roosterteeth/resources/settings.xml
@@ -3,7 +3,7 @@
   <category label="General">
     <setting id="quality" 	    	        type="enum" label="30020" lvalues="30026|30025|30024|30023|30022|30021"   default="4"/>
     <setting id="use_adaptive_inputstream" 	type="bool" label="30018" 											      default="false"/>
-    <setting id="is_sponsor" 	            type="bool" label="30015" 											      default="false"/>
+    <setting id="is_first_member" 	        type="bool" label="30015" 											      default="false"/>
     <setting id="username" 	     	        type="text" label="30016" 											      default=""                   enable="eq(-1,true)"/>
     <setting id="password" 		            type="text" label="30017" 											      default="" option="hidden"   enable="eq(-2,true)"/>
   </category>


### PR DESCRIPTION
1.5 (2020-05-02)
- dynamic channels instead of hardcoded channels
- set initial sorting, changing the sort order in Kodi now seems to actually do something
- added channel shows
- changes due to sponsership to First membership change
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0