### PR TITLE
[plugin.video.vtm.go@leia] 1.2.0

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,0 +1,300 @@
+# Changelog
+
+## [v1.2.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.0) (2020-11-11)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.5...v1.2.0)
+
+**Implemented enhancements:**
+
+- Integrate Movies and TV Series into the Kodi library [\#236](https://github.com/add-ons/plugin.video.vtm.go/pull/236) ([michaelarnauts](https://github.com/michaelarnauts))
+- Allow to install and run Kodi Logfile Uploader from the settings [\#235](https://github.com/add-ons/plugin.video.vtm.go/pull/235) ([michaelarnauts](https://github.com/michaelarnauts))
+- Allow to install IPTV Manager from the settings [\#234](https://github.com/add-ons/plugin.video.vtm.go/pull/234) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add movie and series recommendations [\#233](https://github.com/add-ons/plugin.video.vtm.go/pull/233) ([michaelarnauts](https://github.com/michaelarnauts))
+- Error handling improvements and other various fixes [\#232](https://github.com/add-ons/plugin.video.vtm.go/pull/232) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix unicode in search [\#228](https://github.com/add-ons/plugin.video.vtm.go/pull/228) ([mediaminister](https://github.com/mediaminister))
+
+**Merged pull requests:**
+
+- Use new sakee version [\#229](https://github.com/add-ons/plugin.video.vtm.go/pull/229) ([mediaminister](https://github.com/mediaminister))
+
+## [v1.1.5](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.5) (2020-10-21)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.4...v1.1.5)
+
+**Implemented enhancements:**
+
+- Move to kodiutils [\#214](https://github.com/add-ons/plugin.video.vtm.go/pull/214) ([mediaminister](https://github.com/mediaminister))
+
+**Fixed bugs:**
+
+- Fix My List [\#227](https://github.com/add-ons/plugin.video.vtm.go/pull/227) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix VTM GO authentication [\#224](https://github.com/add-ons/plugin.video.vtm.go/pull/224) ([mediaminister](https://github.com/mediaminister))
+- Ensure listdir items are unicode [\#222](https://github.com/add-ons/plugin.video.vtm.go/pull/222) ([dagwieers](https://github.com/dagwieers))
+
+**Merged pull requests:**
+
+- Use previous sakee version [\#226](https://github.com/add-ons/plugin.video.vtm.go/pull/226) ([mediaminister](https://github.com/mediaminister))
+- Prepare for v1.1.5 [\#225](https://github.com/add-ons/plugin.video.vtm.go/pull/225) ([mediaminister](https://github.com/mediaminister))
+- Fix for upcoming UpNext release [\#220](https://github.com/add-ons/plugin.video.vtm.go/pull/220) ([michaelarnauts](https://github.com/michaelarnauts))
+- Run some checks every 4 hours [\#219](https://github.com/add-ons/plugin.video.vtm.go/pull/219) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.1.4](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.4) (2020-10-10)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.3...v1.1.4)
+
+**Fixed bugs:**
+
+- Fix authentication [\#216](https://github.com/add-ons/plugin.video.vtm.go/pull/216) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.1.3](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.3) (2020-10-02)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.2...v1.1.3)
+
+**Fixed bugs:**
+
+- Fix authentication due to cookie changes [\#212](https://github.com/add-ons/plugin.video.vtm.go/pull/212) ([michaelarnauts](https://github.com/michaelarnauts))
+- Use a uuid as a cookie for the EPG [\#211](https://github.com/add-ons/plugin.video.vtm.go/pull/211) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix EPG [\#210](https://github.com/add-ons/plugin.video.vtm.go/pull/210) ([mediaminister](https://github.com/mediaminister))
+- Fix credentials and profile not properly saved [\#207](https://github.com/add-ons/plugin.video.vtm.go/pull/207) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.1.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.2) (2020-09-03)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.1...v1.1.2)
+
+**Fixed bugs:**
+
+- Fix search [\#206](https://github.com/add-ons/plugin.video.vtm.go/pull/206) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.1.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.1) (2020-08-31)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.1.0...v1.1.1)
+
+**Implemented enhancements:**
+
+- Disable super-with-arguments pylint warnings [\#200](https://github.com/add-ons/plugin.video.vtm.go/pull/200) ([mediaminister](https://github.com/mediaminister))
+- VTM rebranding [\#198](https://github.com/add-ons/plugin.video.vtm.go/pull/198) ([mediaminister](https://github.com/mediaminister))
+
+**Fixed bugs:**
+
+- Debug [\#199](https://github.com/add-ons/plugin.video.vtm.go/pull/199) ([mediaminister](https://github.com/mediaminister))
+- Fix paths in Windows [\#197](https://github.com/add-ons/plugin.video.vtm.go/pull/197) ([mediaminister](https://github.com/mediaminister))
+
+## [v1.1.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.1.0) (2020-07-22)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.0.2...v1.1.0)
+
+**Implemented enhancements:**
+
+- Make authentication more robust [\#192](https://github.com/add-ons/plugin.video.vtm.go/pull/192) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add Integrations menu to settings [\#188](https://github.com/add-ons/plugin.video.vtm.go/pull/188) ([michaelarnauts](https://github.com/michaelarnauts))
+- Pass genre to IPTV Manager [\#186](https://github.com/add-ons/plugin.video.vtm.go/pull/186) ([michaelarnauts](https://github.com/michaelarnauts))
+- Support new inputstream api in Kodi 19 [\#185](https://github.com/add-ons/plugin.video.vtm.go/pull/185) ([mediaminister](https://github.com/mediaminister))
+- Adds IPTV Manager support for Matrix [\#184](https://github.com/add-ons/plugin.video.vtm.go/pull/184) ([michaelarnauts](https://github.com/michaelarnauts))
+- Improve subtitle behaviour using PlayerMonitor [\#183](https://github.com/add-ons/plugin.video.vtm.go/pull/183) ([mediaminister](https://github.com/mediaminister))
+- Add support for playing from the Guide with IPTV Manager [\#181](https://github.com/add-ons/plugin.video.vtm.go/pull/181) ([michaelarnauts](https://github.com/michaelarnauts))
+- Show all channels that we get from VTM GO [\#179](https://github.com/add-ons/plugin.video.vtm.go/pull/179) ([michaelarnauts](https://github.com/michaelarnauts))
+- Remove 'Geen uitzending' from EPG [\#177](https://github.com/add-ons/plugin.video.vtm.go/pull/177) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add channel presets for IPTV Manager [\#176](https://github.com/add-ons/plugin.video.vtm.go/pull/176) ([michaelarnauts](https://github.com/michaelarnauts))
+- Use python logging interface [\#175](https://github.com/add-ons/plugin.video.vtm.go/pull/175) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add compatibility for Kodi 19 Python API [\#172](https://github.com/add-ons/plugin.video.vtm.go/pull/172) ([mediaminister](https://github.com/mediaminister))
+- Add support for IPTV Manager [\#171](https://github.com/add-ons/plugin.video.vtm.go/pull/171) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix data transfers over 1 MB to IPTV Manager [\#187](https://github.com/add-ons/plugin.video.vtm.go/pull/187) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix logging in BackgroundService [\#182](https://github.com/add-ons/plugin.video.vtm.go/pull/182) ([mediaminister](https://github.com/mediaminister))
+
+**Merged pull requests:**
+
+- Use sake for Kodi stubs [\#191](https://github.com/add-ons/plugin.video.vtm.go/pull/191) ([michaelarnauts](https://github.com/michaelarnauts))
+- Automated testing fixes [\#178](https://github.com/add-ons/plugin.video.vtm.go/pull/178) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.0.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.0.2) (2020-05-02)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.0.1...v1.0.2)
+
+**Fixed bugs:**
+
+- Fix authentication [\#174](https://github.com/add-ons/plugin.video.vtm.go/pull/174) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.0.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.0.1) (2020-03-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.0.0...v1.0.1)
+
+**Implemented enhancements:**
+
+- Allow browsing the addon without authentication [\#162](https://github.com/add-ons/plugin.video.vtm.go/pull/162) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add subtitles after playback has started [\#154](https://github.com/add-ons/plugin.video.vtm.go/pull/154) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Add error handling for HTTP 426 [\#167](https://github.com/add-ons/plugin.video.vtm.go/pull/167) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix text encoding when getting data from VTM GO Api [\#160](https://github.com/add-ons/plugin.video.vtm.go/pull/160) ([mediaminister](https://github.com/mediaminister))
+- Fix encoding of profile name [\#157](https://github.com/add-ons/plugin.video.vtm.go/pull/157) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Improve CI [\#164](https://github.com/add-ons/plugin.video.vtm.go/pull/164) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add .gitattributes file with export-ignore to clean up the zip downloads [\#163](https://github.com/add-ons/plugin.video.vtm.go/pull/163) ([michaelarnauts](https://github.com/michaelarnauts))
+- Replace Travis with GitHub Actions [\#161](https://github.com/add-ons/plugin.video.vtm.go/pull/161) ([michaelarnauts](https://github.com/michaelarnauts))
+- Small translation fixes [\#159](https://github.com/add-ons/plugin.video.vtm.go/pull/159) ([dagwieers](https://github.com/dagwieers))
+- Various check fixes [\#158](https://github.com/add-ons/plugin.video.vtm.go/pull/158) ([dagwieers](https://github.com/dagwieers))
+
+## [v1.0.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.0.0) (2020-03-05)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.5...v1.0.0)
+
+**Implemented enhancements:**
+
+- Use xbmc.Player to wait for subtitles and UpNext notification [\#153](https://github.com/add-ons/plugin.video.vtm.go/pull/153) ([michaelarnauts](https://github.com/michaelarnauts))
+- Remove background progress bar [\#152](https://github.com/add-ons/plugin.video.vtm.go/pull/152) ([michaelarnauts](https://github.com/michaelarnauts))
+- Use new EPG API [\#146](https://github.com/add-ons/plugin.video.vtm.go/pull/146) ([michaelarnauts](https://github.com/michaelarnauts))
+- Don't close the settings when updating or clearing the metadata [\#144](https://github.com/add-ons/plugin.video.vtm.go/pull/144) ([michaelarnauts](https://github.com/michaelarnauts))
+- Skip single season selections [\#143](https://github.com/add-ons/plugin.video.vtm.go/pull/143) ([michaelarnauts](https://github.com/michaelarnauts))
+- Cache improvements [\#142](https://github.com/add-ons/plugin.video.vtm.go/pull/142) ([michaelarnauts](https://github.com/michaelarnauts))
+- Require authentication according to VTM GO TOS [\#141](https://github.com/add-ons/plugin.video.vtm.go/pull/141) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- First public release [\#149](https://github.com/add-ons/plugin.video.vtm.go/pull/149) ([michaelarnauts](https://github.com/michaelarnauts))
+- Apply kodi-addon-checker suggestions [\#145](https://github.com/add-ons/plugin.video.vtm.go/pull/145) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v0.9.5](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.5) (2020-03-02)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.4...v0.9.5)
+
+**Fixed bugs:**
+
+- Fix channels menu [\#151](https://github.com/add-ons/plugin.video.vtm.go/pull/151) ([mediaminister](https://github.com/mediaminister))
+
+## [v0.9.4](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.4) (2020-02-16)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.3...v0.9.4)
+
+**Implemented enhancements:**
+
+- Implement Up Next integration [\#138](https://github.com/add-ons/plugin.video.vtm.go/pull/138) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v0.9.3](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.3) (2020-01-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.2...v0.9.3)
+
+**Implemented enhancements:**
+
+- Profile improvements [\#134](https://github.com/add-ons/plugin.video.vtm.go/pull/134) ([michaelarnauts](https://github.com/michaelarnauts))
+- Update API [\#132](https://github.com/add-ons/plugin.video.vtm.go/pull/132) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Add screenshots [\#135](https://github.com/add-ons/plugin.video.vtm.go/pull/135) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v0.9.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.2) (2019-11-18)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.1...v0.9.2)
+
+**Implemented enhancements:**
+
+- Various fixes [\#126](https://github.com/add-ons/plugin.video.vtm.go/pull/126) ([michaelarnauts](https://github.com/michaelarnauts))
+- Small cleanup [\#125](https://github.com/add-ons/plugin.video.vtm.go/pull/125) ([michaelarnauts](https://github.com/michaelarnauts))
+- Improve test coverage [\#123](https://github.com/add-ons/plugin.video.vtm.go/pull/123) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add Catalog to Channel menu [\#122](https://github.com/add-ons/plugin.video.vtm.go/pull/122) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add studio tags like they are in resource.images.studios.white [\#121](https://github.com/add-ons/plugin.video.vtm.go/pull/121) ([michaelarnauts](https://github.com/michaelarnauts))
+- Various TV Guide fixes [\#116](https://github.com/add-ons/plugin.video.vtm.go/pull/116) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add settings to hide menu items [\#115](https://github.com/add-ons/plugin.video.vtm.go/pull/115) ([michaelarnauts](https://github.com/michaelarnauts))
+- Consolidate YouTube, TV Guide and Live TV into one Channels menu [\#114](https://github.com/add-ons/plugin.video.vtm.go/pull/114) ([michaelarnauts](https://github.com/michaelarnauts))
+- Split menu code into different classes [\#112](https://github.com/add-ons/plugin.video.vtm.go/pull/112) ([michaelarnauts](https://github.com/michaelarnauts))
+- Clean up kids-routing [\#111](https://github.com/add-ons/plugin.video.vtm.go/pull/111) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add go to program on context menu of episodes [\#110](https://github.com/add-ons/plugin.video.vtm.go/pull/110) ([michaelarnauts](https://github.com/michaelarnauts))
+- Refactor out Content in favor of Movies, Programs and Episodes [\#109](https://github.com/add-ons/plugin.video.vtm.go/pull/109) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Improve test coverage [\#117](https://github.com/add-ons/plugin.video.vtm.go/pull/117) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v0.9.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.1) (2019-10-16)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v0.9.0...v0.9.1)
+
+**Implemented enhancements:**
+
+- Add caching of metadata [\#104](https://github.com/add-ons/plugin.video.vtm.go/pull/104) ([michaelarnauts](https://github.com/michaelarnauts))
+- General code cleanup [\#99](https://github.com/add-ons/plugin.video.vtm.go/pull/99) ([michaelarnauts](https://github.com/michaelarnauts))
+- Implement playing from EPG with a specified date and time. [\#98](https://github.com/add-ons/plugin.video.vtm.go/pull/98) ([michaelarnauts](https://github.com/michaelarnauts))
+- Integrate My List [\#96](https://github.com/add-ons/plugin.video.vtm.go/pull/96) ([michaelarnauts](https://github.com/michaelarnauts))
+- Use authentication when it is available [\#95](https://github.com/add-ons/plugin.video.vtm.go/pull/95) ([michaelarnauts](https://github.com/michaelarnauts))
+- Implement recommendations [\#94](https://github.com/add-ons/plugin.video.vtm.go/pull/94) ([michaelarnauts](https://github.com/michaelarnauts))
+- Enable reuselanguageinvoker [\#90](https://github.com/add-ons/plugin.video.vtm.go/pull/90) ([michaelarnauts](https://github.com/michaelarnauts))
+- Remove show\_movie [\#89](https://github.com/add-ons/plugin.video.vtm.go/pull/89) ([michaelarnauts](https://github.com/michaelarnauts))
+- Translate breadcrumbs [\#88](https://github.com/add-ons/plugin.video.vtm.go/pull/88) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add PG classification to metadata [\#87](https://github.com/add-ons/plugin.video.vtm.go/pull/87) ([dagwieers](https://github.com/dagwieers))
+- Add higher resolution channel icons [\#86](https://github.com/add-ons/plugin.video.vtm.go/pull/86) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add typing docstrings [\#85](https://github.com/add-ons/plugin.video.vtm.go/pull/85) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix kids mode [\#108](https://github.com/add-ons/plugin.video.vtm.go/pull/108) ([michaelarnauts](https://github.com/michaelarnauts))
+- Show correct error messages when geoblocked or when unavailable. [\#91](https://github.com/add-ons/plugin.video.vtm.go/pull/91) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Less pylint ignores and more tests [\#105](https://github.com/add-ons/plugin.video.vtm.go/pull/105) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v0.9.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v0.9.0) (2019-09-19)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/47c503fcaa947111047cade9fd5a06ce222d0879...v0.9.0)
+
+**Implemented enhancements:**
+
+- Add more metadata when playing a stream [\#82](https://github.com/add-ons/plugin.video.vtm.go/pull/82) ([michaelarnauts](https://github.com/michaelarnauts))
+- Allow direct playing from epg [\#74](https://github.com/add-ons/plugin.video.vtm.go/pull/74) ([michaelarnauts](https://github.com/michaelarnauts))
+- fix geoblocked videoplayer service api [\#71](https://github.com/add-ons/plugin.video.vtm.go/pull/71) ([mediaminister](https://github.com/mediaminister))
+- Various fixes [\#68](https://github.com/add-ons/plugin.video.vtm.go/pull/68) ([dagwieers](https://github.com/dagwieers))
+- Rework Kids zone [\#67](https://github.com/add-ons/plugin.video.vtm.go/pull/67) ([dagwieers](https://github.com/dagwieers))
+- Implement TV Guide [\#63](https://github.com/add-ons/plugin.video.vtm.go/pull/63) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add support for breadcrumbs [\#61](https://github.com/add-ons/plugin.video.vtm.go/pull/61) ([dagwieers](https://github.com/dagwieers))
+- support unicode in python2 and python3 Kodi [\#60](https://github.com/add-ons/plugin.video.vtm.go/pull/60) ([mediaminister](https://github.com/mediaminister))
+- Add settings and features [\#59](https://github.com/add-ons/plugin.video.vtm.go/pull/59) ([dagwieers](https://github.com/dagwieers))
+- Add support for translations [\#57](https://github.com/add-ons/plugin.video.vtm.go/pull/57) ([dagwieers](https://github.com/dagwieers))
+- Add description during playback [\#48](https://github.com/add-ons/plugin.video.vtm.go/pull/48) ([michaelarnauts](https://github.com/michaelarnauts))
+- Move to Kids Zone [\#46](https://github.com/add-ons/plugin.video.vtm.go/pull/46) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add legal \(PG\) info to plot [\#45](https://github.com/add-ons/plugin.video.vtm.go/pull/45) ([dagwieers](https://github.com/dagwieers))
+- Add support for vtm go kids mode [\#44](https://github.com/add-ons/plugin.video.vtm.go/pull/44) ([michaelarnauts](https://github.com/michaelarnauts))
+- Set correct API version since we depend on Leia [\#42](https://github.com/add-ons/plugin.video.vtm.go/pull/42) ([michaelarnauts](https://github.com/michaelarnauts))
+- Assorted fixes [\#41](https://github.com/add-ons/plugin.video.vtm.go/pull/41) ([dagwieers](https://github.com/dagwieers))
+- python3 support, fix unit test and linter warnings [\#40](https://github.com/add-ons/plugin.video.vtm.go/pull/40) ([mediaminister](https://github.com/mediaminister))
+- Add support for geo-blocking [\#36](https://github.com/add-ons/plugin.video.vtm.go/pull/36) ([dagwieers](https://github.com/dagwieers))
+- add inputstreamhelper to auto install Widevine CDM [\#34](https://github.com/add-ons/plugin.video.vtm.go/pull/34) ([mediaminister](https://github.com/mediaminister))
+- separate mpeg dash manifest and api json downloads [\#32](https://github.com/add-ons/plugin.video.vtm.go/pull/32) ([mediaminister](https://github.com/mediaminister))
+- Add proxy support [\#31](https://github.com/add-ons/plugin.video.vtm.go/pull/31) ([dagwieers](https://github.com/dagwieers))
+- Assorted set of fixes [\#30](https://github.com/add-ons/plugin.video.vtm.go/pull/30) ([dagwieers](https://github.com/dagwieers))
+- Add days remaining to plot [\#27](https://github.com/add-ons/plugin.video.vtm.go/pull/27) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix ordering. [\#25](https://github.com/add-ons/plugin.video.vtm.go/pull/25) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add '\* All seasons' support [\#24](https://github.com/add-ons/plugin.video.vtm.go/pull/24) ([dagwieers](https://github.com/dagwieers))
+- Assorted list of improvements [\#21](https://github.com/add-ons/plugin.video.vtm.go/pull/21) ([dagwieers](https://github.com/dagwieers))
+- Add YouTube support [\#15](https://github.com/add-ons/plugin.video.vtm.go/pull/15) ([dagwieers](https://github.com/dagwieers))
+
+**Fixed bugs:**
+
+- Don't error out on geoblocked content [\#80](https://github.com/add-ons/plugin.video.vtm.go/pull/80) ([michaelarnauts](https://github.com/michaelarnauts))
+- fix logging [\#70](https://github.com/add-ons/plugin.video.vtm.go/pull/70) ([mediaminister](https://github.com/mediaminister))
+- delay subtitles taking into account advertisements breaks [\#53](https://github.com/add-ons/plugin.video.vtm.go/pull/53) ([mediaminister](https://github.com/mediaminister))
+- Add check-subscription [\#35](https://github.com/add-ons/plugin.video.vtm.go/pull/35) ([michaelarnauts](https://github.com/michaelarnauts))
+- Use pageSize to request 1000 items at once. [\#20](https://github.com/add-ons/plugin.video.vtm.go/pull/20) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Run auth test on travis [\#79](https://github.com/add-ons/plugin.video.vtm.go/pull/79) ([michaelarnauts](https://github.com/michaelarnauts))
+- Don't count Kodi utils for code coverage  [\#77](https://github.com/add-ons/plugin.video.vtm.go/pull/77) ([michaelarnauts](https://github.com/michaelarnauts))
+- Uniformise travis and local checking flow [\#75](https://github.com/add-ons/plugin.video.vtm.go/pull/75) ([michaelarnauts](https://github.com/michaelarnauts))
+- Check translation during tests [\#73](https://github.com/add-ons/plugin.video.vtm.go/pull/73) ([michaelarnauts](https://github.com/michaelarnauts))
+- Dutch translations [\#69](https://github.com/add-ons/plugin.video.vtm.go/pull/69) ([dagwieers](https://github.com/dagwieers))
+- Increase coverage, remove dead code [\#64](https://github.com/add-ons/plugin.video.vtm.go/pull/64) ([dagwieers](https://github.com/dagwieers))
+- Add coverage support [\#62](https://github.com/add-ons/plugin.video.vtm.go/pull/62) ([dagwieers](https://github.com/dagwieers))
+- fix sanity warnings [\#50](https://github.com/add-ons/plugin.video.vtm.go/pull/50) ([mediaminister](https://github.com/mediaminister))
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/plugin.video.vtm.go/README.md
+++ b/plugin.video.vtm.go/README.md
@@ -4,7 +4,7 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Contributors](https://img.shields.io/github/contributors/add-ons/plugin.video.vtm.go.svg)](https://github.com/add-ons/plugin.video.vtm.go/graphs/contributors)
 
-# VTM GO Kodi add-on
+# VTM GO Kodi Add-on
 
 *plugin.video.vtm.go* is a Kodi add-on for watching live video streams and video-on-demand content available on the VTM GO platform. 
 
@@ -33,6 +33,35 @@ The following features are supported:
 * Search the catalogue
 * Watch YouTube content from some of the DPG Media channels
 * Integration with [IPTV Manager](https://github.com/add-ons/service.iptv.manager)
+* Integratie met Kodi bibliotheek
+
+## Integratie met Kodi
+
+Je kan deze Add-on gebruiken als medialocatie in Kodi zodat de films en series ook in je Kodi bibliotheek geindexeerd staan. Ze worden uiteraard nog steeds
+gewoon gestreamed.
+
+Ga hiervoor naar **Instellingen** > **Media** > **Bibliotheek** > **Video's...** (bij bronnen beheren). Kies vervolgens **Toevoegen video's...** en geef
+onderstaande locatie in door **< Geen >** te kiezen. Geef vervolgens de naam op en kies OK. Stel daarna de opties in zoals hieronder opgegeven en bevestig met OK.
+Stem daarna toe om deze locaties te scannen.
+
+* Films:
+  * Locatie: `plugin://plugin.video.vtm.go/library/movies/`
+  * Naam: **VTM GO - Films**
+  * Opties:
+    * Deze map bevat: **Speelfilms**
+    * Kies informatieleverancier: **Local information only**
+    * Films staan in aparte folders die overeenkomen met de filmtitel: **Uit**
+    * Ook onderliggende mappen scannen : **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
+
+* Series:
+  * Locatie: `plugin://plugin.video.vtm.go/library/tvshows/`
+  * Naam: **VTM GO - Series**
+  * Opties:
+    * Deze map bevat: **Series**
+    * Kies informatieleverancier: **Local information only**
+    * Geselecteerde map bevat één enkele serie: **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
 
 ## Screenshots
 

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.1.5" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.0" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -12,6 +12,8 @@
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
+        <medialibraryscanpath content="movies">library/movies/</medialibraryscanpath>
+        <medialibraryscanpath content="tvshows">library/tvshows/</medialibraryscanpath>
     </extension>
     <extension point="xbmc.service" library="service_entry.py"/>
     <extension point="xbmc.addon.metadata">
@@ -23,8 +25,11 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.1.5
-- Fix authentication.</news>
+	<news>v1.2.0 (2020-11-11)
+- Implement Kodi Library support.
+- Use new Movies and Series categories.
+- Bugfixes and improved error handling.
+</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
@@ -15,19 +15,19 @@ msgid "Alphabetically sorted list of programs"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Catalogue"
+msgid "Movies"
 msgstr ""
 
 msgctxt "#30004"
-msgid "TV Shows and Movies listed by category"
+msgid "Browse through the movie-catalogue"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Live TV"
+msgid "Series"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Watch TV channels live via Internet"
+msgid "Browse through the series-catalogue"
 msgstr ""
 
 msgctxt "#30007"
@@ -84,6 +84,14 @@ msgstr ""
 
 msgctxt "#30020"
 msgid "Continue watching where you left off"
+msgstr ""
+
+msgctxt "#30021"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30022"
+msgid "Show the VTM GO recommendations for Kids"
 msgstr ""
 
 
@@ -335,10 +343,6 @@ msgctxt "#30821"
 msgid "Features"
 msgstr ""
 
-msgctxt "#30822"
-msgid "Show recommendations"
-msgstr ""
-
 msgctxt "#30823"
 msgid "Show My List"
 msgstr ""
@@ -392,7 +396,7 @@ msgid "Up Next"
 msgstr ""
 
 msgctxt "#30862"
-msgid "Install Up Next add-on"
+msgid "Install Up Next add-on…"
 msgstr ""
 
 msgctxt "#30863"
@@ -417,6 +421,46 @@ msgstr ""
 
 msgctxt "#30869"
 msgid "IPTV Manager settings…"
+msgstr ""
+
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr ""
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr ""
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr ""
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr ""
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr ""
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr ""
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr ""
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr ""
+
+msgctxt "#30879"
+msgid "Clean Library…"
 msgstr ""
 
 msgctxt "#30880"
@@ -445,4 +489,12 @@ msgstr ""
 
 msgctxt "#30891"
 msgid "Enable debug logging"
+msgstr ""
+
+msgctxt "#30892"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30893"
+msgid "Open Kodi Logfile Uploader…"
 msgstr ""

--- a/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
@@ -16,20 +16,20 @@ msgid "Alphabetically sorted list of programs"
 msgstr "Volledige lijst van programma's"
 
 msgctxt "#30003"
-msgid "Catalogue"
-msgstr "Catalogus"
+msgid "Movies"
+msgstr "Films"
 
 msgctxt "#30004"
-msgid "TV Shows and Movies listed by category"
-msgstr "Programma's en films per categorie"
+msgid "Browse through the movie-catalogue"
+msgstr "Doorblader de filmcatalogus"
 
 msgctxt "#30005"
-msgid "Live TV"
-msgstr "Live tv"
+msgid "Series"
+msgstr "Programma's"
 
 msgctxt "#30006"
-msgid "Watch TV channels live via Internet"
-msgstr "Bekijk tv-kanalen live via Internet"
+msgid "Browse through the series-catalogue"
+msgstr "Doorblader de programmacatalogus"
 
 msgctxt "#30007"
 msgid "Channels"
@@ -86,6 +86,14 @@ msgstr "Verder kijken"
 msgctxt "#30020"
 msgid "Continue watching where you left off"
 msgstr "Kijk verder waar je gebleven was"
+
+msgctxt "#30021"
+msgid "Kids"
+msgstr "Kids"
+
+msgctxt "#30022"
+msgid "Show the VTM GO recommendations for Kids"
+msgstr "Bekijk de VTM GO aanbevelingen voor kinderen"
 
 
 ### SUBMENUS
@@ -240,7 +248,7 @@ msgstr "Overmorgen"
 ### MESSAGES
 msgctxt "#30701"
 msgid "You need to configure your credentials before you can access the content of VTM GO. Do you want to enter them now?"
-msgstr "Je moet je inloggegevens configureren voordat je VTM GO kan gebruiken. Wil je dit nu doen?"
+msgstr "U moet uw inloggegevens configureren voordat u VTM GO kan gebruiken. Wilt u dit nu doen?"
 
 msgctxt "#30702"
 msgid "Unknown error while logging in: {code}"
@@ -335,10 +343,6 @@ msgctxt "#30821"
 msgid "Features"
 msgstr "Functionaliteit"
 
-msgctxt "#30822"
-msgid "Show recommendations"
-msgstr "Toon 'Aanbevelingen' menu"
-
 msgctxt "#30823"
 msgid "Show My List"
 msgstr "Toon 'Mijn lijst' menu"
@@ -393,8 +397,8 @@ msgid "Up Next"
 msgstr "Up Next"
 
 msgctxt "#30862"
-msgid "Install Up Next add-on"
-msgstr "Installeer de Up Next add-on"
+msgid "Install Up Next add-on…"
+msgstr "Installeer de Up Next add-on…"
 
 msgctxt "#30863"
 msgid "Enable Up Next integration"
@@ -419,6 +423,46 @@ msgstr "Activeer IPTV Manager integratie"
 msgctxt "#30869"
 msgid "IPTV Manager settings…"
 msgstr "IPTV Manager instellingen…"
+
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr "Kodi-bibliotheek"
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr "Indexeren"
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr "Videolocaties toevoegen aan de Kodi-bibliotheek… [COLOR gray](Zie README.md)[/COLOR]"
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr "Indexeer de volgende films"
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr "Indexeer de volgende series"
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr "Volledige catalogus"
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr "Enkel items op 'Mijn lijst'"
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr "Onderhoud"
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr "Verniew bibliotheek…"
+
+msgctxt "#30879"
+msgid "Clean Library…"
+msgstr "Bibliotheek opkuisen…"
 
 msgctxt "#30880"
 msgid "Expert"
@@ -447,3 +491,11 @@ msgstr "Logboek"
 msgctxt "#30891"
 msgid "Enable debug logging"
 msgstr "Activeer debug logging"
+
+msgctxt "#30892"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30893"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"

--- a/plugin.video.vtm.go/resources/lib/addon.py
+++ b/plugin.video.vtm.go/resources/lib/addon.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 
 import routing
+from requests import HTTPError
 
-from resources.lib import kodiutils
-from resources.lib import kodilogging
+from resources.lib import kodilogging, kodiutils
+from resources.lib.vtmgo.exceptions import InvalidLoginException, LoginErrorException
 
 kodilogging.config()
 routing = routing.Plugin()  # pylint: disable=invalid-name
@@ -19,13 +20,39 @@ _LOGGER = logging.getLogger('plugin')
 @routing.route('/')
 def index():
     """ Show the profile selection, or go to the main menu. """
-    if not kodiutils.has_credentials() or (kodiutils.get_setting_bool('auto_login') and bool(kodiutils.get_setting('profile'))):
-        # If we have no credentials (browse only mode) or we have autologin and a profile, go directly to the main menu
-        show_main_menu()
+    while True:
+        if not kodiutils.has_credentials():
+            if not kodiutils.yesno_dialog(message=kodiutils.localize(30701)):  # You need to configure your credentials...
+                # We have no credentials
+                kodiutils.end_of_directory()
+                kodiutils.execute_builtin('ActivateWindow(Home)')
+                return
 
-    else:
-        # Ask the user for the profile to use
-        select_profile()
+            kodiutils.open_settings()
+        else:
+            break
+
+    try:
+        if kodiutils.get_setting_bool('auto_login') and kodiutils.get_setting('profile'):
+            # We have a profile
+            show_main_menu()
+
+        else:
+            # Ask the user for the profile to use
+            select_profile()
+
+    except InvalidLoginException:
+        kodiutils.ok_dialog(message=kodiutils.localize(30203))  # Your credentials are not valid!
+        kodiutils.open_settings()
+        kodiutils.end_of_directory()
+
+    except LoginErrorException as exc:
+        kodiutils.ok_dialog(message=kodiutils.localize(30702, code=exc.code))  # Unknown error while logging in: {code}
+        kodiutils.end_of_directory()
+
+    except HTTPError as exc:
+        kodiutils.ok_dialog(message=kodiutils.localize(30702, code='HTTP %d' % exc.response.status_code))  # Unknown error while logging in: {code}
+        kodiutils.end_of_directory()
 
 
 @routing.route('/menu')
@@ -113,18 +140,86 @@ def show_catalog_program_season(program, season):
     Catalog().show_program_season(program, int(season))
 
 
-@routing.route('/catalog/recommendations')
-def show_recommendations():
-    """ Shows the programs of a specific date in the tv guide """
+@routing.route('/library/movies/')
+def library_movies():
+    """ Show a list of all movies for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    movie = routing.args.get('movie', [])[0] if routing.args.get('movie') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_movie(movie)
+        return
+
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_movies(movie)
+        return
+
+    if movie:
+        play('movies', movie)
+    else:
+        Library().show_library_movies()
+
+
+@routing.route('/library/tvshows/')
+def library_tvshows():
+    """ Show a list of all tv series for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    program = routing.args.get('program', [])[0] if routing.args.get('program') else None
+    episode = routing.args.get('episode', [])[0] if routing.args.get('episode') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_tvshow(program)
+        return
+
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_tvshows(program)
+        return
+
+    if episode:
+        play('episodes', episode)
+    elif program:
+        Library().show_library_tvshows_program(program)
+    else:
+        Library().show_library_tvshows()
+
+
+@routing.route('/library/configure')
+def library_configure():
+    """ Show information on how to enable the library integration """
+    from resources.lib.modules.library import Library
+    Library().configure()
+
+
+@routing.route('/library/update')
+def library_update():
+    """ Refresh the library. """
+    from resources.lib.modules.library import Library
+    Library().update()
+
+
+@routing.route('/library/clean')
+def library_clean():
+    """ Clean the library. """
+    from resources.lib.modules.library import Library
+    Library().clean()
+
+
+@routing.route('/catalog/recommendations/<storefront>')
+def show_recommendations(storefront):
+    """ Shows the recommendations of a storefront """
     from resources.lib.modules.catalog import Catalog
-    Catalog().show_recommendations()
+    Catalog().show_recommendations(storefront)
 
 
-@routing.route('/catalog/recommendations/<category>')
-def show_recommendations_category(category):
+@routing.route('/catalog/recommendations/<storefront>/<category>')
+def show_recommendations_category(storefront, category):
     """ Show the items in a recommendations category """
     from resources.lib.modules.catalog import Catalog
-    Catalog().show_recommendations_category(category)
+    Catalog().show_recommendations_category(storefront, category)
 
 
 @routing.route('/catalog/mylist')
@@ -140,12 +235,18 @@ def mylist_add(video_type, content_id):
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_add(video_type, content_id)
 
+    from resources.lib.modules.library import Library
+    Library().mylist_added(video_type, content_id)
+
 
 @routing.route('/catalog/mylist/del/<video_type>/<content_id>')
 def mylist_del(video_type, content_id):
     """ Remove an item from "My List" """
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_del(video_type, content_id)
+
+    from resources.lib.modules.library import Library
+    Library().mylist_removed(video_type, content_id)
 
 
 @routing.route('/catalog/continuewatching')

--- a/plugin.video.vtm.go/resources/lib/kodilogging.py
+++ b/plugin.video.vtm.go/resources/lib/kodilogging.py
@@ -7,6 +7,7 @@ import logging
 
 import xbmc
 import xbmcaddon
+
 from resources.lib import kodiutils
 
 ADDON = xbmcaddon.Addon()

--- a/plugin.video.vtm.go/resources/lib/modules/authentication.py
+++ b/plugin.video.vtm.go/resources/lib/modules/authentication.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 
 from resources.lib import kodiutils
-from resources.lib.vtmgo.vtmgo import VtmGo, ApiUpdateRequired
-from resources.lib.vtmgo.vtmgoauth import VtmGoAuth, InvalidLoginException, LoginErrorException
+from resources.lib.vtmgo.vtmgo import ApiUpdateRequired, VtmGo
+from resources.lib.vtmgo.vtmgoauth import (InvalidLoginException,
+                                           LoginErrorException, VtmGoAuth)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
@@ -11,9 +11,8 @@ from datetime import timedelta
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
 from resources.lib.vtmgo.vtmgo import VtmGo
-from resources.lib.vtmgo.vtmgoepg import VtmGoEpg
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
-
+from resources.lib.vtmgo.vtmgoepg import VtmGoEpg
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plugin.video.vtm.go/resources/lib/modules/library.py
+++ b/plugin.video.vtm.go/resources/lib/modules/library.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+""" Library module """
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+
+from resources.lib import kodiutils
+from resources.lib.modules.menu import Menu
+from resources.lib.vtmgo import Movie, Program
+from resources.lib.vtmgo.vtmgo import CACHE_AUTO, CACHE_PREVENT, CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM, VtmGo
+from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
+
+_LOGGER = logging.getLogger(__name__)
+
+LIBRARY_FULL_CATALOG = 0
+LIBRARY_ONLY_MYLIST = 1
+
+
+class Library:
+    """ Menu code related to the catalog """
+
+    def __init__(self):
+        """ Initialise object """
+        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                               kodiutils.get_setting('password'),
+                               kodiutils.get_setting('loginprovider'),
+                               kodiutils.get_setting('profile'),
+                               kodiutils.get_tokens_path())
+        self._api = VtmGo(self._auth)
+
+    def show_library_movies(self, movie=None):
+        """ Return a list of the movies that should be exported. """
+        if movie is None:
+            if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+                # Full catalog
+                # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+                items = self._api.get_items(content_filter=Movie, cache=CACHE_AUTO)
+            else:
+                # Only favourites, use cache if available, fetch from api otherwise
+                items = self._api.get_swimlane('my-list', content_filter=Movie)
+        else:
+            items = [self._api.get_movie(movie)]
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)  # We need a trailing /
+            title_item.path = 'plugin://plugin.video.vtm.go/library/movies/?movie=%s' % item.movie_id
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='movies', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows(self, program=None):
+        """ Return a list of the series that should be exported. """
+        if program is None:
+            if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+                # Full catalog
+                # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+                # NOTE: We should probably use CACHE_PREVENT here, so we can pick up new episodes, but we can't since that would
+                #       require a massive amount of API calls for each update. We do this only for programs in 'My list'.
+                items = self._api.get_items(content_filter=Program, cache=CACHE_AUTO)
+            else:
+                # Only favourites, don't use cache, fetch from api
+                # If we use CACHE_AUTO, we will miss updates until the user manually opens the program in the Add-on
+                items = self._api.get_swimlane('my-list', content_filter=Program, cache=CACHE_PREVENT)
+        else:
+            # Fetch only a single program
+            items = [self._api.get_program(program, cache=CACHE_PREVENT)]
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id)  # We need a trailing /
+            title_item.path = 'plugin://plugin.video.vtm.go/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows_program(self, program):
+        """ Return a list of the episodes that should be exported. """
+        program_obj = self._api.get_program(program)
+
+        listing = []
+        for season in list(program_obj.seasons.values()):
+            for item in list(season.episodes.values()):
+                title_item = Menu.generate_titleitem(item)
+                # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id, episode=item.episode_id)
+                title_item.path = 'plugin://plugin.video.vtm.go/library/tvshows/?program={program_id}&episode={episode_id}'.format(program_id=item.program_id,
+                                                                                                                                   episode_id=item.episode_id)
+                listing.append(title_item)
+
+        # Sort by episode number by default. Takes seasons into account.
+        kodiutils.show_listing(listing, 30003, content='episodes', sort=['episode', 'duration'])
+
+    def check_library_movie(self, movie):
+        """ Check if the given movie is still available. """
+        _LOGGER.debug('Checking if movie %s is still available', movie)
+
+        # Our parent path always exists
+        if movie is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+            id_list = self._api.get_catalog_ids()
+        else:
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(movie in id_list)
+
+    def check_library_tvshow(self, program):
+        """ Check if the given program is still available. """
+        _LOGGER.debug('Checking if program %s is still available', program)
+
+        # Our parent path always exists
+        if program is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+            id_list = self._api.get_catalog_ids()
+        else:
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(program in id_list)
+
+    @staticmethod
+    def mylist_added(video_type, content_id):
+        """ Something has been added to My List. We want to index this. """
+        if video_type == CONTENT_TYPE_MOVIE:
+            if kodiutils.get_setting_int('library_movies') != LIBRARY_ONLY_MYLIST:
+                return
+            # This unfortunately adds the movie to the database with the wrong parent path:
+            # Library().update('plugin://plugin.video.vtm.go/library/movies/?movie=%s&kodi_action=refresh_info' % content_id)
+            Library().update('plugin://plugin.video.vtm.go/library/movies/')
+
+        elif video_type == CONTENT_TYPE_PROGRAM:
+            if kodiutils.get_setting_int('library_tvshows') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().update('plugin://plugin.video.vtm.go/library/tvshows/?program=%s&kodi_action=refresh_info' % content_id)
+
+    @staticmethod
+    def mylist_removed(video_type, content_id):
+        """ Something has been removed from My List. We want to de-index this. """
+        if video_type == CONTENT_TYPE_MOVIE:
+            if kodiutils.get_setting_int('library_movies') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().clean('plugin://plugin.video.vtm.go/library/movies/?movie=%s' % content_id)
+
+        elif video_type == CONTENT_TYPE_PROGRAM:
+            if kodiutils.get_setting_int('library_tvshows') != LIBRARY_ONLY_MYLIST:
+                return
+            Library().clean('plugin://plugin.video.vtm.go/library/tvshows/?program=%s' % content_id)
+
+    @staticmethod
+    def configure():
+        """ Configure the library integration. """
+        # There seems to be no way to add sources automatically.
+        # * https://forum.kodi.tv/showthread.php?tid=228840
+
+        # Open the sources view
+        kodiutils.execute_builtin('ActivateWindow(Videos,sources://video/)')
+
+    @staticmethod
+    def update(path=None):
+        """ Update the library integration. """
+        _LOGGER.debug('Scanning %s', path)
+        if path:
+            # We can use this to instantly add something to the library when we've added it to 'My List'.
+            kodiutils.jsonrpc(method='VideoLibrary.Scan', params=dict(
+                directory=path,
+                showdialogs=False,
+            ))
+        else:
+            kodiutils.jsonrpc(method='VideoLibrary.Scan')
+
+    @staticmethod
+    def clean(path=None):
+        """ Cleanup the library integration. """
+        _LOGGER.debug('Cleaning %s', path)
+        if path:
+            # We can use this to instantly remove something from the library when we've removed it from 'My List'.
+            # This only works from Kodi 19 however. See https://github.com/xbmc/xbmc/pull/18562
+            if kodiutils.kodi_version_major() > 18:
+                kodiutils.jsonrpc(method='VideoLibrary.Clean', params=dict(
+                    directory=path,
+                    showdialogs=False,
+                ))
+            else:
+                kodiutils.jsonrpc(method='VideoLibrary.Clean', params=dict(
+                    showdialogs=False,
+                ))
+        else:
+            kodiutils.jsonrpc(method='VideoLibrary.Clean')

--- a/plugin.video.vtm.go/resources/lib/modules/menu.py
+++ b/plugin.video.vtm.go/resources/lib/modules/menu.py
@@ -7,7 +7,9 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
-from resources.lib.vtmgo import CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM, Movie, Program, Episode
+from resources.lib.vtmgo import (Episode, Movie, Program, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SERIES, STOREFRONT_KIDS, STOREFRONT_KIDS_MAIN)
+from resources.lib.vtmgo.vtmgo import CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM
+from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,33 +19,18 @@ class Menu:
 
     def __init__(self):
         """ Initialise object """
+        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                               kodiutils.get_setting('password'),
+                               'VTM',
+                               kodiutils.get_setting('profile'),
+                               kodiutils.get_tokens_path())
 
-    @staticmethod
-    def show_mainmenu():
+    def show_mainmenu(self):
         """ Show the main menu """
         listing = []
-        listing.append(kodiutils.TitleItem(
-            title=kodiutils.localize(30001),  # A-Z
-            path=kodiutils.url_for('show_catalog_all'),
-            art_dict=dict(
-                icon='DefaultMovieTitle.png',
-                fanart=kodiutils.get_addon_info('fanart'),
-            ),
-            info_dict=dict(
-                plot=kodiutils.localize(30002),
-            ),
-        ))
-        listing.append(kodiutils.TitleItem(
-            title=kodiutils.localize(30003),  # Catalogue
-            path=kodiutils.url_for('show_catalog'),
-            art_dict=dict(
-                icon='DefaultGenre.png',
-                fanart=kodiutils.get_addon_info('fanart'),
-            ),
-            info_dict=dict(
-                plot=kodiutils.localize(30004),
-            ),
-        ))
+
+        account = self._auth.login()
+
         listing.append(kodiutils.TitleItem(
             title=kodiutils.localize(30007),  # TV Channels
             path=kodiutils.url_for('show_channels'),
@@ -56,10 +43,10 @@ class Menu:
             ),
         ))
 
-        if kodiutils.get_setting_bool('interface_show_recommendations'):
+        if account.product == 'VTM_GO':
             listing.append(kodiutils.TitleItem(
                 title=kodiutils.localize(30015),  # Recommendations
-                path=kodiutils.url_for('show_recommendations'),
+                path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_MAIN),
                 art_dict=dict(
                     icon='DefaultFavourites.png',
                     fanart=kodiutils.get_addon_info('fanart'),
@@ -68,6 +55,79 @@ class Menu:
                     plot=kodiutils.localize(30016),
                 ),
             ))
+
+            listing.append(kodiutils.TitleItem(
+                title=kodiutils.localize(30003),  # Movies
+                path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_MOVIES),
+                art_dict=dict(
+                    icon='DefaultMovies.png',
+                    fanart=kodiutils.get_addon_info('fanart'),
+                ),
+                info_dict=dict(
+                    plot=kodiutils.localize(30004),
+                ),
+            ))
+
+            listing.append(kodiutils.TitleItem(
+                title=kodiutils.localize(30005),  # Series
+                path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_SERIES),
+                art_dict=dict(
+                    icon='DefaultTVShows.png',
+                    fanart=kodiutils.get_addon_info('fanart'),
+                ),
+                info_dict=dict(
+                    plot=kodiutils.localize(30006),
+                ),
+            ))
+
+            listing.append(kodiutils.TitleItem(
+                title=kodiutils.localize(30021),  # Kids
+                path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_KIDS),
+                art_dict=dict(
+                    icon='DefaultFavourites.png',
+                    fanart=kodiutils.get_addon_info('fanart'),
+                ),
+                info_dict=dict(
+                    plot=kodiutils.localize(30022),
+                ),
+            ))
+
+        elif account.product == 'VTM_GO_KIDS':
+            listing.append(kodiutils.TitleItem(
+                title=kodiutils.localize(30015),  # Recommendations
+                path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_KIDS_MAIN),
+                art_dict=dict(
+                    icon='DefaultFavourites.png',
+                    fanart=kodiutils.get_addon_info('fanart'),
+                ),
+                info_dict=dict(
+                    plot=kodiutils.localize(30016),
+                ),
+            ))
+
+        listing.append(kodiutils.TitleItem(
+            title=kodiutils.localize(30001),  # A-Z
+            path=kodiutils.url_for('show_catalog_all'),
+            art_dict=dict(
+                icon='DefaultMovieTitle.png',
+                fanart=kodiutils.get_addon_info('fanart'),
+            ),
+            info_dict=dict(
+                plot=kodiutils.localize(30002),
+            ),
+        ))
+
+        # listing.append(kodiutils.TitleItem(
+        #     title=kodiutils.localize(30003),  # Catalogue
+        #     path=kodiutils.url_for('show_catalog'),
+        #     art_dict=dict(
+        #         icon='DefaultGenre.png',
+        #         fanart=kodiutils.get_addon_info('fanart'),
+        #     ),
+        #     info_dict=dict(
+        #         plot=kodiutils.localize(30004),
+        #     ),
+        # ))
 
         if kodiutils.get_setting_bool('interface_show_mylist') and kodiutils.has_credentials():
             listing.append(kodiutils.TitleItem(
@@ -158,7 +218,8 @@ class Menu:
 
         return plot.rstrip()
 
-    def generate_titleitem(self, item, progress=False):
+    @classmethod
+    def generate_titleitem(cls, item, progress=False):
         """ Generate a TitleItem based on a Movie, Program or Episode.
         :type item: Union[Movie, Program, Episode]
         :type progress: bool
@@ -170,7 +231,7 @@ class Menu:
         }
         info_dict = {
             'title': item.name,
-            'plot': self.format_plot(item),
+            'plot': cls.format_plot(item),
             'studio': CHANNELS.get(item.channel, {}).get('studio_icon'),
             'mpaa': ', '.join(item.legal) if hasattr(item, 'legal') and item.legal else kodiutils.localize(30216),  # All ages
         }
@@ -215,6 +276,7 @@ class Menu:
                 art_dict=art_dict,
                 info_dict=info_dict,
                 stream_dict=stream_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
                 is_playable=True,
             )
@@ -240,8 +302,11 @@ class Menu:
                 'fanart': item.image,
             })
             info_dict.update({
-                'mediatype': None,
+                'mediatype': 'tvshow',
                 'season': len(item.seasons),
+            })
+            prop_dict.update({
+                'hash': item.content_hash,
             })
 
             return kodiutils.TitleItem(
@@ -249,6 +314,7 @@ class Menu:
                 path=kodiutils.url_for('show_catalog_program', program=item.program_id),
                 art_dict=art_dict,
                 info_dict=info_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
             )
 

--- a/plugin.video.vtm.go/resources/lib/modules/metadata.py
+++ b/plugin.video.vtm.go/resources/lib/modules/metadata.py
@@ -44,7 +44,7 @@ class Metadata:
         """ Fetch the metadata for all the items in the catalog
         :type callback: callable
         """
-        # Fetch all items from the catalog
+        # Fetch a list of all items from the catalog
         items = self._vtm_go.get_items()
         count = len(items)
 

--- a/plugin.video.vtm.go/resources/lib/modules/player.py
+++ b/plugin.video.vtm.go/resources/lib/modules/player.py
@@ -7,9 +7,12 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.kodiplayer import KodiPlayer
-from resources.lib.vtmgo.vtmgo import VtmGo, UnavailableException
+from resources.lib.vtmgo.exceptions import UnavailableException
+from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
-from resources.lib.vtmgo.vtmgostream import VtmGoStream, StreamGeoblockedException, StreamUnavailableException
+from resources.lib.vtmgo.vtmgostream import (StreamGeoblockedException,
+                                             StreamUnavailableException,
+                                             VtmGoStream)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plugin.video.vtm.go/resources/lib/modules/tvguide.py
+++ b/plugin.video.vtm.go/resources/lib/modules/tvguide.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 
 from resources.lib import kodiutils
-from resources.lib.vtmgo.vtmgo import UnavailableException
+from resources.lib.vtmgo.exceptions import UnavailableException
 from resources.lib.vtmgo.vtmgoepg import VtmGoEpg
 
 _LOGGER = logging.getLogger(__name__)

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -3,10 +3,14 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-API_ENDPOINT = 'https://api.vtmgo.be'
-CONTENT_TYPE_MOVIE = 'MOVIE'
-CONTENT_TYPE_PROGRAM = 'PROGRAM'
-CONTENT_TYPE_EPISODE = 'EPISODE'
+API_ENDPOINT = 'https://lfvp-api.dpgmedia.net'
+
+# These seem to be hardcoded
+STOREFRONT_MAIN = '9620cc0b-0f97-4d96-902a-827dcfd0b227'
+STOREFRONT_MOVIES = 'e3fc0750-f110-4808-ae5f-246846ff940f'
+STOREFRONT_SERIES = '1c683de4-3fb0-4cc4-9d9c-c365eba1b155'
+STOREFRONT_KIDS = '73f34fbf-301c-4deb-b366-13ba39e25996'
+STOREFRONT_KIDS_MAIN = '11575a66-af71-4025-8e57-d691a7520773'
 
 
 class Profile:
@@ -135,7 +139,7 @@ class Program:
     """ Defines a Program """
 
     def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
-                 geoblocked=None, channel=None, legal=None, my_list=None):
+                 geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None):
         """
         :type program_id: str
         :type name: str
@@ -147,6 +151,7 @@ class Program:
         :type channel: str
         :type legal: str
         :type my_list: bool
+        :type content_hash: str
         """
         self.program_id = program_id
         self.name = name
@@ -158,6 +163,7 @@ class Program:
         self.channel = channel
         self.legal = legal
         self.my_list = my_list
+        self.content_hash = content_hash
 
     def __repr__(self):
         return "%r" % self.__dict__
@@ -232,6 +238,33 @@ class Episode:
         self.progress = progress
         self.watched = watched
         self.next_episode = next_episode
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class ResolvedStream:
+    """ Defines a stream that we can play"""
+
+    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_url=None, subtitles=None, cookies=None):
+        """
+        :type program: str|None
+        :type program_id: int|None
+        :type title: str
+        :type duration: str|None
+        :type url: str
+        :type license_url: str
+        :type subtitles: list[str]
+        :type cookies: dict
+        """
+        self.program = program
+        self.program_id = program_id
+        self.title = title
+        self.duration = duration
+        self.url = url
+        self.license_url = license_url
+        self.subtitles = subtitles
+        self.cookies = cookies
 
     def __repr__(self):
         return "%r" % self.__dict__

--- a/plugin.video.vtm.go/resources/lib/vtmgo/exceptions.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/exceptions.py
@@ -16,14 +16,6 @@ class InvalidLoginException(Exception):
     """ Is thrown when the credentials are invalid. """
 
 
-class NoStreamzSubscriptionException(Exception):
-    """ Is thrown when you don't have an subscription. """
-
-
-class NoTelenetSubscriptionException(Exception):
-    """ Is thrown when you don't have an subscription. """
-
-
 class LoginErrorException(Exception):
     """ Is thrown when we could not login. """
 
@@ -42,3 +34,6 @@ class StreamGeoblockedException(Exception):
 
 class StreamUnavailableException(Exception):
     """ Is thrown when an unavailable item is played. """
+
+class LimitReachedException(Exception):
+    """ Is thrown when the limit is reached to play an stream. """

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -8,7 +8,9 @@ import logging
 import requests
 from requests import HTTPError
 
-from resources.lib.vtmgo.exceptions import InvalidTokenException, InvalidLoginException
+from resources.lib.vtmgo.exceptions import (InvalidLoginException,
+                                            InvalidTokenException,
+                                            UnavailableException, LimitReachedException)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,11 +38,15 @@ def http_get(url, params=None, token=None, profile=None, headers=None, proxies=N
     """
     try:
         return _request('GET', url=url, params=params, token=token, profile=profile, headers=headers, proxies=proxies)
-    except HTTPError as ex:
-        if ex.response.status_code == 401:
-            raise InvalidTokenException
-        if ex.response.status_code == 403:
-            raise InvalidLoginException
+    except HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise InvalidTokenException(exc)
+        if exc.response.status_code == 403:
+            raise InvalidLoginException(exc)
+        if exc.response.status_code == 404:
+            raise UnavailableException(exc)
+        if exc.response.status_code == 429:
+            raise LimitReachedException(exc)
         raise
 
 
@@ -60,11 +66,15 @@ def http_post(url, params=None, form=None, data=None, token=None, profile=None, 
     """
     try:
         return _request('POST', url=url, params=params, form=form, data=data, token=token, profile=profile, headers=headers, proxies=proxies)
-    except HTTPError as ex:
-        if ex.response.status_code == 401:
-            raise InvalidTokenException
-        if ex.response.status_code == 403:
-            raise InvalidLoginException
+    except HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise InvalidTokenException(exc)
+        if exc.response.status_code == 403:
+            raise InvalidLoginException(exc)
+        if exc.response.status_code == 404:
+            raise UnavailableException(exc)
+        if exc.response.status_code == 429:
+            raise LimitReachedException(exc)
         raise
 
 
@@ -84,11 +94,13 @@ def http_put(url, params=None, form=None, data=None, token=None, profile=None, h
     """
     try:
         return _request('PUT', url=url, params=params, form=form, data=data, token=token, profile=profile, headers=headers, proxies=proxies)
-    except HTTPError as ex:
-        if ex.response.status_code == 401:
-            raise InvalidTokenException
-        if ex.response.status_code == 403:
-            raise InvalidLoginException
+    except HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise InvalidTokenException(exc)
+        if exc.response.status_code == 403:
+            raise InvalidLoginException(exc)
+        if exc.response.status_code == 404:
+            raise UnavailableException(exc)
         raise
 
 
@@ -106,11 +118,13 @@ def http_delete(url, params=None, token=None, profile=None, headers=None, proxie
     """
     try:
         return _request('DELETE', url=url, params=params, token=token, profile=profile, headers=headers, proxies=proxies)
-    except HTTPError as ex:
-        if ex.response.status_code == 401:
-            raise InvalidTokenException
-        if ex.response.status_code == 403:
-            raise InvalidLoginException
+    except HTTPError as exc:
+        if exc.response.status_code == 401:
+            raise InvalidTokenException(exc)
+        if exc.response.status_code == 403:
+            raise InvalidLoginException(exc)
+        if exc.response.status_code == 404:
+            raise UnavailableException(exc)
         raise
 
 
@@ -129,7 +143,10 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
     :returns:                       The HTTP Response object.
     :rtype: requests.Response
     """
-    _LOGGER.debug('Sending %s %s... (%s)', method, url, form or data)
+    if form or data:
+        _LOGGER.debug('Sending %s %s: %s', method, url, form or data)
+    else:
+        _LOGGER.debug('Sending %s %s', method, url)
 
     if headers is None:
         headers = {}
@@ -146,7 +163,8 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
     if not response.encoding:
         response.encoding = 'utf-8'
 
-    _LOGGER.debug('Got response (status=%s): %s', response.status_code, response.text)
+    # Log only the first 1KB of the response
+    _LOGGER.debug('Got response (status=%s): %s', response.status_code, response.text[:1024])
 
     # Raise a generic HTTPError exception when we got an non-okay status code.
     response.raise_for_status()

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
@@ -7,12 +7,14 @@ import json
 import logging
 import os
 import re
-from uuid import uuid4
 from hashlib import md5
+from uuid import uuid4
 
 from resources.lib import kodiutils
 from resources.lib.vtmgo import API_ENDPOINT, Profile, util
-from resources.lib.vtmgo.exceptions import InvalidLoginException, LoginErrorException, NoLoginException
+from resources.lib.vtmgo.exceptions import (InvalidLoginException,
+                                            LoginErrorException,
+                                            NoLoginException)
 
 try:  # Python 3
     import jwt
@@ -25,7 +27,6 @@ _LOGGER = logging.getLogger(__name__)
 
 class AccountStorage:
     """ Data storage for account info """
-    login_token = ''
     jwt_token = ''
     profile = ''
     product = ''

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -10,44 +10,10 @@ import random
 from datetime import timedelta
 
 from resources.lib import kodiutils
-from resources.lib.vtmgo import util
+from resources.lib.vtmgo import util, ResolvedStream
+from resources.lib.vtmgo.exceptions import StreamGeoblockedException, StreamUnavailableException
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class StreamGeoblockedException(Exception):
-    """ Is thrown when a geoblocked item is played. """
-
-
-class StreamUnavailableException(Exception):
-    """ Is thrown when an unavailable item is played. """
-
-
-class ResolvedStream:
-    """ Defines a stream that we can play"""
-
-    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_url=None, subtitles=None, cookies=None):
-        """
-        :type program: str|None
-        :type program_id: int|None
-        :type title: str
-        :type duration: str|None
-        :type url: str
-        :type license_url: str
-        :type subtitles: list[str]
-        :type cookies: dict
-        """
-        self.program = program
-        self.program_id = program_id
-        self.title = title
-        self.duration = duration
-        self.url = url
-        self.license_url = license_url
-        self.subtitles = subtitles
-        self.cookies = cookies
-
-    def __repr__(self):
-        return "%r" % self.__dict__
 
 
 class VtmGoStream:
@@ -446,6 +412,7 @@ class VtmGoStream:
         :rtype str
         """
         import re
+
         # Follow when a <Location>url</Location> tag is found.
         # https://github.com/peak3d/inputstream.adaptive/issues/286
         download = self._download_text(url)
@@ -467,9 +434,9 @@ class VtmGoStream:
         :rtype str
         """
         try:  # Python 3
-            from urllib.parse import urlencode, quote
+            from urllib.parse import quote, urlencode
         except ImportError:  # Python 2
-            from urllib import urlencode, quote
+            from urllib import quote, urlencode
 
         header = ''
         if key_headers:

--- a/plugin.video.vtm.go/resources/settings.xml
+++ b/plugin.video.vtm.go/resources/settings.xml
@@ -13,7 +13,6 @@
     </category>
     <category label="30820"> <!-- Interface -->
         <setting label="30821" type="lsep"/> <!-- Features -->
-        <setting label="30822" type="bool" id="interface_show_recommendations" default="true"/>
         <setting label="30823" type="bool" id="interface_show_mylist" default="true"/>
         <setting label="30826" type="bool" id="interface_show_continuewatching" default="false" visible="false"/>
         <setting label="30827" type="lsep"/> <!-- Metadata -->
@@ -27,6 +26,15 @@
         <setting label="30843" type="lsep"/> <!-- Streaming -->
         <setting label="30844" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>
     </category>
+    <category label="30870"> <!-- Kodi Library -->
+        <setting label="30871" type="lsep"/> <!-- Indexing -->
+        <setting label="30872" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/configure)" option="close"/>
+        <setting label="30873" type="select" id="library_movies" default="1" lvalues="30875|30876"/>
+        <setting label="30874" type="select" id="library_tvshows" default="1" lvalues="30875|30876"/>
+        <setting label="30877" type="lsep"/> <!-- Maintenance -->
+        <setting label="30878" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/update)"/>
+        <setting label="30879" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/library/clean)"/>
+    </category>
     <category label="30860"> <!-- Integrations -->
         <setting label="30861" type="lsep"/> <!-- Up Next -->
         <setting label="30862" type="action" action="InstallAddon(service.upnext)" option="close" visible="!System.HasAddon(service.upnext)"/>
@@ -34,7 +42,7 @@
         <setting label="30864" type="action" action="Addon.OpenSettings(service.upnext)" enable="eq(-1,true)" option="close" visible="System.HasAddon(service.upnext)" subsetting="true"/>
 
         <setting label="30866" type="lsep"/> <!-- IPTV Manager -->
-        <!-- <setting label="30867" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/> &lt;!&ndash; Install IPTV Manager add-on &ndash;&gt;-->
+        <setting label="30867" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/> <!-- Install IPTV Manager add-on -->
         <setting label="30868" type="bool" id="iptv.enabled" default="true" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" />
         <setting label="30869" type="action" action="Addon.OpenSettings(service.iptv.manager)" enable="eq(-1,true)" option="close" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" subsetting="true"/> <!-- IPTV Manager settings -->
         <setting id="iptv.channels_uri" default="plugin://plugin.video.vtm.go/iptv/channels" visible="false"/>
@@ -47,5 +55,7 @@
         <setting label="30887" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)"/>
         <setting label="30889" type="lsep"/> <!-- Logging -->
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
+        <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30893" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.0
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.0 (2020-11-11)
- Implement Kodi Library support.
- Use new Movies and Series categories.
- Bugfixes and improved error handling.


### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
