### PR TITLE
[plugin.video.curiositystream] 2.0.1+matrix.2

### DIFF
--- a/plugin.video.curiositystream/addon.xml
+++ b/plugin.video.curiositystream/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.curiositystream" name="Curiositystream" version="2.0.0+matrix.2" provider-name="GMaxera">
+<addon id="plugin.video.curiositystream" name="Curiositystream" version="2.0.1+matrix.2" provider-name="GMaxera">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.requests" version="2.22.0"/>
@@ -21,6 +21,9 @@ The add-on only provides an interface to access CuriosityStream media from Kodi.
     <email>gmaxera@gmail.com</email>
     <source>https://github.com/GMaxera/repo-plugins/tree/curiositystream-leia/plugin.video.curiositystream</source>
     <news>
+v2.0.1+matrix.2
+- More resilient when API returns 500
+
 v2.0.0+matrix.2
 - Support for Kodi Matrix
 

--- a/plugin.video.curiositystream/resources/lib/curiositystream.py
+++ b/plugin.video.curiositystream/resources/lib/curiositystream.py
@@ -184,6 +184,10 @@ class CuriosityStream(object):
         resp = self._session.get(
             "{}collections/{}".format(self._base_url, collection_id)
         )
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError:
+            return {"title": ""}
         return resp.json()["data"]
 
     def _extract_media_data(self, media_data):
@@ -194,7 +198,7 @@ class CuriosityStream(object):
             return u"{} ({} episodes)".format(m["title"], m["media_count"])
 
         def enhanced_description(m):
-            return (u"{episode_number}\n{description}\n{producer}").format(
+            return u"{episode_number}\n{description}\n{producer}".format(
                 description=m["description"],
                 producer=m["producer"],
                 episode_number="Episode {} of {}\n".format(


### PR DESCRIPTION
### Description
v2.0.1+matrix.2
- More resilient when API returns 500

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
