### PR TITLE
[plugin.onedrive] 2.2.2

### DIFF
--- a/plugin.onedrive/addon.py
+++ b/plugin.onedrive/addon.py
@@ -34,8 +34,7 @@ class OneDriveAddon(CloudDriveAddon):
         return self._provider
     
     def get_custom_drive_folders(self, driveid):
-        self._account_manager.load()
-        drive = self._account_manager.get_drive_by_driveid(driveid)
+        drive = self._account_manager.get_by_driveid('drive', driveid)
         drive_folders = []
         if drive['type'] == 'personal':
             if self._content_type == 'image':

--- a/plugin.onedrive/addon.xml
+++ b/plugin.onedrive/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.onedrive" name="OneDrive" version="2.1.6" provider-name="Carlos Guzman (cguZZman)">
+<addon id="plugin.onedrive" name="OneDrive" version="2.2.2" provider-name="Carlos Guzman (cguZZman)">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0" />
-		<import addon="script.module.clouddrive.common" version="1.2.8"/>
+		<import addon="script.module.clouddrive.common" version="1.3.2"/>
 	</requires>
 	<extension point="xbmc.python.pluginsource" library="addon.py">
 		<provides>image audio video</provides>
@@ -30,32 +30,18 @@ Play all your media from OneDrive including Videos, Music and Pictures.
   - שימוש ב-OneDrive כמקור
   - תוכנית זו אינה מזוהה עם או בחסות מיקרוסופט.
 		</description>		
-		<license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
+		<license>GPL-3.0-or-later</license>
 		<source>https://github.com/cguZZman/plugin.onedrive</source>
 		<forum>https://github.com/cguZZman/plugin.onedrive/issues</forum>
 		<website>https://addons.kodi.tv/show/plugin.onedrive</website>
+		<assets>
+			<icon>icon.png</icon>
+			<fanart>fanart.jpg</fanart>
+		</assets>
 		<news>
-v2.1.6 released Sep 20, 2018:
-- Resume points and watched status for strm files in library
-v2.1.5 released Sep 12, 2018:
-- Sign-in fix
-v2.1.4 released Sep 10, 2018:
-- Subtitles assigned in source mode
-- Fixes
-v2.1.3 released Aug 24, 2018:
-- strm files saved in the cloud are exported as is.
-v2.1.2 released Aug 15, 2018:
-- Auto export and watch export folder.
-v2.1.1 released Jul 14, 2018:
-- Source mode fix
-v2.1.0 released Jul 11, 2018:
-- New mode for source and download services. Both moved to respective addons.
-- Source service fixed.
-v2.0.1 released Nov 30, 2017:
-- Bug fixes
-v2.0.0 released Nov 06, 2017:
-- Remake using script.module.clouddrive.common library
-- Fix OneDrive for Business functionality
+v2.2.2 released Oct 11, 2020:
+- New export functionality
+- Multiple fixes
 		</news>
 		<disclaimer lang="en_GB">
 This cloud drive addon uses a third-party authentication mechanism commonly known as OAuth 2.0.

--- a/plugin.onedrive/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.onedrive/resources/language/resource.language.en_gb/strings.po
@@ -76,6 +76,10 @@ msgctxt "#32018"
 msgid "Save resume points and watched status in library"
 msgstr ""
 
+msgctxt "#32019"
+msgid "Do not include filename extension in a .strm"
+msgstr ""
+
 msgctxt "#32030"
 msgid "Collaboration"
 msgstr ""

--- a/plugin.onedrive/resources/lib/provider/onedrive.py
+++ b/plugin.onedrive/resources/lib/provider/onedrive.py
@@ -189,7 +189,7 @@ class OneDrive(Provider):
         files = self.get(search_url)
         for f in files['value']:
             subtitle = self._extract_item(f, include_download_info)
-            if subtitle['name_extension'] == 'srt' or subtitle['name_extension'] == 'sub' or subtitle['name_extension'] == 'sbv':
+            if subtitle['name_extension'].lower() in ('srt','idx','sub','sbv','ass','ssa','smi'):
                 subtitles.append(subtitle)
         return subtitles
                 

--- a/plugin.onedrive/resources/settings.xml
+++ b/plugin.onedrive/resources/settings.xml
@@ -8,6 +8,7 @@
     	<setting label="32017" type="bool" id="ask_resume" default="true" visible="String.IsEmpty(window(home).property(iskrypton))" />
     	<setting label="32001" type="lsep"/>
     	<setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
+    	<setting label="32019" type="bool" id="no_extension_strm" default="false" value="false"/>
     	<setting label="32002" type="lsep"/>
 		<setting label="32068" type="bool" id="allow_directory_listing" default="true"/>
 		<setting label="32069" type="number" id="port_directory_listing" default="8586"/>


### PR DESCRIPTION
### Description
- Fix corruption on configurations
- Fix export
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
