### PR TITLE
[plugin.video.nhlgcl@jarvis] 2021.1.25

### DIFF
--- a/plugin.video.nhlgcl/addon.xml
+++ b/plugin.video.nhlgcl/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2021.1.21" provider-name="eracknaphobia">
+<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2021.1.25" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.24.0"/>
         <import addon="script.module.pytz" />
@@ -20,9 +20,8 @@
             restrictions apply, including national blackouts.
         </disclaimer>
         <news>
-            - Update code for python 3 compatibility
-            - Fix for too many sign-ins error
-            - Code Cleanup
+            - Fix Fav team montreal
+            - Fix watch from beginning dialog on archive
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.nhlgcl/resources/lib/globals.py
+++ b/plugin.video.nhlgcl/resources/lib/globals.py
@@ -36,7 +36,7 @@ PASSWORD = settings.getSetting("password")
 ROGERS_SUBSCRIBER = settings.getSetting("rogers")
 NO_SPOILERS = settings.getSetting("no_spoilers")
 QUALITY = settings.getSetting("stream_quality")
-FAV_TEAM = settings.getSetting("fav_team")
+FAV_TEAM = settings.getSetting("fav_team").encode('utf8')
 TEAM_NAMES = settings.getSetting("team_names")
 TIME_FORMAT = settings.getSetting("time_format")
 VIEW_MODE = settings.getSetting("view_mode")
@@ -592,7 +592,7 @@ def natural_sort_key(s):
 
 
 # Refresh Fav team info if fav team changed
-if FAV_TEAM != str(settings.getSetting("fav_team_name")):
+if FAV_TEAM != settings.getSetting("fav_team_name").encode('utf8'):
     if FAV_TEAM == 'None':
         settings.setSetting(id="fav_team_name", value='')
         settings.setSetting(id="fav_team_id", value='')

--- a/plugin.video.nhlgcl/resources/lib/nhl_tv.py
+++ b/plugin.video.nhlgcl/resources/lib/nhl_tv.py
@@ -5,8 +5,8 @@ def categories():
     add_dir(LOCAL_STRING(30360), '/live', 100, ICON, FANART)
     add_dir(LOCAL_STRING(30361), '/live', 105, ICON, FANART)
     if FAV_TEAM != 'None' and FAV_TEAM != '':
-        add_fav_today(FAV_TEAM + LOCAL_STRING(30362), FAV_TEAM_LOGO, FANART)
-        add_dir(FAV_TEAM + LOCAL_STRING(30363), 'favteam', 500, FAV_TEAM_LOGO, FANART)
+        add_fav_today(FAV_TEAM + LOCAL_STRING(30362).encode('utf8'), FAV_TEAM_LOGO, FANART)
+        add_dir(FAV_TEAM + LOCAL_STRING(30363).encode('utf8'), 'favteam', 500, FAV_TEAM_LOGO, FANART)
     add_dir(LOCAL_STRING(30364), '/date', 200, ICON, FANART)
     add_dir(LOCAL_STRING(30365), '/qp', 300, ICON, FANART)
 
@@ -241,7 +241,7 @@ def stream_select(game_id, start_time):
         sys.exit()
     else:
         start_from_beginning = -1
-        if start_time is not None:
+        if start_time is not None and 'archive' not in media_state[0].lower().strip():
             dialog = xbmcgui.Dialog()
             start_from_beginning = dialog.select("Choose Start", ['Watch Live', 'Start from Beginning'])
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NHL TV™
  - Add-on ID: plugin.video.nhlgcl
  - Version number: 2021.1.25
  - Kodi/repository version: jarvis

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nhlgcl
  
With NHL.TV you can access revolutionary 60fps (frames per second) video through Kodi
        

### Description of changes:


            - Fix Fav team montreal
            - Fix watch from beginning dialog on archive
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
