### PR TITLE
[plugin.video.vrt.nu@krypton] 2.4.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,16 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.4.1 (2020-10-31)
+- Add new category "Nostalgia" (@dagwieers)
+- Add poster support (@dagwieers)
+- Add product placement and "kijkwijzer" metadata (@mediaminister)
+- Get categories from online JSON (@mediaminister)
+- Improvements to connection error handling (@dagwieers)
+- Improvements to virtual subclip support (@mediaminister)
+- Extend soon offline menu to seven days (@mediaminster)
+- Improve Up Next support (@mediaminister)
+
 ### v2.4.0 (2020-07-18)
 - Show error messages when connections fail (@mediaminister, @dagwieers)
 - Improve user authentication cache (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.0" provider-name="Martijn Moreel, dagwieers">
-<requires>
-  <import addon="resource.images.studios.white" version="0.0.22"/>
-  <import addon="script.module.beautifulsoup4" version="4.6.2"/>
-  <import addon="script.module.dateutil" version="2.8.0"/>
-  <import addon="script.module.inputstreamhelper" version="0.4.3"/>
-  <import addon="script.module.routing" version="0.2.3"/>
-  <import addon="xbmc.python" version="2.25.0"/>
-</requires>
-<extension point="xbmc.python.pluginsource" library="resources/lib/addon_entry.py">
-  <provides>video</provides>
-</extension>
-<extension point="xbmc.service" library="resources/lib/service_entry.py"/>
-<extension point="xbmc.addon.metadata">
-  <summary lang="en_GB">Watch videos from VRT NU</summary>
-  <description lang="en_GB">VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+  <requires>
+    <import addon="resource.images.studios.white" version="0.0.22"/>
+    <import addon="script.module.beautifulsoup4" version="4.6.2"/>
+    <import addon="script.module.dateutil" version="2.8.0"/>
+    <import addon="script.module.inputstreamhelper" version="0.4.3"/>
+    <import addon="script.module.routing" version="0.2.3"/>
+    <import addon="xbmc.python" version="2.25.0"/>
+  </requires>
+  <extension point="xbmc.python.pluginsource" library="resources/lib/addon_entry.py">
+    <provides>video</provides>
+  </extension>
+  <extension point="xbmc.service" library="resources/lib/service_entry.py"/>
+  <extension point="xbmc.addon.metadata">
+    <summary lang="en_GB">Watch videos from VRT NU</summary>
+    <description lang="en_GB">VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).
 
   - Track the programs you like
   - List all videos alphabetically by program, category, channel or feature
@@ -23,9 +23,9 @@
   - Browse the online TV guides or search VRT NU
 
 [I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]</description>
-  <disclaimer lang="en_GB">The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.</disclaimer>
-  <summary lang="nl_NL">VRT NU videos bekijken.</summary>
-  <description lang="nl_NL">VRT NU is het video-on-demand platform van de Vlaamse publieke omroep (VRT).
+    <disclaimer lang="en_GB">The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.</disclaimer>
+    <summary lang="nl_NL">VRT NU videos bekijken.</summary>
+    <description lang="nl_NL">VRT NU is het video-on-demand platform van de Vlaamse publieke omroep (VRT).
 
   - Volg je favoriete tv-programma's
   - Raadpleeg video's op basis van programma, categorie, kanaal of feature
@@ -34,14 +34,24 @@
   - Doorblader de online tv-gids of doorzoek VRT NU
 
 [I]Deze VRT NU add-on wordt niet ondersteund door de VRT, en wordt aangeboden 'as is', zonder enige garantie.[/I]</description>
-  <disclaimer lang="nl_NL">Deze VRT NU add-on wordt niet ondersteund door de VRT, en wordt aangeboden 'as is', zonder enige garantie.</disclaimer>
-  <language>en nl</language>
-  <platform>all</platform>
-  <license>GPL-3.0-only</license>
-  <forum>https://www.facebook.com/kodivrtnu/</forum>
-  <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
-  <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
-  <news>
+    <disclaimer lang="nl_NL">Deze VRT NU add-on wordt niet ondersteund door de VRT, en wordt aangeboden 'as is', zonder enige garantie.</disclaimer>
+    <language>en nl</language>
+    <platform>all</platform>
+    <license>GPL-3.0-only</license>
+    <forum>https://www.facebook.com/kodivrtnu/</forum>
+    <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
+    <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
+    <news>
+v2.4.1 (2020-10-31)
+- Add new category "Nostalgia"
+- Add poster support
+- Add product placement and "kijkwijzer" metadata
+- Get categories from online JSON
+- Improvements to connection error handling
+- Improvements to virtual subclip support
+- Extend soon offline menu to seven days
+- Improve Up Next support
+
 v2.4.0 (2020-07-18)
 - Show error messages when connections fail
 - Improve user authentication cache
@@ -49,46 +59,15 @@ v2.4.0 (2020-07-18)
 - Improve playing programs using the TV guide
 - Improve IPTV Manager support
 - Add user setting to update the VRT NU add-on easily
-
-v2.3.5 (2020-05-27)
-- Fix watching VRT NU abroad
-- Improve and fix user authentication
-- Add support for playing from the Guide with IPTV Manager
-
-v2.3.4 (2020-05-18)
-- Fix token issue caused by new cross-site request forgery (XSRF) checks
-- Add experimental IPTV Manager support
-- Always unescape HTML in outline and description
-
-v2.3.3 (2020-04-30)
-- Fix Radio 1 livestream
-- Fix watching VRT NU abroad
-- Add support for Kodi 19 Matrix "pre-release" builds
-- Add colour preferences to accomodate light skins
-- Add a favourites music subsection
-- Allow editing a search query from search history
-- Expand TV guide range
-- Add livestreams for Radio 2 and Klara
-
-v2.3.2 (2020-01-18)
-- Fix issues related to categories scraping and caching
-- Various improvements to TV guide
-
-v2.3.1 (2020-01-14)
-- Fix an issue related to type-handling for settings
-- Fix an issue related to marking played videos as watched when using Up Next
-- Small fix for livestreams
-- Improvements to metadata handling specific to Kodi rendering
-- Support multiple YouTube links per channel
-  </news>
-  <assets>
-    <icon>resources/media/icon.png</icon>
-    <fanart>resources/media/fanart.png</fanart>
-    <screenshot>resources/media/screenshot01.jpg</screenshot>
-    <screenshot>resources/media/screenshot02.jpg</screenshot>
-    <screenshot>resources/media/screenshot03.jpg</screenshot>
-    <screenshot>resources/media/screenshot04.jpg</screenshot>
-  </assets>
-  <reuselanguageinvoker>true</reuselanguageinvoker>
-</extension>
+    </news>
+    <assets>
+      <icon>resources/media/icon.png</icon>
+      <fanart>resources/media/fanart.png</fanart>
+      <screenshot>resources/media/screenshot01.jpg</screenshot>
+      <screenshot>resources/media/screenshot02.jpg</screenshot>
+      <screenshot>resources/media/screenshot03.jpg</screenshot>
+      <screenshot>resources/media/screenshot04.jpg</screenshot>
+    </assets>
+    <reuselanguageinvoker>true</reuselanguageinvoker>
+  </extension>
 </addon>

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -252,6 +252,11 @@ msgctxt "#30087"
 msgid "Worldview"
 msgstr ""
 
+msgctxt "#30088"
+msgid "Nostalgia"
+msgstr ""
+
+
 ### FEATURED
 msgctxt "#30100"
 msgid "Online exclusive"

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -252,6 +252,11 @@ msgctxt "#30087"
 msgid "Worldview"
 msgstr "Levensbeschouwing"
 
+msgctxt "#30088"
+msgid "Nostalgia"
+msgstr "Nostalgie"
+
+
 ### FEATURED
 msgctxt "#30100"
 msgid "Online exclusive"

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -12,22 +12,23 @@ SECONDS_MARGIN = 30
 CATEGORIES = [
     dict(name='Audiodescriptie', id='met-audiodescriptie', msgctxt=30070),
     dict(name='Cultuur', id='cultuur', msgctxt=30071),
-    dict(name='Docu', id='docu', msgctxt=30072),
+    dict(name='Documentaire', id='docu', msgctxt=30072),
     dict(name='Entertainment', id='entertainment', msgctxt=30073),
-    dict(name='Films', id='films', msgctxt=30074),
+    dict(name='Film', id='films', msgctxt=30074),
     dict(name='Human interest', id='human-interest', msgctxt=30075),
     dict(name='Humor', id='humor', msgctxt=30076),
-    dict(name='Kinderen en jongeren', id='voor-kinderen', msgctxt=30077),
+    dict(name='Kinderen & jongeren', id='voor-kinderen', msgctxt=30077),
     dict(name='Koken', id='koken', msgctxt=30078),
     dict(name='Levensbeschouwing', id='levensbeschouwing', msgctxt=30087),
     dict(name='Lifestyle', id='lifestyle', msgctxt=30079),
     dict(name='Muziek', id='muziek', msgctxt=30080),
     dict(name='Nieuws en actua', id='nieuws-en-actua', msgctxt=30081),
-    dict(name='Series', id='series', msgctxt=30082),
+    dict(name='Nostalgie', id='nostalgie', msgctxt=30088),
+    dict(name='Serie', id='series', msgctxt=30082),
     dict(name='Sport', id='sport', msgctxt=30083),
     dict(name='Talkshows', id='talkshows', msgctxt=30084),
     dict(name='Vlaamse Gebarentaal', id='met-gebarentaal', msgctxt=30085),
-    dict(name='Wetenschap en natuur', id='wetenschap-en-natuur', msgctxt=30086),
+    dict(name='Wetenschap & natuur', id='wetenschap-en-natuur', msgctxt=30086),
 ]
 
 # TODO: Find a solution for the below VRT YouTube channels

--- a/plugin.video.vrt.nu/resources/lib/iptvmanager.py
+++ b/plugin.video.vrt.nu/resources/lib/iptvmanager.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 from data import CHANNELS
-from kodiutils import log
+from kodiutils import log, url_for
 
 
 class IPTVManager:
@@ -45,10 +45,10 @@ class IPTVManager:
                 name=channel.get('label'),
                 logo=channel.get('logo'),
                 preset=channel.get('preset'),
-                stream='plugin://plugin.video.vrt.nu/play/id/{live_stream_id}'.format(**channel),
+                stream=url_for('play_id', video_id=channel.get('live_stream_id')),
             )
             if channel.get('has_tvguide'):
-                item.update(dict(vod='plugin://plugin.video.vrt.nu/play/airdate/{name}/{{start}}/{{stop}}'.format(**channel)))
+                item.update(dict(vod=url_for('play_air_date', channel=channel.get('name'), start_date='{{start}}', end_date='{{stop}}')))
 
             streams.append(item)
         return dict(version=1, streams=streams)

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -284,10 +284,13 @@ class VRTPlayer:
         self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         page = realpage(page)
-        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='offline')
+        items_per_page = get_setting_int('itemsperpage', default=50)
+        sort_key = 'assetOffTime'
+        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, items_per_page=items_per_page, use_favorites=use_favorites,
+                                                                                variety='offline', sort_key=sort_key)
 
         # Add 'More...' entry at the end
-        if len(episode_items) == get_setting_int('itemsperpage', default=50):
+        if len(episode_items) == items_per_page:
             offline = 'favorites_offline' if use_favorites else 'offline'
             episode_items.append(TitleItem(
                 label=localize(30300),


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.4.1
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
