### PR TITLE
[plugin.video.southpark_unofficial] 0.6.1+matrix.1

### DIFF
--- a/plugin.video.southpark_unofficial/addon.xml
+++ b/plugin.video.southpark_unofficial/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.6.0+matrix.1" provider-name="Deroad">
+<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.6.1+matrix.1" provider-name="Deroad">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
     </requires>

--- a/plugin.video.southpark_unofficial/changelog.txt
+++ b/plugin.video.southpark_unofficial/changelog.txt
@@ -1,3 +1,5 @@
+0.6.1
+- Removed debug lines.
 0.6.0
 - New api. for now only english will work.
 0.5.9

--- a/plugin.video.southpark_unofficial/southpark.py
+++ b/plugin.video.southpark_unofficial/southpark.py
@@ -275,9 +275,6 @@ def _parse_episodes(data, season, domain):
 
 def _download_data(url, link_in_html):
 	webpage = _http_get(url)
-	with open("/tmp/test.html",'wb') as output:
-		output.truncate()
-		output.write(webpage)
 	if "window.__DATA__" in webpage:
 		dataidx  = webpage.index("window.__DATA__")
 		data     = webpage[dataidx:]


### PR DESCRIPTION
### Description

In the last release i forgot to remove a debug line.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
