### PR TITLE
[plugin.video.vrt.nu@krypton] 2.3.5

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,11 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.3.5 (2020-05-27)
+- Fix watching VRT NU abroad (@mediaminister)
+- Improve and fix user authentication (@mediaminister, @dagwieers)
+- Add support for playing from the Guide with IPTV Manager (@michaelarnauts)
+
 ### v2.3.4 (2020-05-18)
 - Fix token issue caused by new cross-site request forgery (XSRF) checks (@mediaminister)
 - Add experimental IPTV Manager support (@dagwieers)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.3.4" provider-name="Martijn Moreel, dagwieers">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.3.5" provider-name="Martijn Moreel, dagwieers">
 <requires>
   <import addon="resource.images.studios.white" version="0.0.22"/>
   <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,11 @@
   <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
   <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
   <news>
+v2.3.5 (2020-05-27)
+- Fix watching VRT NU abroad
+- Improve and fix user authentication
+- Add support for playing from the Guide with IPTV Manager
+
 v2.3.4 (2020-05-18)
 - Fix token issue caused by new cross-site request forgery (XSRF) checks
 - Add experimental IPTV Manager support

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -521,7 +521,7 @@ msgid "Email address"
 msgstr ""
 
 msgctxt "#30704"
-msgid "Provide your VRT NU email address. In case this is a Google or Facebook account, please ensure that this login is enabled for normal username/password authentication. See the wiki for more information."
+msgid "Provide your VRT NU email address. In case this is a Google, Facebook or Apple account, please ensure that this login is enabled for normal username/password authentication. See the wiki for more information."
 msgstr ""
 
 msgctxt "#30705"
@@ -859,7 +859,7 @@ msgid "Login succeeded."
 msgstr ""
 
 msgctxt "#30953"
-msgid "Invalid email address or password. Only VRT logins are supported, no Google or Facebook logins."
+msgid "Invalid email address or password. Only VRT logins are supported, no Google, Facebook or Apple logins."
 msgstr ""
 
 msgctxt "#30954"

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -521,8 +521,8 @@ msgid "Email address"
 msgstr "E-mailadres"
 
 msgctxt "#30704"
-msgid "Provide your VRT NU email address. In case this is a Google or Facebook account, please ensure that this login is enabled for normal username/password authentication. See the wiki for more information."
-msgstr "Geef je VRT NU e-mailadres in. In het geval je een Google of Facebook account gebruikt, controleer dat deze login geactiveerd werd voor normale gebruikersnaam/wachtwoord authenticatie. Zie de wiki pagina voor meer informatie."
+msgid "Provide your VRT NU email address. In case this is a Google, Facebook or Apple account, please ensure that this login is enabled for normal username/password authentication. See the wiki for more information."
+msgstr "Geef je VRT NU e-mailadres in. In het geval je een Google-, Facebook- of Apple-account gebruikt, controleer dat deze login geactiveerd werd voor normale gebruikersnaam/wachtwoord authenticatie. Zie de wiki pagina voor meer informatie."
 
 msgctxt "#30705"
 msgid "Password"
@@ -859,8 +859,8 @@ msgid "Login succeeded."
 msgstr "Inloggen gelukt."
 
 msgctxt "#30953"
-msgid "Invalid email address or password. Only VRT logins are supported, no Google or Facebook logins."
-msgstr "Ongeldig e-mailadres of wachtwoord. Alleen VRT-logins worden ondersteund, geen Google- of Facebook-logins."
+msgid "Invalid email address or password. Only VRT logins are supported, no Google, Facebook or Apple logins."
+msgstr "Ongeldig e-mailadres of wachtwoord. Alleen VRT-logins worden ondersteund, geen Google-, Facebook- of Apple-logins."
 
 msgctxt "#30954"
 msgid "Whoops something went wrong, check the kodi log for more details."

--- a/plugin.video.vrt.nu/resources/lib/favorites.py
+++ b/plugin.video.vrt.nu/resources/lib/favorites.py
@@ -38,7 +38,7 @@ class Favorites:
         favorites_json = get_cache('favorites.json', ttl)
         if not favorites_json:
             from tokenresolver import TokenResolver
-            xvrttoken = TokenResolver().get_xvrttoken(token_variant='user')
+            xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
             if xvrttoken:
                 headers = {
                     'authorization': 'Bearer ' + xvrttoken,
@@ -61,7 +61,7 @@ class Favorites:
             return True
 
         from tokenresolver import TokenResolver
-        xvrttoken = TokenResolver().get_xvrttoken(token_variant='user')
+        xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
         if xvrttoken is None:
             log_error('Failed to get favorites token from VRT NU')
             notification(message=localize(30975))

--- a/plugin.video.vrt.nu/resources/lib/iptvmanager.py
+++ b/plugin.video.vrt.nu/resources/lib/iptvmanager.py
@@ -4,8 +4,9 @@
 """Implementation of IPTVManager class"""
 
 from __future__ import absolute_import, division, unicode_literals
-from kodiutils import log
+
 from data import CHANNELS
+from kodiutils import log
 
 
 class IPTVManager:
@@ -39,13 +40,17 @@ class IPTVManager:
         for channel in CHANNELS:
             if not channel.get('live_stream_id'):
                 continue
-            streams.append(dict(
+            item = dict(
                 id=channel.get('epg_id'),
                 name=channel.get('label'),
                 logo=channel.get('logo'),
                 preset=channel.get('preset'),
                 stream='plugin://plugin.video.vrt.nu/play/id/{live_stream_id}'.format(**channel),
-            ))
+            )
+            if channel.get('has_tvguide'):
+                item.update(dict(vod='plugin://plugin.video.vrt.nu/play/airdate/{name}/{{date}}'.format(**channel)))
+
+            streams.append(item)
         return dict(version=1, streams=streams)
 
     @via_socket

--- a/plugin.video.vrt.nu/resources/lib/metadata.py
+++ b/plugin.video.vrt.nu/resources/lib/metadata.py
@@ -203,7 +203,7 @@ class Metadata:
                 if position and total and SECONDS_MARGIN < position < total - SECONDS_MARGIN:
                     properties['resumetime'] = position
                     properties['totaltime'] = total
-                    log(2, '[Metadata] manual resumetime set to %d' % position)
+                    log(2, '[Metadata] manual resumetime set to {position}', position=position)
 
             episode = self.get_episode(api_data)
             season = self.get_season(api_data)

--- a/plugin.video.vrt.nu/resources/lib/resumepoints.py
+++ b/plugin.video.vrt.nu/resources/lib/resumepoints.py
@@ -33,7 +33,7 @@ class ResumePoints:
     def resumepoint_headers(url=None):
         """Generate http headers for VRT NU Resumepoints API"""
         from tokenresolver import TokenResolver
-        xvrttoken = TokenResolver().get_xvrttoken(token_variant='user')
+        xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
         headers = {}
         if xvrttoken:
             url = 'https://www.vrt.be' + url if url else 'https://www.vrt.be/vrtnu'

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -143,9 +143,9 @@ class StreamService:
             return None
         token_url = api_data.media_api_url + '/tokens'
         if api_data.is_live_stream:
-            playertoken = self._tokenresolver.get_playertoken(token_url, token_variant='live', roaming=roaming)
+            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'live', token_url, roaming=roaming)
         else:
-            playertoken = self._tokenresolver.get_playertoken(token_url, token_variant='ondemand', roaming=roaming)
+            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'ondemand', token_url, roaming=roaming)
 
         # Construct api_url and get video json
         if not playertoken:
@@ -210,11 +210,6 @@ class StreamService:
             elif vudrm_token:
                 protocol = 'hls_aes'
             else:
-                protocol = 'hls'
-
-            # Workaround for Radio 1 live stream slow starts with HTTP 415
-            # https://github.com/add-ons/plugin.video.vrt.nu/issues/735
-            if video.get('video_id') == 'vualto_radio1':
                 protocol = 'hls'
 
             # Get stream manifest url

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -19,9 +19,11 @@ HTML_MAPPING = [
     (re.compile(r'<(/?)b(|\s[^>]+)>', re.I), '[\\1B]'),
     (re.compile(r'<em(|\s[^>]+)>', re.I), '[B][COLOR={highlighted}]'),
     (re.compile(r'</em>', re.I), '[/COLOR][/B]'),
+    (re.compile(r'<(strong|h\d)>', re.I), '[B]'),
+    (re.compile(r'</(strong|h\d)>', re.I), '[/B]'),
     (re.compile(r'<li>', re.I), '- '),
-    (re.compile(r'</?(li|ul)(|\s[^>]+)>', re.I), '\n'),
-    (re.compile(r'</?(div|p|span)(|\s[^>]+)>', re.I), ''),
+    (re.compile(r'</?(li|ul|ol)(|\s[^>]+)>', re.I), '\n'),
+    (re.compile(r'</?(code|div|p|pre|span)(|\s[^>]+)>', re.I), ''),
     (re.compile('<br>\n{0,1}', re.I), ' '),  # This appears to be specific formatting for VRT NU, but unwanted by us
     (re.compile('(&nbsp;\n){2,}', re.I), '\n'),  # Remove repeating non-blocking spaced newlines
 ]

--- a/plugin.video.vrt.nu/resources/settings.xml
+++ b/plugin.video.vrt.nu/resources/settings.xml
@@ -62,8 +62,8 @@
         <setting label="30873" help="30874" type="action" action="Addon.OpenSettings(service.upnext)" enable="eq(-1,true)" option="close" visible="System.HasAddon(service.upnext)" subsetting="true"/> <!-- Up Next settings -->
         <!-- IPTV Manager -->
         <!-- setting label="30875" help="30876" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/ --> <!-- Install IPTV Manager add-on -->
-        <setting label="30877" help="30878" type="bool" id="iptv.enabled" default="true" visible="System.HasAddon(service.iptv.manager)" />
-        <setting label="30879" help="30880" type="action" action="Addon.OpenSettings(service.iptv.manager)" enable="eq(-1,true)" option="close" visible="System.HasAddon(service.iptv.manager)" subsetting="true"/> <!-- IPTV Manager settings -->
+        <setting label="30877" help="30878" type="bool" id="iptv.enabled" default="true" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" />
+        <setting label="30879" help="30880" type="action" action="Addon.OpenSettings(service.iptv.manager)" enable="eq(-1,true)" option="close" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" subsetting="true"/> <!-- IPTV Manager settings -->
         <setting id="iptv.channels_uri" default="plugin://plugin.video.vrt.nu/iptv/channels" visible="false"/>
         <setting id="iptv.epg_uri" default="plugin://plugin.video.vrt.nu/iptv/epg" visible="false"/>
         <!-- PySocks -->


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.3.5
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

*The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.*

### Description of changes:

v2.3.5 (2020-05-27)
- Fix watching VRT NU abroad
- Improve and fix user authentication
- Add support for playing from the Guide with IPTV Manager

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
