### PR TITLE
[plugin.video.streamz@matrix] 1.0.5+matrix.1

### DIFF
--- a/plugin.video.streamz/CHANGELOG.md
+++ b/plugin.video.streamz/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.0.5](https://github.com/add-ons/plugin.video.streamz/tree/v1.0.5) (2021-02-04)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.0.4...v1.0.5)
+
+**Implemented enhancements:**
+
+- Indicate what movies or series are not available in your subscription [\#35](https://github.com/add-ons/plugin.video.streamz/pull/35) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Make use of git archive [\#34](https://github.com/add-ons/plugin.video.streamz/pull/34) ([dagwieers](https://github.com/dagwieers))
+
 ## [v1.0.4](https://github.com/add-ons/plugin.video.streamz/tree/v1.0.4) (2021-01-13)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.0.3...v1.0.4)

--- a/plugin.video.streamz/README.md
+++ b/plugin.video.streamz/README.md
@@ -8,7 +8,7 @@
 
 *plugin.video.streamz* is een Kodi add-on om naar de catalogus van Streamz te kijken. 
 
-> Note: Je hebt hiervoor een betalend abonnement nodig van [Streamz](https://www.streamz.be/), of een Play, Play More of Yugo abbonement bij Telenet.
+> Note: Je hebt hiervoor een betalend abonnement nodig van [Streamz](https://www.streamz.be/), of een Play, Play More of Yugo abonnement bij Telenet.
 
 Meer informatie kan je vinden op de [Wiki pagina](https://github.com/add-ons/plugin.video.streamz/wiki).
 

--- a/plugin.video.streamz/addon.xml
+++ b/plugin.video.streamz/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.streamz" name="Streamz" version="1.0.4+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.streamz" name="Streamz" version="1.0.5+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,9 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door Streamz BV, en wordt aangeboden 'as is', zonder enige garantie. De Streamz naam en Streamz logo zijn eigendom van Streamz BV en worden gebruikt in overeenstemming met de 'fair use' regels.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.0.4 (2021-01-13)
-- Fix encoding issue in Kodi Matrix.
-- Add HTTP Proxy support.</news>
+	<news>v1.0.5 (2021-02-04)
+- Indicate content that isn't available when you don't have a Streamz+ subscription.</news>
         <source>https://github.com/add-ons/plugin.video.streamz</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.streamz/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.streamz/resources/language/resource.language.en_gb/strings.po
@@ -114,6 +114,10 @@ msgctxt "#30205"
 msgid "Season {season}"
 msgstr ""
 
+msgctxt "#30206"
+msgid "[COLOR red]Available in Streamz+[/COLOR]\n"
+msgstr ""
+
 msgctxt "#30207"
 msgid "[COLOR red]Geo-blocked[/COLOR]\n"
 msgstr ""
@@ -159,10 +163,6 @@ msgstr ""
 
 msgctxt "#30708"
 msgid "Please restart Kodi."
-msgstr ""
-
-msgctxt "#30710"
-msgid "This video is geo-blocked and can't be played from your location."
 msgstr ""
 
 msgctxt "#30712"
@@ -245,6 +245,10 @@ msgstr ""
 
 msgctxt "#30823"
 msgid "Show My List"
+msgstr ""
+
+msgctxt "#30825"
+msgid "Show unavailable movies and series (Streamz+)"
 msgstr ""
 
 msgctxt "#30826"

--- a/plugin.video.streamz/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.streamz/resources/language/resource.language.nl_nl/strings.po
@@ -115,6 +115,10 @@ msgctxt "#30205"
 msgid "Season {season}"
 msgstr "Seizoen {season}"
 
+msgctxt "#30206"
+msgid "[COLOR red]Available in Streamz+[/COLOR]\n"
+msgstr "[COLOR red]Beschikbaar in Streamz+[/COLOR]\n"
+
 msgctxt "#30207"
 msgid "[COLOR red]Geo-blocked[/COLOR]\n"
 msgstr "[COLOR red]Geo-geblokkeerd[/COLOR]\n"
@@ -161,10 +165,6 @@ msgstr "Uw account heeft geen profielen. Gelieve in te loggen op www.streamz.be 
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
-
-msgctxt "#30710"
-msgid "This video is geo-blocked and can't be played from your location."
-msgstr "Deze video is geografisch geblokkeerd en kan niet worden afgespeeld vanaf uw locatie."
 
 msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
@@ -247,6 +247,10 @@ msgstr "Toon 'A-Z' menu"
 msgctxt "#30823"
 msgid "Show My List"
 msgstr "Toon 'Mijn lijst' menu"
+
+msgctxt "#30825"
+msgid "Show unavailable movies and series (Streamz+)"
+msgstr "Toon onbeschikbare films en series (Streamz+)"
 
 msgctxt "#30826"
 msgid "Show Continue watching"

--- a/plugin.video.streamz/resources/lib/modules/catalog.py
+++ b/plugin.video.streamz/resources/lib/modules/catalog.py
@@ -51,10 +51,12 @@ class Catalog:
         :type category: str
         """
         items = self._api.get_items(category)
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
 
         listing = []
         for item in items:
-            listing.append(Menu.generate_titleitem(item))
+            if show_unavailable or item.available:
+                listing.append(Menu.generate_titleitem(item))
 
         # Sort items by label, but don't put folders at the top.
         # Used for A-Z listing or when movies and episodes are mixed.
@@ -153,6 +155,7 @@ class Catalog:
         :type storefront: str
         """
         results = self._api.get_storefront(storefront)
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
 
         listing = []
         for item in results:
@@ -165,7 +168,8 @@ class Catalog:
                     ),
                 ))
             else:
-                listing.append(Menu.generate_titleitem(item))
+                if show_unavailable or item.available:
+                    listing.append(Menu.generate_titleitem(item))
 
         if storefront == STOREFRONT_SERIES:
             label = 30005  # Series
@@ -183,10 +187,12 @@ class Catalog:
         :type category: str
         """
         result = self._api.get_storefront_category(storefront, category)
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
 
         listing = []
         for item in result.content:
-            listing.append(Menu.generate_titleitem(item))
+            if show_unavailable or item.available:
+                listing.append(Menu.generate_titleitem(item))
 
         if storefront == STOREFRONT_SERIES:
             content = 'tvshows'

--- a/plugin.video.streamz/resources/lib/modules/library.py
+++ b/plugin.video.streamz/resources/lib/modules/library.py
@@ -42,12 +42,15 @@ class Library:
         else:
             items = [self._api.get_movie(movie)]
 
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
+
         listing = []
         for item in items:
-            title_item = Menu.generate_titleitem(item)
-            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)  # We need a trailing /
-            title_item.path = 'plugin://plugin.video.streamz/library/movies/?movie=%s' % item.movie_id
-            listing.append(title_item)
+            if show_unavailable or item.available:
+                title_item = Menu.generate_titleitem(item)
+                # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)  # We need a trailing /
+                title_item.path = 'plugin://plugin.video.streamz/library/movies/?movie=%s' % item.movie_id
+                listing.append(title_item)
 
         kodiutils.show_listing(listing, 30003, content='movies', sort=['label', 'year', 'duration'])
 
@@ -68,12 +71,15 @@ class Library:
             # Fetch only a single program
             items = [self._api.get_program(program, cache=CACHE_PREVENT)]
 
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
+
         listing = []
         for item in items:
-            title_item = Menu.generate_titleitem(item)
-            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id)  # We need a trailing /
-            title_item.path = 'plugin://plugin.video.streamz/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
-            listing.append(title_item)
+            if show_unavailable or item.available:
+                title_item = Menu.generate_titleitem(item)
+                # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id)  # We need a trailing /
+                title_item.path = 'plugin://plugin.video.streamz/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
+                listing.append(title_item)
 
         kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label', 'year', 'duration'])
 

--- a/plugin.video.streamz/resources/lib/modules/menu.py
+++ b/plugin.video.streamz/resources/lib/modules/menu.py
@@ -167,6 +167,11 @@ class Menu:
         """
         plot = ''
 
+        # Add geo-blocked message
+        if hasattr(obj, 'available') and not obj.available:
+            plot += kodiutils.localize(30206)  # Available in Streamz+
+            plot += '\n'
+
         # Add remaining
         if hasattr(obj, 'remaining') and obj.remaining is not None:
             if obj.remaining == 0:
@@ -247,8 +252,16 @@ class Menu:
                 'width': 1920,
             }
 
+            if item.available:
+                title = item.name
+            else:
+                title = item.name + ' [COLOR=red](S+)[/COLOR]'
+                info_dict.update({
+                    'title': title,
+                })
+
             return TitleItem(
-                title=item.name,
+                title=title,
                 path=kodiutils.url_for('play', category='movies', item=item.movie_id),
                 art_dict=art_dict,
                 info_dict=info_dict,

--- a/plugin.video.streamz/resources/lib/modules/player.py
+++ b/plugin.video.streamz/resources/lib/modules/player.py
@@ -9,7 +9,7 @@ from resources.lib import kodiutils
 from resources.lib.kodiplayer import KodiPlayer
 from resources.lib.streamz.api import Api
 from resources.lib.streamz.auth import Auth
-from resources.lib.streamz.exceptions import LimitReachedException, StreamGeoblockedException, StreamUnavailableException, UnavailableException
+from resources.lib.streamz.exceptions import LimitReachedException, UnavailableException
 from resources.lib.streamz.stream import Stream
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,12 +43,7 @@ class Player:
             # Get stream information
             resolved_stream = self._stream.get_stream(category, item)
 
-        except StreamGeoblockedException:
-            kodiutils.ok_dialog(message=kodiutils.localize(30710))  # This video is geo-blocked...
-            kodiutils.end_of_directory()
-            return
-
-        except StreamUnavailableException:
+        except UnavailableException:
             kodiutils.ok_dialog(message=kodiutils.localize(30712))  # The video is unavailable...
             kodiutils.end_of_directory()
             return

--- a/plugin.video.streamz/resources/lib/modules/search.py
+++ b/plugin.video.streamz/resources/lib/modules/search.py
@@ -46,9 +46,11 @@ class Search:
             return
 
         # Display results
+        show_unavailable = kodiutils.get_setting_bool('interface_show_unavailable')
         listing = []
         for item in items:
-            listing.append(Menu.generate_titleitem(item))
+            if show_unavailable or item.available:
+                listing.append(Menu.generate_titleitem(item))
 
         # Sort like we get our results back.
         kodiutils.show_listing(listing, 30009, content='tvshows')

--- a/plugin.video.streamz/resources/lib/streamz/__init__.py
+++ b/plugin.video.streamz/resources/lib/streamz/__init__.py
@@ -59,7 +59,7 @@ class Movie:
     """ Defines a Movie """
 
     def __init__(self, movie_id=None, name=None, description=None, year=None, cover=None, image=None, duration=None,
-                 remaining=None, geoblocked=None, channel=None, legal=None, aired=None, my_list=None):
+                 remaining=None, geoblocked=None, channel=None, legal=None, aired=None, my_list=None, available=True):
         """
         :type movie_id: str
         :type name: str
@@ -74,6 +74,7 @@ class Movie:
         :type legal: str
         :type aired: str
         :type my_list: bool
+        :type available: bool
         """
         self.movie_id = movie_id
         self.name = name
@@ -88,6 +89,7 @@ class Movie:
         self.legal = legal
         self.aired = aired
         self.my_list = my_list
+        self.available = available
 
     def __repr__(self):
         return "%r" % self.__dict__
@@ -97,7 +99,7 @@ class Program:
     """ Defines a Program """
 
     def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
-                 geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None):
+                 geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None, available=True):
         """
         :type program_id: str
         :type name: str
@@ -110,6 +112,7 @@ class Program:
         :type legal: str
         :type my_list: bool
         :type content_hash: str
+        :type available: bool
         """
         self.program_id = program_id
         self.name = name
@@ -122,6 +125,7 @@ class Program:
         self.legal = legal
         self.my_list = my_list
         self.content_hash = content_hash
+        self.available = available
 
     def __repr__(self):
         return "%r" % self.__dict__
@@ -155,7 +159,7 @@ class Episode:
 
     def __init__(self, episode_id=None, program_id=None, program_name=None, number=None, season=None, name=None,
                  description=None, cover=None, duration=None, remaining=None, geoblocked=None, channel=None, legal=None,
-                 aired=None, progress=None, watched=False, next_episode=None):
+                 aired=None, progress=None, watched=False, next_episode=None, available=True):
         """
         :type episode_id: str
         :type program_id: str
@@ -174,6 +178,7 @@ class Episode:
         :type progress: int
         :type watched: bool
         :type next_episode: Episode
+        :type available: bool
         """
         import re
         self.episode_id = episode_id
@@ -196,6 +201,7 @@ class Episode:
         self.progress = progress
         self.watched = watched
         self.next_episode = next_episode
+        self.available = available
 
     def __repr__(self):
         return "%r" % self.__dict__

--- a/plugin.video.streamz/resources/lib/streamz/api.py
+++ b/plugin.video.streamz/resources/lib/streamz/api.py
@@ -232,6 +232,7 @@ class Api:
             # aired=movie.get('broadcastTimestamp'),
             channel=self._parse_channel(movie.get('channelLogoUrl')),
             # my_list=program.get('addedToMyList'),  # Don't use addedToMyList, since we might have cached this info
+            available=movie.get('blockedFor') != 'SUBSCRIPTION',
         )
 
     def get_program(self, program_id, cache=CACHE_AUTO):
@@ -286,6 +287,7 @@ class Api:
                     aired=item_episode.get('broadcastTimestamp'),
                     progress=item_episode.get('playerPositionSeconds', 0),
                     watched=item_episode.get('doneWatching', False),
+                    available=item_episode.get('blockedFor') != 'SUBSCRIPTION',
                 )
                 program_hash.update(item_episode.get('id').encode())
 
@@ -311,6 +313,7 @@ class Api:
             legal=program.get('legalIcons'),
             content_hash=program_hash.hexdigest().upper(),
             # my_list=program.get('addedToMyList'),  # Don't use addedToMyList, since we might have cached this info
+            available=program.get('blockedFor') != 'SUBSCRIPTION',
         )
 
     @staticmethod
@@ -453,6 +456,7 @@ class Api:
             # We might have a cover from the overview that we don't have in the details
             if item.get('imageUrl'):
                 movie.cover = item.get('imageUrl')
+            movie.available = item.get('blockedFor') != 'SUBSCRIPTION'
             return movie
 
         return Movie(
@@ -461,6 +465,7 @@ class Api:
             cover=item.get('imageUrl'),
             image=item.get('imageUrl'),
             geoblocked=item.get('geoBlocked'),
+            available=item.get('blockedFor') != 'SUBSCRIPTION',
         )
 
     def _parse_program_teaser(self, item, cache=CACHE_ONLY):
@@ -474,6 +479,7 @@ class Api:
             # We might have a cover from the overview that we don't have in the details
             if item.get('imageUrl'):
                 program.cover = item.get('imageUrl')
+            program.available = item.get('blockedFor') != 'SUBSCRIPTION'
             return program
 
         return Program(
@@ -482,6 +488,7 @@ class Api:
             cover=item.get('imageUrl'),
             image=item.get('imageUrl'),
             geoblocked=item.get('geoBlocked'),
+            available=item.get('blockedFor') != 'SUBSCRIPTION',
         )
 
     def _parse_episode_teaser(self, item, cache=CACHE_ONLY):

--- a/plugin.video.streamz/resources/lib/streamz/exceptions.py
+++ b/plugin.video.streamz/resources/lib/streamz/exceptions.py
@@ -36,13 +36,5 @@ class UnavailableException(Exception):
     """ Is thrown when an item is unavailable. """
 
 
-class StreamGeoblockedException(Exception):
-    """ Is thrown when a geoblocked item is played. """
-
-
-class StreamUnavailableException(Exception):
-    """ Is thrown when an unavailable item is played. """
-
-
 class LimitReachedException(Exception):
     """ Is thrown when the limit is reached to play an stream. """

--- a/plugin.video.streamz/resources/settings.xml
+++ b/plugin.video.streamz/resources/settings.xml
@@ -16,6 +16,7 @@
         <setting label="30822" type="bool" id="interface_show_az" default="false"/>
         <setting label="30823" type="bool" id="interface_show_mylist" default="true"/>
         <setting label="30826" type="bool" id="interface_show_continuewatching" default="false" visible="false"/>
+        <setting label="30825" type="bool" id="interface_show_unavailable" default="true"/>
         <setting label="30827" type="lsep"/> <!-- Metadata -->
         <setting label="30829" type="bool" id="metadata_update" default="true" subsetting="true"/>
         <setting label="30831" type="action" action="RunPlugin(plugin://plugin.video.streamz/metadata/update)"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Streamz
  - Add-on ID: plugin.video.streamz
  - Version number: 1.0.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.streamz
  
Streamz is a video-on-demand platform offering Flemish content from DPG Media, Telenet and VRT, but also including 'Home of HBO' content and blockbuster movies.

### Description of changes:

v1.0.5 (2021-02-04)
- Indicate content that isn't available when you don't have a Streamz+ subscription.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
