### PR TITLE
[plugin.video.newyankeeworkshop] 0.0.2

### DIFF
--- a/plugin.video.newyankeeworkshop/addon.xml
+++ b/plugin.video.newyankeeworkshop/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.newyankeeworkshop" name="The New Yankee Workshop" version="0.0.1" provider-name="th0ma5w">
+<addon id="plugin.video.newyankeeworkshop" name="The New Yankee Workshop" version="0.0.2" provider-name="th0ma5w">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0" />
 		<import addon="xbmc.addon" version="13.0.0" />
@@ -12,13 +12,17 @@
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Episodes of The New Yankee Workshop</summary>
     <description lang="en_GB">Hosted by master carpenter Norm Abram, who is legendary for his woodworking skills, The New Yankee Workshop has guided millions of viewers through the hands-on process of furniture making.</description>
-    <news>v0.0.1 (09.09.2018)
-	    - Initial Release</news>
+<news>
+v0.0.2 (05.17.2020)
+  - Updates to video extraction code
+v0.0.1 (09.09.2018)
+  - Initial Release
+</news>
     <language>en</language>
     <platform>all</platform>
-    <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
+    <license>GPL-3.0-or-later</license>
     <website>https://www.newyankee.com/</website>
-    <source></source>
+    <source>https://github.com/th0ma5w/repo-plugins/tree/newyankeeworkshop</source>
     <assets>
 	    <icon>icon.png</icon>
 	    <fanart>fanart.jpg</fanart>


### PR DESCRIPTION
### Description
Corrected video extraction code for source website. Formerly the site made an MP4 video available, but now it provides an .m3u8 playlist. Additionally, a requests library session is now used for maintaining cookies during interaction with the source site. Thank you all for you continued hard work on Kodi!

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
