### PR TITLE
[plugin.video.vrt.nu@matrix] 2.4.5+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,10 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.4.5 (2021-02-05)
+- Fix watching livestreams with DRM enabled (@mediaminister)
+- Warn user that InputStream Adaptive is needed for timeshifting (@siemon-geeroms)
+
 ### v2.4.4 (2021-01-25)
 - Fix watching VRT NU abroad (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.4+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.4.5+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,10 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.4.5 (2021-02-05)
+- Fix watching livestreams with DRM enabled
+- Warn user that InputStream Adaptive is needed for timeshifting
+
 v2.4.4 (2021-01-25)
 - Fix watching VRT NU abroad
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -1042,3 +1042,7 @@ msgstr ""
 msgctxt "#30987"
 msgid "No stream found, please try again!"
 msgstr ""
+
+msgctxt "#30988"
+msgid "InputStream Adaptive is not installed, therefore pause and timeshift of live streams may not work"
+msgstr ""

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -1042,3 +1042,7 @@ msgstr "Geen on demand stream beschikbaar voor {title}."
 msgctxt "#30987"
 msgid "No stream found, please try again!"
 msgstr "Geen stream gevonden, gelieve opnieuw te proberen!"
+
+msgctxt "#30988"
+msgid "InputStream Adaptive is not available, therefore pause and timeshift of live streams may not work"
+msgstr "InputStream Adaptive is niet geïnstalleerd, daarom kan het pauzeren en timeshift van live tv niet werken"

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -8,8 +8,9 @@ from favorites import Favorites
 from helperobjects import TitleItem
 from kodiutils import (colour, delete_cached_thumbnail, end_of_directory, get_addon_info,
                        get_setting, get_setting_bool, get_setting_int, has_credentials,
-                       localize, log_error, ok_dialog, play, set_setting, show_listing,
-                       ttl, url_for, wait_for_resumepoints)
+                       has_inputstream_adaptive, localize, kodi_version_major, log_error,
+                       ok_dialog, play, set_setting, show_listing, ttl, url_for,
+                       wait_for_resumepoints)
 from resumepoints import ResumePoints
 from utils import find_entry, realpage
 
@@ -93,6 +94,10 @@ class VRTPlayer:
                 # 2.2.1 version: moved tokens: delete old tokens
                 from tokenresolver import TokenResolver
                 TokenResolver().delete_tokens()
+
+            # Make user aware that timeshift functionality will not work without ISA when user starts up the first time
+            if settings_version == '' and kodi_version_major() > 17 and not has_inputstream_adaptive():
+                ok_dialog(message=localize(30988))
 
     @staticmethod
     def _first_run():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.4.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.4.5 (2021-02-05)
- Fix watching livestreams with DRM enabled
- Warn user that InputStream Adaptive is needed for timeshifting

v2.4.4 (2021-01-25)
- Fix watching VRT NU abroad

v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
