### PR TITLE
[plugin.video.retrospect] v5.2.21

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.2.20"
+        version="5.2.21"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -132,7 +132,7 @@
 
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.2.20 - Changelog - 2021-01-16[/B]
+        <news>[B]Retrospect v5.2.21 - Changelog - 2021-01-17[/B]
 
 This version of Retrospect focusses on artwork: we introduced poster artwork for channels and shows. Not all channels support them, but more will come over time.
 
@@ -159,7 +159,7 @@ There are also some channels fixes in this build: VTM and related channels  now 
 * Updated: Dumpert artwork.
 * Updated: Pathe artwork.
 * Updated: NPO Start artwork.
-
+* Fixed: Kijk.nl movies broke.
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/plugin.video.retrospect/channels/channel.sbsnl/kijknl/chn_kijknl.py
+++ b/plugin.video.retrospect/channels/channel.sbsnl/kijknl/chn_kijknl.py
@@ -509,8 +509,13 @@ class Channel(chn_class.Channel):
         items.append(search)
 
         movie_url = self.__get_api_persisted_url(
-            "programs", "b6f65688f7e1fbe22aae20816d24ca5dcea8c86c8e72d80b462a345b5b70fa41",
+            "programs", "cd8d5f074397e43ccd27b1c958d8c24264b0a92a94f3162e8281f6a2934d0391",
             variables={"programTypes": "MOVIE", "limit": 100}
+        )
+        movie_url = self.__get_api_query_url(
+            "programs(programTypes: MOVIE)",
+            "{totalResults,items{type,__typename,guid,title,description,duration,displayGenre,"
+            "imageMedia{url,label},epgDate,sources{type,file,drm},tracks{type,kind,label,file}}}"
         )
         movies_title = LanguageHelper.get_localized_string(LanguageHelper.Movies)
         movies = MediaItem("\a.: {} :.".format(movies_title), movie_url)


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->

Fixed an anoying new bug in the Kijk.nl channel.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
