### PR TITLE
[plugin.video.redbull.tv@leia] 3.2.2

### DIFF
--- a/plugin.video.redbull.tv/README.md
+++ b/plugin.video.redbull.tv/README.md
@@ -32,9 +32,18 @@ content available on [Red Bull TV](https://www.redbull.com/discover).
 </table>
 
 ## Releases
+### v3.2.2 (2021-01-12)
+- A fix in the parsing using the new standard for UTC timezone (@dagwiers)
+- Improvements to the parsing and logging of these issues in the future (@dagwiers)
+- Unit tests to detect EPG issues (test for empty results) (@dagwiers)
+- Add GitHub CI workflow for testing EPG issues (@dagwiers)
+- Add python 3.9 support (@dagwiers)
+- Add descriptions to GitHub CI workflows (@dagwiers)
+- Allow installing IPTV Manager from the add-on settings (@michaelarnauts)
+
 ### v3.2.1 (2020-10-31)
 - Fix OK dialog (@dagwiers)
-- Catch missing EPG time markers (@dagpiejanssens)
+- Catch missing EPG time markers (@piejanssens)
 
 ### v3.2.0 (2020-10-29)
 - Support VOD playback from EPG via context menu (@piejanssens)

--- a/plugin.video.redbull.tv/addon.xml
+++ b/plugin.video.redbull.tv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.redbull.tv" name="Red Bull TV" version="3.2.1" provider-name="piejanssens">
+<addon id="plugin.video.redbull.tv" name="Red Bull TV" version="3.2.2" provider-name="piejanssens">
   <requires>
     <import addon="script.module.dateutil" version="2.8.0" />
     <import addon="script.module.routing" version="0.2.0" />
@@ -29,6 +29,11 @@
       <screenshot>resources/media/screenshot04.jpg</screenshot>
     </assets>
     <news>
+v3.2.2
+- Fix EPG loading
+- Support for Python 3.9
+- Allow installing IPTV Manager from the add-on settings 
+
 v3.2.1
 - Fix OK dialog
 - Catch missing EPG time markers

--- a/plugin.video.redbull.tv/resources/settings.xml
+++ b/plugin.video.redbull.tv/resources/settings.xml
@@ -3,7 +3,7 @@
   <category label="30860"> <!--Integration -->
     <setting label="30861" type="lsep"/> <!-- Integration with other add-ons -->
     <!-- IPTV Manager -->
-    <!-- setting label="30875" help="30876" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/ --> <!-- Install IPTV Manager add-on -->
+    <setting label="30875" help="30876" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/> <!-- Install IPTV Manager add-on -->
     <setting label="30877" help="30878" type="bool" id="iptv.enabled" default="true" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" />
     <setting label="30879" help="30880" type="action" action="Addon.OpenSettings(service.iptv.manager)" enable="eq(-1,true)" option="close" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(service.iptv.manager) | System.AddonIsEnabled(service.iptv.manager)" subsetting="true"/> <!-- IPTV Manager settings -->
     <setting type="text" id="iptv.channels_uri" default="plugin://plugin.video.redbull.tv/iptv/channels" visible="false"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Red Bull TV
  - Add-on ID: plugin.video.redbull.tv
  - Version number: 3.2.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.redbull.tv
  
Red Bull TV gives you front-row access to live events, the best inaction sports, new music and entertainment, and thrilling videos from world adventurers.

### Description of changes:


v3.2.2
- Fix EPG loading
- Support for Python 3.9
- Allow installing IPTV Manager from the add-on settings 

v3.2.1
- Fix OK dialog
- Catch missing EPG time markers

v3.2.0
- Support VOD playback from EPG via context menu
- Add YouTube integration (requires YouTube add-on)
- Improve channel listing
- New add-on icon

v3.1.0
- IPTV Manager support

v3.0.0
- Harder, Better, Faster, Stronger
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
