### PR TITLE
[plugin.video.svtplay@krypton] 5.1.13

### DIFF
--- a/plugin.video.svtplay/README.md
+++ b/plugin.video.svtplay/README.md
@@ -1,13 +1,11 @@
 # Kodi SVT Play Addon
-[![Build Status](https://travis-ci.org/linqcan/xbmc-svtplay.svg?branch=krypton)](https://travis-ci.org/linqcan/xbmc-svtplay)
-
-![Python tests](https://github.com/nilzen/xbmc-svtplay/workflows/Python%20package/badge.svg?branch=krypton)
+![Python test suite](https://github.com/kodi-svtplay/xbmc-svtplay/workflows/Python%20test%20suite/badge.svg)
 
 With this addon you can stream content from SVT Play (svtplay.se).
 
 The plugin fetches the video URL from the SVT Play website and feeds it to the Kodi video player.
 
-It requires Kodi (XBMC) 17.0 (Krypton) to function.
+It requires Kodi (XBMC) 17.0 (Krypton) or 19 (Matrix) to function.
 
 ## Development
 

--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.12">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.13">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="2.25.0" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SVT Play
  - Add-on ID: plugin.video.svtplay
  - Version number: 5.1.13
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/nilzen/xbmc-svtplay
  
With this addon you can stream content from SVT Play (svtplay.se).

### Description of changes:


- Added support for Kodi 19 (Matrix)
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
