### PR TITLE
[plugin.video.francetv] Mark addon as broken (no longer maintained for Krypton)

### DIFF
--- a/plugin.video.francetv/addon.xml
+++ b/plugin.video.francetv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.francetv" name="france.tv" version="1.1.0" provider-name="melmorabity">
+<addon id="plugin.video.francetv" name="france.tv" version="1.1.1" provider-name="melmorabity">
   <requires>
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.dateutil" version="2.5.3"/>
@@ -24,7 +24,11 @@
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.jpg</fanart>
     </assets>
-    <news>v1.1.0 (2019-11-18)
+    <broken>This addon will only be supported for Leia and higher versions. Please upgrade your Kodi version.</broken>
+    <news>v1.1.1 (2020-11-24)
+    - Mark the addon as broken (no longer maintained for Krypton)
+
+v1.1.0 (2019-11-18)
     - Fixes for Python 3 support
     - Update Slash icon
 


### PR DESCRIPTION
### Description

Mark addon as broken (will only support Kodi 18 and above).

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ x Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
