### PR TITLE
[plugin.video.crackle@matrix] 2020.10.7+matrix.1

### DIFF
--- a/plugin.video.crackle/addon.xml
+++ b/plugin.video.crackle/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.crackle" name="Crackle" version="2020.10.4+matrix.0" provider-name="eracknaphobia">
+<addon id="plugin.video.crackle" name="Crackle" version="2020.10.7+matrix.1" provider-name="eracknaphobia">
   <requires>
       <import addon="xbmc.python" version="3.0.0"/>
-      <import addon="script.module.requests" version="2.22.0"/>
-      <import addon="script.module.inputstreamhelper" version="0.3.3"/>
+      <import addon="script.module.requests"/>
+      <import addon="script.module.inputstreamhelper"/>
       <import addon="script.module.kodi-six" />
   </requires>
   <extension point="xbmc.python.pluginsource" library="main.py">
@@ -14,9 +14,7 @@
     <summary lang="en_GB">Crackle delivers popular, award-winning TV, movies and originals. With no limit to how much you can watch across all your devices, you can binge all you want, wherever you want.</summary>
     <description lang="en_GB">Crackle is a video streaming distributor of original web shows, Hollywood movies, and TV shows. Founded in the early 2000s as Grouper, and rebranded in 2007, Crackle is owned by Sony Pictures Entertainment.</description>
       <news>
-        - Update code for Python3
-        - Improve Sorting of list items (thanks ssreekanth)
-        - Add DRM playback support
+        - Sort tv shows by episode
       </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.crackle/resources/lib/globals.py
+++ b/plugin.video.crackle/resources/lib/globals.py
@@ -128,8 +128,7 @@ def get_episodes(channel):
 
         add_stream(title,id,'tvshows',icon,fanart,info)
 
-    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL)
-    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_LABEL_IGNORE_THE)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_EPISODE)
 
 
 def get_movie_id(channel):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Crackle
  - Add-on ID: plugin.video.crackle
  - Version number: 2020.10.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.crackle
  
Crackle is a video streaming distributor of original web shows, Hollywood movies, and TV shows. Founded in the early 2000s as Grouper, and rebranded in 2007, Crackle is owned by Sony Pictures Entertainment.

### Description of changes:


        - Sort tv shows by episode
      

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
