### PR TITLE
[service.upnext@leia] 1.1.2

### DIFF
--- a/service.upnext/addon.xml
+++ b/service.upnext/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<addon id="service.upnext" name="Up Next" version="1.1.1" provider-name="im85288">
+<addon id="service.upnext" name="Up Next" version="1.1.2" provider-name="im85288">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
     </requires>
@@ -40,6 +40,10 @@ Många befintliga tillägg integreras redan med den här utanför lådan-tjänst
         <platform>all</platform>
         <license>GPL-2.0-only</license>
         <news>
+
+### v1.1.2 (2020-06-22)
+- Bug fix for change from sleep to waitForAbort using seconds and not ms
+
 ### v1.1.1 (2020-06-21)
 - Avoid conflict with external players
 - Restore "Ignore Playlist" option

--- a/service.upnext/resources/lib/player.py
+++ b/service.upnext/resources/lib/player.py
@@ -15,6 +15,7 @@ class UpNextPlayer(Player):
     def __init__(self):
         self.api = Api()
         self.state = State()
+        self.monitor = Monitor()
         Player.__init__(self)
 
     def set_last_file(self, filename):
@@ -31,7 +32,7 @@ class UpNextPlayer(Player):
 
     def onPlayBackStarted(self):  # pylint: disable=invalid-name
         """Will be called when kodi starts playing a file"""
-        Monitor().waitForAbort(5000)
+        self.monitor.waitForAbort(5)
         if not getCondVisibility('videoplayer.content(episodes)'):
             return
         self.state.track = True


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Up Next
  - Add-on ID: service.upnext
  - Version number: 1.1.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/im85288/service.upnext
  
A service add-on that shows a Netflix-style notification for watching the next episode. After a few automatic iterations it asks the user if he is still there watching.

A lot of existing add-ons already integrate with this service out-of-the-box.

### Description of changes:



### v1.1.2 (2020-06-22)
- Bug fix for change from sleep to waitForAbort using seconds and not ms

### v1.1.1 (2020-06-21)
- Avoid conflict with external players
- Restore "Ignore Playlist" option
- Fix a known Kodi bug related to displaying hours
- Improvements to endtime visualization
- New translations for Hindi and Romanian
- Translation updates to Hungarian and Spanish

### v1.1.0 (2020-01-17)
- Add notification_offset for Netflix add-on
- Fix various runtime exceptions
- Implement new settings
- Implement new developer mode
- Show current time and next endtime in notification
- New translations for Brazilian, Czech, Greek, Japanese, Korean
- New translations for Russian, Slovak, Spanish, Swedish
- Translation updates to Croatian, French, German, Hungarian, Italian, Polish
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
