### PR TITLE
[plugin.video.rtpplay@matrix] 5.0.12+matrix.1

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.11+matrix.1" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.12+matrix.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -23,7 +23,8 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            - Fix streams
+            Version 5.0.12 (11/2/2021)
+                - Fix EPG on Live listings
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
@@ -59,3 +59,7 @@ msgstr ""
 msgctxt "#32010"
 msgid "#EstudoEmCasa"
 msgstr ""
+
+msgctxt "#32011"
+msgid "Not Available"
+msgstr ""

--- a/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
@@ -59,3 +59,7 @@ msgstr "Página"
 msgctxt "#32010"
 msgid "#EstudoEmCasa"
 msgstr "#EstudoEmCasa"
+
+msgctxt "#32011"
+msgid "Not Available"
+msgstr "Indisponível"

--- a/plugin.video.rtpplay/resources/lib/plugin.py
+++ b/plugin.video.rtpplay/resources/lib/plugin.py
@@ -102,10 +102,10 @@ def live():
     except:
         raise_notification()
 
-    match = re.compile(r'<a title=".+? - (.+?)" href="/play/direto/(.+?)".*?\n.*?\n.*?<img alt=".+?" src ="(.+?)".*?\n.*?\n.*?width:(.+?)%').findall(req)
+    match = re.compile(r'<a.+?title=".+? - (.+?)" href="/play/direto/(.+?)".*?\n.*?\n.*?<img alt=".+?" src="(.+?)".*?\n.*?\n.*?width:(.+?)%').findall(req)
 
     for rtp_channel in RTP_CHANNELS:
-        dvr = "Not available"
+        dvr = kodiutils.get_string(32011)
         progimg = ""
         progpercent = 0
         for prog, key, img, percent in match:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.12+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 5.0.12 (11/2/2021)
                - Fix EPG on Live listings
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
