### PR TITLE
[plugin.video.vrt.nu@krypton] 2.4.2

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,13 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.4.2 (2020-12-18)
+- Fix missing seasons (for 'Thuis') in TV Show menu (@mediaminister)
+- Fix missing favourite programs in 'My programs' menu (@mediaminister)
+- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settings (@michaelarnauts)
+- Updated Categories menu (@dagwieers)
+- Fix date parsing on Windows (@michaelarnauts)
+
 ### v2.4.1 (2020-10-31)
 - Add new category "Nostalgia" (@dagwieers)
 - Add poster support (@dagwieers)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.2" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,13 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.4.2 (2020-12-18)
+- Fix missing seasons (for 'Thuis') in TV Show menu
+- Fix missing favourite programs in 'My programs' menuu
+- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
+- Updated Categories menu
+- Fix date parsing on Windows
+
 v2.4.1 (2020-10-31)
 - Add new category "Nostalgia"
 - Add poster support

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -741,6 +741,10 @@ msgctxt "#30834"
 msgid "VRT NWS"
 msgstr ""
 
+msgctxt "#30835"
+msgid "De Warmste Week"
+msgstr ""
+
 msgctxt "#30860"
 msgid "Integration"
 msgstr ""
@@ -790,7 +794,7 @@ msgid "Install IPTV Manager add-on…"
 msgstr ""
 
 msgctxt "#30877"
-msgid "Enable IPTV Manager integration (experimental)"
+msgid "Enable IPTV Manager integration"
 msgstr ""
 
 msgctxt "#30879"
@@ -895,6 +899,14 @@ msgstr ""
 
 msgctxt "#30933"
 msgid "Log level"
+msgstr ""
+
+msgctxt "#30935"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30937"
+msgid "Open Kodi Logfile Uploader…"
 msgstr ""
 
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -741,6 +741,10 @@ msgctxt "#30834"
 msgid "VRT NWS"
 msgstr "VRT NWS"
 
+msgctxt "#30835"
+msgid "De Warmste Week"
+msgstr "De Warmste Week"
+
 msgctxt "#30860"
 msgid "Integration"
 msgstr "Integratie"
@@ -790,8 +794,8 @@ msgid "Install IPTV Manager add-on…"
 msgstr "Installeer de IPTV Manager add-on…"
 
 msgctxt "#30877"
-msgid "Enable IPTV Manager integration (experimental)"
-msgstr "Activeer IPTV Manager integratie (experimenteel)"
+msgid "Enable IPTV Manager integration"
+msgstr "Activeer IPTV Manager integratie"
 
 msgctxt "#30879"
 msgid "IPTV Manager settings…"
@@ -896,6 +900,14 @@ msgstr "Logboek"
 msgctxt "#30933"
 msgid "Log level"
 msgstr "Log niveau"
+
+msgctxt "#30935"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30937"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"
 
 
 ### MESSAGES

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -12,19 +12,19 @@ SECONDS_MARGIN = 30
 CATEGORIES = [
     dict(name='Audiodescriptie', id='met-audiodescriptie', msgctxt=30070),
     dict(name='Cultuur', id='cultuur', msgctxt=30071),
-    dict(name='Documentaire', id='docu', msgctxt=30072),
+    dict(name='Docu', id='docu', msgctxt=30072),
     dict(name='Entertainment', id='entertainment', msgctxt=30073),
     dict(name='Film', id='films', msgctxt=30074),
     dict(name='Human interest', id='human-interest', msgctxt=30075),
     dict(name='Humor', id='humor', msgctxt=30076),
-    dict(name='Kinderen & jongeren', id='voor-kinderen', msgctxt=30077),
+    dict(name='Kinderen en jongeren', id='voor-kinderen', msgctxt=30077),
     dict(name='Koken', id='koken', msgctxt=30078),
     dict(name='Levensbeschouwing', id='levensbeschouwing', msgctxt=30087),
     dict(name='Lifestyle', id='lifestyle', msgctxt=30079),
     dict(name='Muziek', id='muziek', msgctxt=30080),
     dict(name='Nieuws en actua', id='nieuws-en-actua', msgctxt=30081),
     dict(name='Nostalgie', id='nostalgie', msgctxt=30088),
-    dict(name='Serie', id='series', msgctxt=30082),
+    dict(name='Series', id='series', msgctxt=30082),
     dict(name='Sport', id='sport', msgctxt=30083),
     dict(name='Talkshows', id='talkshows', msgctxt=30084),
     dict(name='Vlaamse Gebarentaal', id='met-gebarentaal', msgctxt=30085),
@@ -52,6 +52,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/een/een_LOGO_zwart.png',
         epg_id='een.be',
         preset=1,
+        vod=True,
     ),
     dict(
         id='1H',
@@ -69,6 +70,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/canvas/CANVAS_logo_lichtblauw.jpg',
         epg_id='canvas.be',
         preset=2,
+        vod=True,
     ),
     dict(
         id='O9',
@@ -86,6 +88,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/ketnet/ketnet_LOGO_rood_geel.png',
         epg_id='ketnet.be',
         preset=12,
+        vod=True,
     ),
     dict(
         id='',
@@ -99,6 +102,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/2019/07/19/c309360a-aa10-11e9-abcc-02b7b76bf47f.png',
         epg_id='ketnetjr.be',
         preset=11,
+        vod=True,
     ),
     dict(
         id='12',
@@ -112,6 +116,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/sporza/sporza_logo_zwart.png',
         epg_id='sporza.be',
         preset=801,
+        vod=True,
     ),
     dict(
         id='13',
@@ -127,6 +132,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/vrtnws.png',
         epg_id='vrtnws.be',
         preset=802,
+        vod=True,
     ),
     dict(
         id='11',
@@ -141,6 +147,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/radio1.png',
         epg_id='radio1.be',
         preset=901,
+        vod=True,
     ),
     dict(
         id='22',
@@ -155,6 +162,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/radio2.png',
         epg_id='radio2vlb.be',
         preset=902,
+        vod=True,
     ),
     dict(
         id='31',
@@ -169,6 +177,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/klara.png',
         epg_id='klara.be',
         preset=903,
+        vod=True,
     ),
     dict(
         id='41',
@@ -183,6 +192,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/2019/03/12/1e383cf5-44a7-11e9-abcc-02b7b76bf47f.png',
         epg_id='stubru.be',
         preset=904,
+        vod=True,
     ),
     dict(
         id='55',
@@ -197,6 +207,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/mnm/logo_witte_achtergrond.png',
         epg_id='mnm.be',
         preset=905,
+        vod=True,
     ),
     dict(
         id='',
@@ -206,6 +217,7 @@ CHANNELS = [
         youtube=[
             dict(label='VRT NXT', url='https://www.youtube.com/channel/UCO-VoGCVzhYVwvQvWYJq4-Q'),
         ],
+        vod=True,
     ),
     dict(
         id='',
@@ -215,6 +227,7 @@ CHANNELS = [
         youtube=[
             dict(label='De Warmste Week', url='https://www.youtube.com/channel/UC_PsMpKLAp4hSGSXyUCPtxw'),
         ],
+        vod=True,
     ),
     dict(
         id='',
@@ -225,6 +238,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents1.be',
         preset=851,
+        vod=False,
     ),
     dict(
         id='',
@@ -235,6 +249,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents2.be',
         preset=852,
+        vod=False,
     ),
     dict(
         id='',
@@ -245,6 +260,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents3.be',
         preset=853,
+        vod=False,
     ),
 ]
 

--- a/plugin.video.vrt.nu/resources/lib/metadata.py
+++ b/plugin.video.vrt.nu/resources/lib/metadata.py
@@ -280,7 +280,7 @@ class Metadata:
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':
-            if season:
+            if season is not False:
                 plot = html_to_kodi(api_data.get('programDescription', ''))
 
                 # Add additional metadata to plot
@@ -373,7 +373,7 @@ class Metadata:
         """Get plotoutline string from single item json api data"""
         # VRT NU Search API
         if api_data.get('type') == 'episode':
-            if season:
+            if season is not False:
                 plotoutline = html_to_kodi(api_data.get('programDescription', ''))
                 return plotoutline
 
@@ -551,7 +551,7 @@ class Metadata:
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':
-            if season:
+            if season is not False:
                 return 'season'
 
             # If this is a oneoff (e.g. movie) and we get a year of release, do not set 'aired'
@@ -577,7 +577,7 @@ class Metadata:
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':
-            if season:
+            if season is not False:
                 if get_setting_bool('showfanart', default=True):
                     art_dict['fanart'] = add_https_proto(api_data.get('programImageUrl', 'DefaultSets.png'))
                     if season != 'allseasons':
@@ -637,7 +637,7 @@ class Metadata:
         # VRT NU Search API
         if api_data.get('type') == 'episode':
             info_labels = dict(
-                title=self.get_title(api_data),
+                title=self.get_title(api_data, season=season),
                 # sorttitle=self.get_title(api_data),  # NOTE: Does not appear to work
                 tvshowtitle=self.get_tvshowtitle(api_data),
                 # date=self.get_date(api_data),  # NOTE: Not sure when or how this is used
@@ -687,8 +687,12 @@ class Metadata:
         return {}
 
     @staticmethod
-    def get_title(api_data):
+    def get_title(api_data, season=False):
         """Get an appropriate video title"""
+
+        if season is not False:
+            title = '%s %s' % (localize(30131), season)  # Season X
+            return title
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -130,6 +130,9 @@ def url_to_program(url):
     elif url.startswith('/vrtnu/a-z/'):
         # short programUrl
         program = url.split('/')[3]
+        # Workaround: when adding a favourite on https://www.vrt.be/vrtnu/ sometimes '.html' is wrongly added to the short program Url
+        if program.endswith('.html'):
+            program = program.replace('.html', '')
     if program.endswith('.relevant'):
         # targetUrl
         program = program.replace('.relevant', '')

--- a/plugin.video.vrt.nu/resources/settings.xml
+++ b/plugin.video.vrt.nu/resources/settings.xml
@@ -49,6 +49,7 @@
         <setting label="30832" type="bool" id="mnm" default="true"/> <!-- MNM -->
         <setting label="30833" type="bool" id="vrtnws" default="true"/> <!-- VRT NWS -->
         <setting label="30834" type="bool" id="vrtnxt" default="true"/> <!-- VRT NXT -->
+        <setting label="30835" type="bool" id="de-warmste-week" default="false"/> <!-- De Warmste Week -->
     </category>
     <category label="30860"> <!--Integration -->
         <setting label="30861" type="lsep"/> <!-- Integration with other add-ons -->
@@ -61,7 +62,7 @@
         <setting label="30871" help="30872" type="bool" id="useupnext" default="true" visible="System.HasAddon(service.upnext)" />
         <setting label="30873" help="30874" type="action" action="Addon.OpenSettings(service.upnext)" enable="eq(-1,true)" option="close" visible="System.HasAddon(service.upnext)" subsetting="true"/> <!-- Up Next settings -->
         <!-- IPTV Manager -->
-        <!-- setting label="30875" help="30876" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/ --> <!-- Install IPTV Manager add-on -->
+        <setting label="30875" help="30876" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/> <!-- Install IPTV Manager add-on -->
         <setting label="30877" help="30878" type="bool" id="iptv.enabled" default="true" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" />
         <setting label="30879" help="30880" type="action" action="Addon.OpenSettings(service.iptv.manager)" enable="eq(-1,true)" option="close" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" subsetting="true"/> <!-- IPTV Manager settings -->
         <setting id="iptv.channels_uri" default="plugin://plugin.video.vrt.nu/iptv/channels" visible="false"/>
@@ -92,5 +93,7 @@
         <setting label="30929" help="30930" type="slider" id="httpcachettlindirect" default="60" range="1,1,240" option="int" enable="eq(-3,true)" subsetting="true"/>
         <setting label="30931" type="lsep"/> <!-- Logging -->
         <setting label="30933" help="30934" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
+        <setting label="30935" help="30936" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30937" help="30938" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.4.2
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
