### PR TITLE
[plugin.video.nasa@matrix] 3.0.1+matrix.1

### DIFF
--- a/plugin.video.nasa/addon.xml
+++ b/plugin.video.nasa/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nasa" name="Nasa" provider-name="Tristan Fischer (sphere@dersphere.de), enen92" version="3.0.0+matrix.1">
+<addon id="plugin.video.nasa" name="Nasa" provider-name="Tristan Fischer (sphere@dersphere.de), enen92" version="3.0.1+matrix.1">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.xbmcswift2" version="2.5.0" />
@@ -14,10 +14,8 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=123001</forum>
     <license>GPL-2.0-only</license>
     <news>
-      3.0.0 (12.04.2020)
-        - Automatic submissions to matrix
-        - Adjust language files
-        - Addon.xml fixes
+      3.0.1 (25.01.2021)
+        - Use tubed instead of youtube for matrix
     </news>
     <summary lang="af_ZA">Video plugin om toegang na nasa.gov te bekom</summary>
     <summary lang="ar_SA">ملحق يساعدك للوصول الى المقاطع المرئيه من موقع ناسا nasa.gov</summary>

--- a/plugin.video.nasa/resources/lib/plugin.py
+++ b/plugin.video.nasa/resources/lib/plugin.py
@@ -20,8 +20,8 @@
 import os
 from xbmcswift2 import Plugin
 
-YOUTUBE_URL = 'plugin://plugin.video.youtube/channel/%s/?page=1'
-YOUTUBE_VIDEO_URL = 'plugin://plugin.video.youtube/play/?video_id=%s'
+YOUTUBE_URL = 'plugin://plugin.video.tubed/?channel_id=%s&mode=channel'
+YOUTUBE_VIDEO_URL = 'plugin://plugin.video.tubed/?mode=play&video_id=%s'
 
 plugin = Plugin()
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Nasa
  - Add-on ID: plugin.video.nasa
  - Version number: 3.0.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.video.nasa
  
This video plugin provides access to more than 1800 videos, 8 vodcasts and 4 nasa-tv livestreams[CR]All content is dynamic and should be always up to date.

### Description of changes:


      3.0.1 (25.01.2021)
        - Use tubed instead of youtube for matrix
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
