### PR TITLE
[plugin.whereareyou] 0.4.1

### DIFF
--- a/plugin.whereareyou/addon.xml
+++ b/plugin.whereareyou/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.4.0">
+<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.4.1">
 	<requires>
 		<import addon="xbmc.python" version="2.26.0" />
 		<import addon="script.module.kodi-six" version="0.0.3" />
@@ -10,9 +10,8 @@
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<news>
-v.0.4.0
-- added ability to open external apps using Harmony Hub
-- fix for looping dialog box if called from home window
+v.0.4.1
+- fix for "no next item in playlist" error
 		</news>
 		<assets>
 			<icon>icon.png</icon>

--- a/plugin.whereareyou/changelog.txt
+++ b/plugin.whereareyou/changelog.txt
@@ -1,0 +1,22 @@
+v.0.4.1
+- fix for "no next item in playlist" error
+
+v.0.4.0
+- added ability to open external apps using Harmony Hub
+- fix for looping dialog box if called from home window
+
+v.0.2.1
+- version bump for resubmission to repo-plugins
+
+v.0.2.0
+- changes in logging to accomodate new logging requirements for Kodi 19
+- re-organized code so it can be submitted to the Kodi repo
+
+v.0.1.0
+- Python 2/3 compatibility
+
+v.0.0.2
+- updated readme and icon
+
+v.0.0.1
+- initial release

--- a/plugin.whereareyou/resources/lib/whereareyou.py
+++ b/plugin.whereareyou/resources/lib/whereareyou.py
@@ -1,4 +1,4 @@
-from kodi_six import xbmc, xbmcgui
+from kodi_six import xbmc, xbmcgui, xbmcplugin
 from kodi_six.utils import py2_decode
 import json, os, sys
 from resources.lib.waysettings import loadSettings
@@ -54,7 +54,10 @@ class Main:
                 self._run_activity( activity, cmds )
         else:
             self.DIALOG.ok( self.TITLE, self.MESSAGE )
-        xbmc.Player().play( os.path.join( self.SETTINGS['ADDONPATH'], 'resources', 'blank.mp4' ) )
+        pluginhandle = int( sys.argv[1] )
+        xbmcplugin.setContent(pluginhandle, 'files')
+        play_item = xbmcgui.ListItem( path=os.path.join( self.SETTINGS['ADDONPATH'], 'resources', 'blank.mp4' ) )
+        xbmcplugin.setResolvedUrl( pluginhandle, True, listitem=play_item )
 
 
     def _init_vars( self ):


### PR DESCRIPTION
### Description
v.0.4.1
- fix for "no next item in playlist" error
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
