### PR TITLE
[plugin.googledrive] 1.4.3

### DIFF
--- a/plugin.googledrive/addon.xml
+++ b/plugin.googledrive/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.googledrive" name="Google Drive" version="1.3.4" provider-name="Carlos Guzman (cguZZman)">
+<addon id="plugin.googledrive" name="Google Drive" version="1.4.3" provider-name="Carlos Guzman (cguZZman)">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0" />
-		<import addon="script.module.clouddrive.common" version="1.2.12"/>
+		<import addon="script.module.clouddrive.common" version="1.3.2"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="addon.py">
 		<provides>image audio video</provides>
@@ -41,8 +41,9 @@ Play all your media from Google Drive including Videos, Music and Pictures (incl
 			<fanart>fanart.jpg</fanart>
 		</assets>
 		<news>
-v1.3.4 released Mar 3, 2020:
-- NFO export
+v1.4.3 released Oct 11, 2020:
+- New export functionality
+- Multiple fixes
 		</news>
 		<disclaimer lang="en_GB">
 This cloud drive addon uses a third-party authentication mechanism commonly known as OAuth 2.0.

--- a/plugin.googledrive/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.googledrive/resources/language/resource.language.en_gb/strings.po
@@ -29,7 +29,7 @@ msgid "Source Service"
 msgstr ""
 
 msgctxt "#32003"
-msgid "Before export to library, remove previous files and folders"
+msgid "Before full export, remove previous local files and folders"
 msgstr ""
 
 msgctxt "#32004"
@@ -92,6 +92,10 @@ msgctxt "#32018"
 msgid "Save resume points and watched status in library"
 msgstr ""
 
+msgctxt "#32019"
+msgid "Do not include filename extension in a .strm"
+msgstr ""
+
 msgctxt "#32030"
 msgid "Collaboration"
 msgstr ""
@@ -145,9 +149,13 @@ msgid "Response code: %s"
 msgstr ""
 
 msgctxt "#32074"
-msgid "Export .nfo files"
+msgid "Download metadata files (.nfo, .strm)"
 msgstr ""
 
 msgctxt "#32075"
 msgid "Skip unmodified files"
+msgstr ""
+
+msgctxt "#32076"
+msgid "Play choosing stream format"
 msgstr ""

--- a/plugin.googledrive/resources/lib/provider/googledrive.py
+++ b/plugin.googledrive/resources/lib/provider/googledrive.py
@@ -24,9 +24,9 @@ import copy
 from clouddrive.common.remote.provider import Provider
 from clouddrive.common.utils import Utils
 from clouddrive.common.ui.logger import Logger
-from clouddrive.common.cache.cache import Cache
 from clouddrive.common.ui.utils import KodiUtils
 from clouddrive.common.exception import RequestException, ExceptionUtils
+from clouddrive.common.cache.cache import Cache
 try:
     from urllib.error import HTTPError
 except ImportError:
@@ -39,20 +39,20 @@ except NameError:
 
 
 class GoogleDrive(Provider):
-    _default_parameters = {'spaces': 'drive', 'prettyPrint': 'false'}
-    _is_team_drive = False
-    _team_drive_parameters = {'includeTeamDriveItems': 'true', 'supportsTeamDrives': 'true', 'corpora': 'teamDrive', 'teamDriveId': ''}
+    _default_parameters = {'spaces': 'drive', 'supportsAllDrives': 'true', 'prettyPrint': 'false'}
+    _is_shared_drive = False
+    _shared_drive_parameters = {'includeItemsFromAllDrives': 'true', 'corpora': 'drive', 'driveId': ''}
     _user = None
 
     def __init__(self, source_mode = False):
         super(GoogleDrive, self).__init__('googledrive', source_mode)
+        self.download_requires_auth = True
         self._items_cache = Cache(KodiUtils.get_addon_info('id'), 'items', datetime.timedelta(minutes=KodiUtils.get_cache_expiration_time()))
             
     def configure(self, account_manager, driveid):
         super(GoogleDrive, self).configure(account_manager, driveid)
-        self._account_manager.load()
-        drive = account_manager.get_drive_by_driveid(driveid)
-        self._is_team_drive = drive and 'type' in drive and drive['type'] == 'drive#teamDrive'
+        drive = account_manager.get_by_driveid('drive', driveid)
+        self._is_shared_drive = drive and 'type' in drive and (drive['type'] == 'drive#drive' or drive['type'] == 'drive#teamDrive')
         
     def _get_api_url(self):
         return 'https://www.googleapis.com/drive/v3'
@@ -74,15 +74,15 @@ class GoogleDrive(Provider):
             'type' : ''
         }]
         try:
-            all_teamdrives_fetch = False
+            all_shareddrives_fetch = False
             page_token = None
             parameters = {'pageSize': 100}
-            while not all_teamdrives_fetch:
+            while not all_shareddrives_fetch:
                 if page_token:
-                    parameters['nextPageToken'] = page_token
-                response = self.get('/teamdrives', parameters=parameters, request_params=request_params, access_tokens=access_tokens)
-                if response and 'teamDrives' in response:
-                    for drive in response['teamDrives']:
+                    parameters['pageToken'] = page_token
+                response = self.get('/drives', parameters=parameters, request_params=request_params, access_tokens=access_tokens)
+                if response and 'drives' in response:
+                    for drive in response['drives']:
                         drives.append({
                             'id' : drive['id'],
                             'name' : Utils.get_safe_value(drive, 'name', drive['id']),
@@ -91,7 +91,7 @@ class GoogleDrive(Provider):
                 if response and 'nextPageToken' in response:
                     page_token = response['nextPageToken']
                 else:
-                    all_teamdrives_fetch = True
+                    all_shareddrives_fetch = True
         except RequestException as ex:
             httpex = ExceptionUtils.extract_exception(ex, HTTPError)
             if not httpex or httpex.code != 403:
@@ -99,21 +99,21 @@ class GoogleDrive(Provider):
         return drives
     
     def get_drive_type_name(self, drive_type):
-        if drive_type == 'drive#teamDrive':
-            return 'Team Drive'
+        if drive_type == 'drive#drive' or drive_type == 'drive#teamDrive':
+            return 'Shared Drive'
         return drive_type
     
     def prepare_parameters(self):
         parameters = copy.deepcopy(self._default_parameters)
-        if self._is_team_drive:
-            parameters.update(self._team_drive_parameters)
-            parameters['teamDriveId'] = self._driveid
+        if self._is_shared_drive:
+            parameters.update(self._shared_drive_parameters)
+            parameters['driveId'] = self._driveid
         return parameters
     
     def _get_field_parameters(self):
         file_fileds = 'id,name,modifiedTime,size,mimeType'
         if not self.source_mode:
-            file_fileds = file_fileds + ',description,hasThumbnail,thumbnailLink,owners(permissionId),parents,trashed,imageMediaMetadata(width),videoMediaMetadata'
+            file_fileds = file_fileds + ',description,hasThumbnail,thumbnailLink,owners(permissionId),parents,trashed,imageMediaMetadata(width),videoMediaMetadata,shortcutDetails'
         return file_fileds
         
     def get_folder_items(self, item_driveid=None, item_id=None, path=None, on_items_page_completed=None, include_download_info=False):
@@ -128,7 +128,7 @@ class GoogleDrive(Provider):
             parameters['q'] = path
         elif path != 'photos':
             if path == '/':
-                parent = self._driveid if self._is_team_drive else 'root'
+                parent = self._driveid if self._is_shared_drive else 'root'
                 parameters['q'] = '\'%s\' in parents' % parent
             elif not is_album:
                 item = self.get_item_by_path(path, include_download_info)
@@ -141,23 +141,30 @@ class GoogleDrive(Provider):
         self.configure(self._account_manager, self._driveid)
         provider_method = self.get
         url = '/files'
+        parameters['pageSize'] = 1000
+        items = []
         if path == 'photos':
             self._photos_provider = GooglePhotos()
             self._photos_provider.configure(self._account_manager, self._driveid)
             parameters = {}
             provider_method = self._photos_provider.get
             url = '/albums'
+            items.append(self._extract_item({'id': 'photos', 'title': 'Photos', 'kind': 'album'}))
         elif is_album:
             self._photos_provider = GooglePhotos()
             self._photos_provider.configure(self._account_manager, self._driveid)
-            parameters = {'albumId': item_id}
+            if item_id == 'photos':
+                parameters = {}
+            else:
+                parameters = {'albumId': item_id}
             provider_method = self._photos_provider.post
             url = '/mediaItems:search'
             
         files = provider_method(url, parameters = parameters)
         if self.cancel_operation():
             return
-        return self.process_files(files, parameters, on_items_page_completed, include_download_info)
+        items.extend(self.process_files(files, parameters, on_items_page_completed, include_download_info))
+        return items
     
     def search(self, query, item_driveid=None, item_id=None, on_items_page_completed=None):
         item_driveid = Utils.default(item_driveid, self._driveid)
@@ -167,6 +174,7 @@ class GoogleDrive(Provider):
         if item_id:
             query += ' and \'%s\' in parents' % item_id
         parameters['q'] = query + ' and not trashed'
+        parameters['pageSize'] = 1000
         files = self.get('/files', parameters = parameters)
         if self.cancel_operation():
             return
@@ -219,8 +227,14 @@ class GoogleDrive(Provider):
     def _extract_item(self, f, include_download_info=False):
         kind = Utils.get_safe_value(f, 'kind', '')
         if kind == 'drive#change':
-            if 'file' in f:
-                f = f['file']
+            change_type = Utils.get_safe_value(f, 'changeType', '')
+            if change_type == 'file':
+                if 'file' in f:
+                    f = f['file']
+                else:
+                    f['id'] = Utils.get_safe_value(f, 'fileId')
+                    f['trashed'] = Utils.get_safe_value(f, 'removed')
+                    f['modifiedTime'] = Utils.get_safe_value(f, 'time')
             else:
                 return {}
         size = long('%s' % Utils.get_safe_value(f, 'size', 0))
@@ -233,6 +247,10 @@ class GoogleDrive(Provider):
         else:
             mimetype = Utils.get_safe_value(f, 'mimeType', '')
             name = Utils.get_safe_value(f, 'name', '')
+        if mimetype == 'application/vnd.google-apps.shortcut':
+            shortcut = Utils.get_safe_value(f, 'shortcutDetails') 
+            item_id = Utils.get_safe_value(shortcut, 'targetId', item_id)
+            mimetype = Utils.get_safe_value(shortcut, 'targetMimeType', mimetype)
         if is_media_items:
             name = Utils.get_safe_value(f, 'filename', item_id) 
         item = {
@@ -318,6 +336,7 @@ class GoogleDrive(Provider):
                 parent = self.get_item_by_path(parent, include_download_info)['id']
             item = None
             parameters['q'] = '\'%s\' in parents and name = \'%s\'' % (Utils.str(parent), Utils.str(filename).replace("'","\\'"))
+            parameters['pageSize'] = 1000
             files = self.get('/files', parameters = parameters)
             if (len(files['files']) > 0):
                 for f in files['files']:
@@ -338,6 +357,7 @@ class GoogleDrive(Provider):
         subtitles = []
         parameters['fields'] = 'files(' + self._get_field_parameters() + ')'
         parameters['q'] = 'name contains \'%s\'' % Utils.str(Utils.remove_extension(name)).replace("'","\\'")
+        parameters['pageSize'] = 1000
         files = self.get('/files', parameters = parameters)
         for f in files['files']:
             subtitle = self._extract_item(f, include_download_info)
@@ -370,7 +390,8 @@ class GoogleDrive(Provider):
         extra_info = {}
         parameters = self.prepare_parameters()
         parameters['pageToken'] = change_token
-        parameters['fields'] = 'kind,nextPageToken,newStartPageToken,changes(kind,type,removed,file(%s))' % self._get_field_parameters()
+        parameters['pageSize'] = 1000
+        parameters['fields'] = 'kind,nextPageToken,newStartPageToken,changes(kind,fileId,removed,changeType,time,file(%s))' % self._get_field_parameters()
         f = self.get('/changes', parameters = parameters)
         changes = self.process_files(f, parameters, include_download_info=True, extra_info=extra_info)
         self.persist_change_token(Utils.get_safe_value(extra_info, 'change_token'))

--- a/plugin.googledrive/resources/settings.xml
+++ b/plugin.googledrive/resources/settings.xml
@@ -10,8 +10,7 @@
         <setting label="32070" type="labelenum" id="default_stream_quality" subsetting="true" values="Original|1080p|720p|480p|360p" default="Original" value="Original"  enable="eq(-1,false)"/>
         <setting label="32001" type="lsep"/>
         <setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
-        <setting label="32074" type="bool" id="nfo_export" default="false" value="false"/>
-        <setting label="32075" type="bool" id="skip_unmodified" default="true" value="false"/>
+        <setting label="32019" type="bool" id="no_extension_strm" default="false" value="false"/>
         <setting label="32002" type="lsep"/>
         <setting label="32068" type="bool" id="allow_directory_listing" default="true"/>
         <setting label="32069" type="number" id="port_directory_listing" default="8587"/>


### PR DESCRIPTION
### Description
- Fix corruption on configurations
- Fix export
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
