### PR TITLE
[plugin.video.pcloud-video-streaming] 1.4.2

### DIFF
--- a/plugin.video.pcloud-video-streaming/addon.py
+++ b/plugin.video.pcloud-video-streaming/addon.py
@@ -153,7 +153,8 @@ if mode[0] in ("folder", "myshares"):
 			oneFileOrFolderItem = oneItem["metadata"]
 		filename = oneFileOrFolderItem["name"]
 		if oneFileOrFolderItem["isfolder"]:
-			li = xbmcgui.ListItem(filename, iconImage='DefaultFolder.png')
+			li = xbmcgui.ListItem(filename)
+			li.setIconImage("DefaultFolder.png")
 			# Add context menu item for "delete folder"
 			deleteActionMenuText = myAddon.getLocalizedString(30114) # "Delete from PCloud..."
 			deleteActionUrl = base_url + "?mode=delete&folderID=" + str(oneFileOrFolderItem["folderid"]) + "&filename=" + quote(oneFileOrFolderItem["name"].encode("utf-8"))
@@ -179,7 +180,8 @@ if mode[0] in ("folder", "myshares"):
 					thumbnailUrl = "DefaultVideo.png"
 				elif contentType[:6] == "audio/":
 					thumbnailUrl = "DefaultAlbumCover.png"
-			li = xbmcgui.ListItem(filename, iconImage=thumbnailUrl)
+			li = xbmcgui.ListItem(filename)
+			li.setIconImage(thumbnailUrl)
 			if contentType[:6] == "video/":
 				li.addStreamInfo(
 					"video",
@@ -223,15 +225,17 @@ if mode[0] in ("folder", "myshares"):
 			url = base_url + "?mode=myshares"
 			# "My Shares" (in a different color)
 			mySharesFolderText = "[COLOR blue]{0}[/COLOR]".format(myAddon.getLocalizedString(30122))
-			li = xbmcgui.ListItem(mySharesFolderText, iconImage="DefaultFolder.png")
+			li = xbmcgui.ListItem(mySharesFolderText)
+			li.setIconImage("DefaultFolder.png")
 			xbmcplugin.addDirectoryItem(handle=addon_handle, url=url, listitem=li, isFolder=True)
 		else:
 			# now add "go up one level" fake directory if we're NOT in the root folder
 			parentFolderID = folderContents["metadata"]["parentfolderid"]
 			url = base_url + "?mode=folder&folderID=" + str(parentFolderID)
 			# "Back to parent folder"
-			parentFolderText = "[I]{0}[/I]".format(myAddon.getLocalizedString(30113))
-			li = xbmcgui.ListItem(parentFolderText, iconImage="DefaultFolder.png")
+			parentFolderText = "--[I]{0}[/I]".format(myAddon.getLocalizedString(30113))
+			li = xbmcgui.ListItem(parentFolderText)
+			li.setIconImage("DefaultFolder.png")
 			xbmcplugin.addDirectoryItem(handle=addon_handle, url=url, listitem=li, isFolder=True)
 	else:
 		# if we're in the "My Shares" folder, add "go to my pCloud (root folder)" virtual directory
@@ -239,7 +243,8 @@ if mode[0] in ("folder", "myshares"):
 		url = base_url + "?mode=folder&folderID={0}".format(rootFolderID)
 		# "Back to My pCloud"
 		parentFolderText = "[I]{0}[/I]".format(myAddon.getLocalizedString(30123))
-		li = xbmcgui.ListItem(parentFolderText, iconImage="DefaultFolder.png")
+		li = xbmcgui.ListItem(parentFolderText)
+		li.setIconImage("DefaultFolder.png")
 		xbmcplugin.addDirectoryItem(handle=addon_handle, url=url, listitem=li, isFolder=True)
 
 	# Add various sort methods

--- a/plugin.video.pcloud-video-streaming/addon.xml
+++ b/plugin.video.pcloud-video-streaming/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.4.1" provider-name="Guido Domenici">
+<addon id="plugin.video.pcloud-video-streaming" name="PCloud Video Streaming" version="1.4.2" provider-name="Guido Domenici">
   <requires>
     <import addon="xbmc.python" version="2.19.0"/>
   </requires>

--- a/plugin.video.pcloud-video-streaming/changelog.txt
+++ b/plugin.video.pcloud-video-streaming/changelog.txt
@@ -1,3 +1,7 @@
+v1.4.2 -- 07-Jun-2020
+- Fixed issue #27: In certain locales (such as en-nz), the "Back to parent folder" list item would sort
+  after folders starting with a number. Now it sorts correctly at the top of the list.
+
 v1.4.1 -- 27-Mar-2020
 - Now also made available as a Music add-on.
 


### PR DESCRIPTION
### Description
Fixed issue #27: In certain locales (such as en-nz), the "Back to parent folder" list item would sort after folders starting with a number. Now it sorts correctly at the top of the list.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
