### PR TITLE
[plugin.video.southpark_unofficial] 0.6.3

### DIFF
--- a/plugin.video.southpark_unofficial/addon.xml
+++ b/plugin.video.southpark_unofficial/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.6.2" provider-name="Deroad">
+<addon id="plugin.video.southpark_unofficial" name="South Park" version="0.6.3" provider-name="Deroad">
     <requires>
         <import addon="xbmc.python" version="2.19.0"/>
     </requires>

--- a/plugin.video.southpark_unofficial/changelog.txt
+++ b/plugin.video.southpark_unofficial/changelog.txt
@@ -1,7 +1,9 @@
+0.6.3
+- Cleanup, generic european stream and clear cache features.
 0.6.2
 - Use new apis
 - Added back all languages
-- unfortunately some streams might contain ads (based by location)
+- Unfortunately some streams might contain ads (based by location)
 0.6.1
 - Removed debug lines.
 0.6.0

--- a/plugin.video.southpark_unofficial/resources/language/English/strings.po
+++ b/plugin.video.southpark_unofficial/resources/language/English/strings.po
@@ -57,7 +57,7 @@ msgid "Check your internet connection!"
 msgstr ""
 
 msgctxt "#30011"
-msgid "Banned Episode! It's not available, sorry"
+msgid "It's not available, sorry"
 msgstr ""
 
 msgctxt "#30012"
@@ -74,4 +74,8 @@ msgstr ""
 
 msgctxt "#30015"
 msgid "Play directly the random episode"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Clear cache"
 msgstr ""

--- a/plugin.video.southpark_unofficial/resources/language/German/strings.po
+++ b/plugin.video.southpark_unofficial/resources/language/German/strings.po
@@ -57,8 +57,8 @@ msgid "Check your internet connection!"
 msgstr "Prüfe deine Internetverbindung!"
 
 msgctxt "#30011"
-msgid "Banned Episode! It's not available, sorry"
-msgstr "Gebannte Episode! Leider nicht verfügbar, sorry!"
+msgid "It's not available, sorry"
+msgstr "Leider nicht verfügbar, sorry!"
 
 msgctxt "#30012"
 msgid "Enable CC"
@@ -75,3 +75,7 @@ msgstr "Diese Episode ist noch nicht freigegeben!"
 msgctxt "#30015"
 msgid "Play directly the random episode"
 msgstr "Spielen Sie direkt die zufällige Folge"
+
+msgctxt "#30016"
+msgid "Clear cache"
+msgstr "Cache leeren"

--- a/plugin.video.southpark_unofficial/resources/language/Italian/strings.po
+++ b/plugin.video.southpark_unofficial/resources/language/Italian/strings.po
@@ -57,8 +57,8 @@ msgid "Check your internet connection!"
 msgstr "Controlla la tua connessione internet!"
 
 msgctxt "#30011"
-msgid "Banned Episode! It's not available, sorry"
-msgstr "Episodio Bannato! NON e' disponibile, mi spiace"
+msgid "It's not available, sorry"
+msgstr "Non e' disponibile, mi spiace"
 
 msgctxt "#30012"
 msgid "Enable CC"
@@ -75,3 +75,7 @@ msgstr "Questo episodio non è ancora stato rilasciato!"
 msgctxt "#30015"
 msgid "Play directly the random episode"
 msgstr "Riproduci direttamente l'episodio casuale"
+
+msgctxt "#30016"
+msgid "Clear cache"
+msgstr "Rimuovi la cache"

--- a/plugin.video.southpark_unofficial/resources/settings.xml
+++ b/plugin.video.southpark_unofficial/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-	<setting default="0" id="audio_lang" label="30000" type="enum" values="EN|ES|DE|SE"/>
-	<setting default="0" id="geolocation" label="30001" type="enum" values="US|UK|ES|DE|IT|SE"/>
+	<setting default="0" id="audio_lang" label="30001" type="enum" values="North America[EN]|North America[ES]|Germany|Sweden|Europe"/>
 	<setting default="false" id="cc" label="30012" type="bool"/>
 	<setting default="false" id="playrandom" label="30015" type="bool"/>
+	<setting action="RunPlugin(plugin://$ID?mode=sp:clearcache)" option="close" label="30016" type="action"/>
 </settings>


### PR DESCRIPTION
### Description

Cleanup, generic european stream and clear cache features.

Matrix release: https://github.com/xbmc/repo-plugins/pull/3164

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
