### PR TITLE
[plugin.video.rtpplay@matrix] 5.0.11+matrix.1

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.10+matrix.1" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.11+matrix.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -23,7 +23,7 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Move xbmc.translatepath to xbmcvfs.translatepath
+            - Fix streams
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/lib/channels.py
+++ b/plugin.video.rtpplay/resources/lib/channels.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.61 Mobile Safari/537.36",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.146 Safari/537.36",
     "Referer": "https://www.rtp.pt/",
 }
 

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -305,7 +305,7 @@ def programs_episodes():
     for a in soup.find_all('a'):
         url = a.get('href')
         if a.find('script') != None:
-            match = re.search(r'\'(.+?)\'', a.find('script').text)
+            match = re.search(r'\'(.+?)\'', str(a.find('script')))
             if len(match.groups()) > 0:
                 img = match.group(1)
         metas = a.find_next_sibling('i').find_all('meta')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.11+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            - Fix streams
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
