### PR TITLE
[plugin.video.tvvlaanderen@leia] 1.0.1

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.1](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.1) (2020-12-17)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.0...v1.0.1)
+
+**Fixed bugs:**
+
+- Fix EPG on windows [\#28](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/28) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.0.0](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.0) (2020-12-05)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v0.0.1...v1.0.0)

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.0" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -22,8 +22,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.0
-- First release.</news>
+        <news>v1.0.1
+- Fix TV Guide on Windows.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
@@ -97,16 +97,21 @@ class EpgApi:
         if not isinstance(channels, list):
             channels = [channels]
 
+        # Python 2.7 doesn't support .timestamp(), and windows doesn't do '%s', so we need to calculate it ourself
+        epoch = datetime(1970, 1, 1, tzinfo=dateutil.tz.gettz('UTC'))
+
         # Generate dates in UTC format
         if date_from is not None:
             date_from = self._parse_date(date_from)
         else:
             date_from = self._parse_date('today')
+        date_from_posix = str(int((date_from - epoch).total_seconds())) + '000'
 
         if date_to is not None:
             date_to = self._parse_date(date_to)
         else:
             date_to = (date_from + timedelta(days=1))
+        date_to_posix = str(int((date_to - epoch).total_seconds())) + '000'
 
         programs = {}
 
@@ -122,8 +127,8 @@ class EpgApi:
                     'u': self._tokens.device_serial,
                     'a': self._tenant.get('app'),
                     's': '!'.join(channels[i:i + self.EPG_CAPI_CHUNK_SIZE]),  # station id's separated with a !
-                    'f': date_from.strftime("%s") + '000',  # from timestamp
-                    't': date_to.strftime("%s") + '000',  # to timestamp
+                    'f': date_from_posix,  # from timestamp
+                    't': date_to_posix,  # to timestamp
                     # 736763 = BIT_EPG_DETAIL_ID | BIT_EPG_DETAIL_TITLE | BIT_EPG_DETAIL_DESCRIPTION | BIT_EPG_DETAIL_AGE |
                     #          BIT_EPG_DETAIL_CATEGORY | BIT_EPG_DETAIL_START | BIT_EPG_DETAIL_END | BIT_EPG_DETAIL_FLAGS |
                     #          BIT_EPG_DETAIL_COVER | BIT_EPG_DETAIL_SEASON_NO | BIT_EPG_DETAIL_EPISODE_NO |


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen
  
This add-on gives access to the live tv channels and the video-on-demand content available in your TV Vlaanderen subscription.

### Description of changes:

v1.0.1
- Fix TV Guide on Windows.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
