### PR TITLE
[plugin.audio.radio_de@matrix] 3.0.4+matrix.0

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.3+matrix.6">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.4+matrix.0">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.xbmcswift2" version="19.0.0" />
@@ -12,10 +12,8 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>v3.0.3+matrix.6 (1/5/2020)
-            [fix] Custom stations if the url is not a playlist
-            [new] Spanish website radio.es and improved translations
-            [new] screenshot support for addon-website
+        <news>v3.0.4+matrix.0 (27/9/2020)
+            [new] Add stationname property
         </news>
         <summary lang="be_BY">Access &gt;30000 radio broadcasts</summary>
         <summary lang="ca_ES">accedeix a mes de 30000 emissores de radio</summary>

--- a/plugin.audio.radio_de/changelog.txt
+++ b/plugin.audio.radio_de/changelog.txt
@@ -1,3 +1,6 @@
+v3.0.4+matrix.0 (27/9/2020)
+    - [new] Add stationname property
+
 v3.0.3+matrix.6 (1/5/2020)
     - [fix] Custom stations if the url is not a playlist
     - [new] Spanish website radio.es and improved translations

--- a/plugin.audio.radio_de/resources/lib/plugin.py
+++ b/plugin.audio.radio_de/resources/lib/plugin.py
@@ -542,6 +542,9 @@ def __add_stations(stations, add_custom=False, browse_more=None):
                 station_id=station_id,
             ),
             'is_playable': True,
+            'properties': {
+                'StationName': station.get('name', '') # Matrix++ only
+            }
         })
     if add_custom:
         items.append({


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 3.0.4+matrix.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.radio_de
  
Music plugin to access over 30000 international radio broadcasts from rad.io, radio.de, radio.fr, radio.pt and radio.es[CR]Currently features[CR]- English, german, french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

v3.0.4+matrix.0 (27/9/2020)
            [new] Add stationname property
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
