### PR TITLE
[plugin.audio.shoutcast@matrix] 2.5.1+matrix.0

### DIFF
--- a/plugin.audio.shoutcast/addon.xml
+++ b/plugin.audio.shoutcast/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.shoutcast" name="SHOUTcast" provider-name="Tristan Fischer (sphere@dersphere.de), enen92" version="2.5.0+matrix.1">
+<addon id="plugin.audio.shoutcast" name="SHOUTcast" provider-name="Tristan Fischer (sphere@dersphere.de), enen92" version="2.5.1+matrix.0">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.xbmcswift2" version="19.0.0" />
@@ -88,12 +88,8 @@
         <description lang="ta_IN">இந்த துணை பயன் மூலம் நீங்கள் 50.000 மேற்பட்ட இலவச இணைய வானொலி நிலையங்களை உலாவ முடியும். தற்போதய சிறப்பியல்:[CR]- உச்சி 500 நிலையங்கள்[CR]- வகைபடி உலாவு (துணை வகைப்படி சேர்க்கவும் - அமைப்புகளில் தேர்வு செய்யவும்)[CR]- பெயர்படி நிலையத்தனி தேடுக[CR]- பெயர்படி நிலையத்தனி தேடுக[CR]- "என்னுடைய நிலையங்கள்" பட்டியலை நீங்கள் நிர்வகிக்க முடியும்[CR]- பிட்வீதம் மற்றும் கேட்போர் அளவுகளை பார்க்கவும் மற்றும் வரிசைபடுத்தவும்[CR]- ஒரு பக்கத்தில் 500 நிலையங்கள் (அமைப்புகளில் மாற்ற இயலும்)[CR]- தேக்கத்தை பயன்படுத்தவும் (24 மணிநேர வகை, 1 மணிநேர நிலைய பட்டியல்)</description>
         <description lang="zh_CN">你可以使用本插件浏览超过50.000免费网络电台。当前功能：[CR]- 500强电台[CR]- 按类别浏览（可设置子类）[CR]- 按名字搜索电台[CR]- 按当前播放曲目搜索电台[CR]- 管理“我的电台”-列表[CR]- 按比特率和收听人数排序[CR]- 每页500个电台（可设置）[CR]- 使用缓存（24小时类别，1小时站点列表）</description>
         <news>
-            2.5.0+matrix.1 (12.4.2020) - matrix edition
-            - Remove python2 support
-            - Remove simplejson
-            - New language folder layout
-            - Automated submissions to matrix branch
-            - Addon.xml cosmetics
+            2.5.1+matrix.0 (27/09/2020)
+            - Add stationname property (matrix only)
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/plugin.audio.shoutcast/changelog.txt
+++ b/plugin.audio.shoutcast/changelog.txt
@@ -1,3 +1,6 @@
+2.5.1+matrix.0 (27/09/2020)
+ - Add stationname property (matrix only)
+
 2.5.0+matrix.1 (12.4.2020) - matrix edition
  - Remove python2 support
  - Remove simplejson

--- a/plugin.audio.shoutcast/resources/lib/plugin.py
+++ b/plugin.audio.shoutcast/resources/lib/plugin.py
@@ -183,7 +183,7 @@ def __add_stations(stations):
                 'RunPlugin(%s)' % plugin.url_for(
                     endpoint='add_to_my_stations',
                     station_id=station_id,
-                    station_name=station['name'].encode('utf-8')
+                    station_name=station.get('name', '')
                 )
             )]
         else:
@@ -197,7 +197,7 @@ def __add_stations(stations):
         if show_bitrate and station.get('bitrate'):
             name = '%s  [%s kbps]' % (station['name'], station['bitrate'])
         else:
-            name = station['name']
+            name = station.get('name', '')
         item = {
             'label': name,
             'thumbnail': icon,
@@ -216,7 +216,10 @@ def __add_stations(stations):
             'path': plugin.url_for(
                 endpoint='resolve_play_url',
                 station_id=station['id'],
-            )
+            ),
+            'properties': {
+                'StationName': station.get('name', '') # Matrix++ only
+            }
         }
         items.append(item)
     finish_kwargs = {


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SHOUTcast
  - Add-on ID: plugin.audio.shoutcast
  - Version number: 2.5.1+matrix.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.shoutcast
  
With this Add-on you can browse more than 50.000 free internet radio stations. Current Features:[CR]- Top 500 Stations[CR]- Browse by genre (and subgenre if enabled in settings)[CR]- Search Station by name[CR]- Search Stations by current playing track[CR]- You can manage a "My Stations"-list[CR]- bitrate and amount of listeners visible and sortable[CR]- 500 Stations on each Page (can be changed in the settings)[CR]- uses cache (24h genre, 1h station listings)

### Description of changes:


            2.5.1+matrix.0 (27/09/2020)
            - Add stationname property (matrix only)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
