### PR TITLE
[plugin.audio.radiobrowser] 1.2.0

### DIFF
--- a/plugin.audio.radiobrowser/addon.xml
+++ b/plugin.audio.radiobrowser/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.radiobrowser" name="Radio-Browser.info" version="1.1.0" provider-name="sailor">
+<addon id="plugin.audio.radiobrowser" name="Radio-Browser.info" version="1.2.0" provider-name="sailor">
   <requires>
     <import addon="xbmc.python" version="2.24.0"/>
   </requires>

--- a/plugin.audio.radiobrowser/changelog.txt
+++ b/plugin.audio.radiobrowser/changelog.txt
@@ -3,3 +3,5 @@ v1.0.0 (2016-06-19)
 v1.1.0 (2018-12-17)
 - Add search function
 - Add in-app favorites menu
+v1.2.0 (2020-06-21)
+- Use new api (api.radio-browser.info)

--- a/plugin.audio.radiobrowser/resources/language/resource.language.bg_bg/strings.po
+++ b/plugin.audio.radiobrowser/resources/language/resource.language.bg_bg/strings.po
@@ -42,8 +42,8 @@ msgid "Countries"
 msgstr "Държави"
 
 msgctxt "#32006"
-msgstr "Всички"
 msgid "All"
+msgstr "Всички"
 
 msgctxt "#32007"
 msgid "Search..."


### PR DESCRIPTION
### Description
This is an update of the plugin audio radiobrowser to version 1.2.0 with the following changes:
* use new api as documented at https://api.radio-browser.info
* stop play before start again to fix play only every second time bug
* use xbmc log instead of print

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0