### PR TITLE
[plugin.video.tvvlaanderen@matrix] 1.0.2+matrix.1

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.2](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.2) (2020-12-21)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.1...v1.0.2)
+
+**Fixed bugs:**
+
+- Don't show the password in the debug log [\#29](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/29) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.0.1](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.1) (2020-12-17)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.0...v1.0.1)

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.1+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.2+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -22,8 +22,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.1
-- Fix TV Guide on Windows.</news>
+        <news>v1.0.2 (2020-12-21)
+- Don't leak credentials in the Kodi log when debug logging.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
@@ -279,7 +279,15 @@ def _request(method, url, params=None, form=None, data=None, token_bearer=None, 
     :returns:                           The HTTP Response object.
     :rtype: requests.Response
     """
-    _LOGGER.debug('Sending %s %s... (%s)', method, url, form or data)
+    if form or data:
+        # Make sure we don't log the password
+        debug_data = dict()
+        debug_data.update(form or data)
+        if 'Password' in debug_data:
+            debug_data['Password'] = '**redacted**'
+        _LOGGER.debug('Sending %s %s: %s', method, url, debug_data)
+    else:
+        _LOGGER.debug('Sending %s %s', method, url)
 
     if token_bearer:
         headers = {


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen
  
This add-on gives access to the live tv channels and the video-on-demand content available in your TV Vlaanderen subscription.

### Description of changes:

v1.0.2 (2020-12-21)
- Don't leak credentials in the Kodi log when debug logging.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
