### PR TITLE
[plugin.video.vtm.go@matrix] 1.2.2+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.2.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.2) (2020-12-30)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.1...v1.2.2)
+
+**Fixed bugs:**
+
+- Fix subtitles when there are more than one [\#248](https://github.com/add-ons/plugin.video.vtm.go/pull/248) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add proxy to modify the MPEG DASH Manifest [\#247](https://github.com/add-ons/plugin.video.vtm.go/pull/247) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.2.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.1) (2020-12-21)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.0...v1.2.1)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.1+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.2+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,11 +25,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.1 (2020-12-21)
-- Show all items in a category and improve loading speed.
-- Show current serie in the breadcrumbs.
-- Don't leak credentials in the Kodi log when debug logging.
-- Fix authentication issue when using the Library-feature.</news>
+	<news>v1.2.2 (2020-12-30)
+- Add workaround for Inputstream Adaptive bug so playback works again.
+- Fix subtitles.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
@@ -305,6 +305,10 @@ msgctxt "#30717"
 msgid "This program is not available in the VTM GO catalogue."
 msgstr ""
 
+msgctxt "#30718"
+msgid "The Manifest proxy is not running. Please restart Kodi."
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30800"
@@ -481,6 +485,10 @@ msgstr ""
 
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
+msgstr ""
+
+msgctxt "#30888"
+msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
 msgstr ""
 
 msgctxt "#30889"

--- a/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
@@ -306,6 +306,10 @@ msgctxt "#30717"
 msgid "This program is not available in the VTM GO catalogue."
 msgstr "Dit programma is niet beschikbaar in de VTM GO catalogus."
 
+msgctxt "#30718"
+msgid "The Manifest proxy is not running. Please restart Kodi."
+msgstr "De Manifest-proxy is niet gestart. Gelieve Kodi te herstarten."
+
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
@@ -483,6 +487,10 @@ msgstr "InputStream Adaptive configuratie…"
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
 msgstr "InputStream Helper configuratie…"
+
+msgctxt "#30888"
+msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
+msgstr "Pas de MPEG DASH Manifest aan om rond een bug in InputStream Adaptive te werken"
 
 msgctxt "#30889"
 msgid "Logging"

--- a/plugin.video.vtm.go/resources/lib/kodiutils.py
+++ b/plugin.video.vtm.go/resources/lib/kodiutils.py
@@ -398,7 +398,6 @@ def get_setting_float(key, default=None):
 
 def set_setting(key, value):
     """Set an add-on setting"""
-    # return ADDON.setSetting(key, from_unicode(str(value)))
     return ADDON.setSetting(key, from_unicode(value))
 
 

--- a/plugin.video.vtm.go/resources/lib/modules/player.py
+++ b/plugin.video.vtm.go/resources/lib/modules/player.py
@@ -140,15 +140,34 @@ class Player:
             # This allows to play some programs that don't have metadata (yet).
             pass
 
+        # If we have enabled the Manifest proxy, route the call trough that.
+        if category in ['movies', 'oneoffs', 'episodes'] and kodiutils.get_setting_bool('manifest_proxy'):
+            try:  # Python 3
+                from urllib.parse import urlencode
+            except ImportError:  # Python 2
+                from urllib import urlencode
+
+            port = kodiutils.get_setting_int('manifest_proxy_port')
+            if not port:
+                kodiutils.notification(message=kodiutils.localize(30718), icon='error')
+                kodiutils.end_of_directory()
+                return
+
+            url = 'http://127.0.0.1:{port}/manifest?{path}'.format(port=port,
+                                                                   path=urlencode({'path': resolved_stream.url}))
+        else:
+            url = resolved_stream.url
+
         license_key = self._vtm_go_stream.create_license_key(resolved_stream.license_url)
 
         # Play this item
-        kodiutils.play(resolved_stream.url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict)
+        kodiutils.play(url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict)
 
         # Wait for playback to start
         kodi_player = KodiPlayer()
-        if not kodi_player.waitForPlayBack(url=resolved_stream.url):
+        if not kodi_player.waitForPlayBack(url=url):
             # Playback didn't start
+            kodiutils.end_of_directory()
             return
 
         # Send Up Next data

--- a/plugin.video.vtm.go/resources/lib/modules/proxy.py
+++ b/plugin.video.vtm.go/resources/lib/modules/proxy.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+""" Kodi Manifest Proxy
+
+This Proxy is used to workaround an Inputstream Adaptive bug. For more info, see:
+* https://github.com/add-ons/plugin.video.vtm.go/issues/241
+* https://github.com/peak3d/inputstream.adaptive/pull/565
+* https://github.com/peak3d/inputstream.adaptive/pull/566
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+import re
+import threading
+
+import requests
+
+from resources.lib import kodiutils
+
+try:  # Python 3
+    from http.server import BaseHTTPRequestHandler
+except ImportError:  # Python 2
+    from BaseHTTPServer import BaseHTTPRequestHandler
+
+try:  # Python 3
+    from socketserver import TCPServer
+except ImportError:  # Python 2
+    from SocketServer import TCPServer
+
+try:  # Python 3
+    from urllib.parse import urlparse, parse_qs
+except ImportError:  # Python 2
+    from urlparse import urlparse, parse_qs
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Proxy(BaseHTTPRequestHandler):
+    """ Manifest Proxy to workaround a Inputstream Adaptive bug """
+    server_inst = None
+
+    @staticmethod
+    def start():
+        """ Start the Proxy. """
+
+        def start_proxy():
+            """ Start the Proxy. """
+            Proxy.server_inst = TCPServer(('127.0.0.1', 0), Proxy)
+            port = Proxy.server_inst.socket.getsockname()[1]
+            kodiutils.set_setting('manifest_proxy_port', str(port))
+            _LOGGER.debug('Listening on port %s', port)
+
+            # Start listening
+            Proxy.server_inst.serve_forever()
+
+        thread = threading.Thread(target=start_proxy)
+        thread.start()
+
+        return thread
+
+    @staticmethod
+    def stop():
+        """ Stop the Proxy. """
+        if Proxy.server_inst:
+            Proxy.server_inst.shutdown()
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        """ Handle http get requests, used for manifest. """
+        _LOGGER.debug('HTTP GET Request received for %s', self.path)
+
+        if not self.path.startswith('/manifest'):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        try:
+            # Make real request
+            params = parse_qs(urlparse(self.path).query)
+            url = params.get('path')[0]
+            _LOGGER.debug('Proxying to %s', url)
+            response = requests.get(url=url)
+
+            # Return response code
+            self.send_response(response.status_code)
+            self.end_headers()
+
+            if response.status_code == 200:
+                self.wfile.write(self.modify_manifest(response.text).encode())
+            else:
+                self.wfile.write(response.content)
+
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.exception(exc)
+            self.send_response(500)
+            self.end_headers()
+
+    @staticmethod
+    def modify_manifest(manifest):
+        """ Modify the manifest so Inputstream Adaptive can handle it. """
+
+        def repl(matchobj):
+            """ Modify an AdaptationSet. We will be removing the BaseURL and prefixing it with the URL's in all SegmentTemplates. """
+            adaptationset = matchobj.group(0)
+
+            # Only process AdaptationSets that use a SegmentTemplate
+            if '<SegmentTemplate' not in adaptationset:
+                return adaptationset
+
+            # Extract BaseURL
+            match = re.search(r'<BaseURL>(.*?)</BaseURL>', adaptationset)
+            if not match:
+                return adaptationset
+            base_url = match.group(1)
+
+            # Remove BaseURL
+            adaptationset = re.sub(r'\s*?<BaseURL>.*?</BaseURL>', '', adaptationset)
+
+            # Prefix BaseURL on initialization=" and media=" tags
+            adaptationset = re.sub(r'(<SegmentTemplate[^>]*?initialization=\")([^\"]*)(\"[^>]*?>)', r'\1' + base_url + r'\2\3', adaptationset)
+            adaptationset = re.sub(r'(<SegmentTemplate[^>]*?media=\")([^\"]*)(\"[^>]*?>)', r'\1' + base_url + r'\2\3', adaptationset)
+
+            return adaptationset
+
+        # Process all AdaptationSets
+        output = re.sub(r'<AdaptationSet[^>]*>(.*?)</AdaptationSet>', repl, manifest, flags=re.DOTALL)
+
+        return output

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -170,12 +170,12 @@ class VtmGoStream:
         """
         subtitles = list()
         if stream_info.get('video').get('subtitles'):
-            for idx, subtitle in enumerate(stream_info.get('video').get('subtitles')):
-                program = stream_info.get('video').get('metadata').get('program')
-                if program:
-                    name = '{} - {}_{}'.format(program.get('title'), stream_info.get('video').get('metadata').get('title'), idx)
-                else:
-                    name = '{}_{}'.format(stream_info.get('video').get('metadata').get('title'), idx)
+            for _, subtitle in enumerate(stream_info.get('video').get('subtitles')):
+                name = subtitle.get('language')
+                if name == 'nl':
+                    name = 'nl.default'
+                elif name == 'nl-tt':
+                    name = 'nl.T888'
                 subtitles.append(dict(name=name, url=subtitle.get('url')))
                 _LOGGER.debug('Found subtitle url %s', subtitle.get('url'))
         return subtitles
@@ -217,8 +217,7 @@ class VtmGoStream:
         _, files = kodiutils.listdir(temp_dir)
         if files:
             for item in files:
-                if kodiutils.to_unicode(item).endswith('.vtt'):
-                    kodiutils.delete(temp_dir + kodiutils.to_unicode(item))
+                kodiutils.delete(temp_dir + kodiutils.to_unicode(item))
 
         # Return if there are no subtitles available
         if not subtitles:
@@ -240,7 +239,7 @@ class VtmGoStream:
             )
 
         for subtitle in subtitles:
-            output_file = temp_dir + subtitle.get('name') + '.' + subtitle.get('url').split('.')[-1]
+            output_file = temp_dir + subtitle.get('name')
             webvtt_content = util.http_get(subtitle.get('url')).text
             webvtt_content = webvtt_timing_regex.sub(lambda match: self._delay_webvtt_timing(match, ad_breaks), webvtt_content)
             with kodiutils.open_file(output_file, 'w') as webvtt_output:

--- a/plugin.video.vtm.go/resources/settings.xml
+++ b/plugin.video.vtm.go/resources/settings.xml
@@ -53,6 +53,8 @@
         <setting label="30883" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting label="30885" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]"/>
         <setting label="30887" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)"/>
+        <setting label="30888" type="bool" id="manifest_proxy" default="true"/>
+        <setting id="manifest_proxy_port" visible="false"/>
         <setting label="30889" type="lsep"/> <!-- Logging -->
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
         <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.2 (2020-12-30)
- Add workaround for Inputstream Adaptive bug so playback works again.
- Fix subtitles.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
