### PR TITLE
[plugin.video.vrt.nu@matrix] 2.4.4+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.4.4 (2021-01-25)
+- Fix watching VRT NU abroad (@mediaminister)
+
 ### v2.4.3 (2021-01-22)
 - Add new channel "Podium 19" (@dagwieers)
 - Add livestream cache to speed up playback (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.3+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.4+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.4.4 (2021-01-25)
+- Fix watching VRT NU abroad
+
 v2.4.3 (2021-01-21)
 - Add new channel "Podium 19"
 - Add livestream cache to speed up playback

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -149,7 +149,7 @@ class StreamService:
             return None
 
         # Try cache for livestreams
-        if api_data.is_live_stream:
+        if api_data.is_live_stream and not roaming:
             filename = api_data.video_id + '.json'
             data = get_cache(filename)
             if data:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.4.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.4.4 (2021-01-25)
- Fix watching VRT NU abroad

v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
