### PR TITLE
[plugin.video.vrt.nu@matrix] 2.4.2+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,12 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.4.3 (2021-01-22)
+- Add new channel "Podium 19" (@dagwieers)
+- Add livestream cache to speed up playback (@mediaminister)
+- Use InputStream Adaptive to play HLS (@mediaminister)
+- Don't log credentials in the Kodi debug log (@michaelarnauts)
+
 ### v2.4.2 (2020-12-18)
 - Fix missing seasons (for 'Thuis') in TV Show menu (@mediaminister)
 - Fix missing favourite programs in 'My programs' menu (@mediaminister)
@@ -73,7 +79,7 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 - Get categories from online JSON (@mediaminister)
 - Improvements to connection error handling (@dagwieers)
 - Improvements to virtual subclip support (@mediaminister)
-- Extend soon offline menu to seven days (@mediaminster)
+- Extend soon offline menu to seven days (@mediaminister)
 - Improve Up Next support (@mediaminister)
 
 ### v2.4.0 (2020-07-18)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -42,6 +42,12 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.4.3 (2021-01-21)
+- Add new channel "Podium 19"
+- Add livestream cache to speed up playback
+- Use InputStream Adaptive to play HLS
+- Don't log credentials in the Kodi debug log
+
 v2.4.2 (2020-12-18)
 - Fix missing seasons (for 'Thuis') in TV Show menu
 - Fix missing favourite programs in 'My programs' menuu

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -105,6 +105,14 @@ CHANNELS = [
         vod=True,
     ),
     dict(
+        id='',
+        name='podium19',
+        label='Podium 19',
+        studio='Podium 19',
+        logo='https://images.vrt.be/orig/2020/12/19/53f5fa6f-4223-11eb-aae0-02b7b76bf47f.png',
+        vod=True,
+    ),
+    dict(
         id='12',
         name='sporza',
         label='Sporza',

--- a/plugin.video.vrt.nu/resources/lib/iptvmanager.py
+++ b/plugin.video.vrt.nu/resources/lib/iptvmanager.py
@@ -4,8 +4,6 @@
 """Implementation of IPTVManager class"""
 
 from __future__ import absolute_import, division, unicode_literals
-
-from data import CHANNELS
 from kodiutils import log, url_for
 
 
@@ -36,6 +34,7 @@ class IPTVManager:
     @via_socket
     def send_channels():  # pylint: disable=no-method-argument
         """Return JSON-M3U formatted information to IPTV Manager"""
+        from data import CHANNELS
         streams = []
         for channel in CHANNELS:
             if not channel.get('live_stream_id'):

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -239,7 +239,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
            we can work around this problem by automatically seeking to the beginning of the program.
         """
         playing_file = self.getPlayingFile()
-        if '?t=' in playing_file:
+        if any(param in playing_file for param in ('?t=', '&t=')):
             try:  # Python 3
                 from urllib.parse import parse_qs, urlsplit
             except ImportError:  # Python 2


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.4.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
