### PR TITLE
[plugin.video.streamz@leia] 1.0.2

### DIFF
--- a/plugin.video.streamz/CHANGELOG.md
+++ b/plugin.video.streamz/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.0.2](https://github.com/add-ons/plugin.video.streamz/tree/v1.0.2) (2020-12-21)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.0.1...v1.0.2)
+
+**Fixed bugs:**
+
+- Don't show the password in the debug log [\#24](https://github.com/add-ons/plugin.video.streamz/pull/24) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Run CI on Windows [\#23](https://github.com/add-ons/plugin.video.streamz/pull/23) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.0.1](https://github.com/add-ons/plugin.video.streamz/tree/v1.0.1) (2020-12-07)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.0.0...v1.0.1)

--- a/plugin.video.streamz/addon.xml
+++ b/plugin.video.streamz/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.streamz" name="Streamz" version="1.0.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.streamz" name="Streamz" version="1.0.2" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,9 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door Streamz BV, en wordt aangeboden 'as is', zonder enige garantie. De Streamz naam en Streamz logo zijn eigendom van Streamz BV en worden gebruikt in overeenstemming met de 'fair use' regels.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.1 (2020-12-07)
-- Show all items in a category and improve loading speed.
-- Show current serie in the breadcrumbs.</news>
+	<news>v1.0.2 (2020-12-21)
+- Don't leak credentials in the Kodi log when debug logging.</news>
         <source>https://github.com/add-ons/plugin.video.streamz</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.streamz/resources/lib/streamz/util.py
+++ b/plugin.video.streamz/resources/lib/streamz/util.py
@@ -143,7 +143,12 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
     :rtype: requests.Response
     """
     if form or data:
-        _LOGGER.debug('Sending %s %s: %s', method, url, form or data)
+        # Make sure we don't log the password
+        debug_data = dict()
+        debug_data.update(form or data)
+        if 'password' in debug_data:
+            debug_data['password'] = '**redacted**'
+        _LOGGER.debug('Sending %s %s: %s', method, url, debug_data)
     else:
         _LOGGER.debug('Sending %s %s', method, url)
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Streamz
  - Add-on ID: plugin.video.streamz
  - Version number: 1.0.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.streamz
  
Streamz is a video-on-demand platform offering Flemish content from DPG Media, Telenet and VRT, but also including 'Home of HBO' content and blockbuster movies.

### Description of changes:

v1.0.2 (2020-12-21)
- Don't leak credentials in the Kodi log when debug logging.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
