### PR TITLE
[plugin.video.zattoobox] v1.0.8

### DIFF
--- a/plugin.video.zattoobox/addon.xml
+++ b/plugin.video.zattoobox/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.zattoobox"
-       version="1.0.7"
+       version="1.0.8"
        name="Zattoo Box"
        provider-name="Pascal Nançoz">
   <requires>

--- a/plugin.video.zattoobox/changelog.txt
+++ b/plugin.video.zattoobox/changelog.txt
@@ -1,3 +1,6 @@
+[B]1.0.8[/B]
+- [Fix] The plugin stopped working due to provider changes (hls5). Fixed.
+
 [B]1.0.7[/B]
 - [Fix] The plugin stopped working due to provider changes. Fixed.
 

--- a/plugin.video.zattoobox/plugin.py
+++ b/plugin.video.zattoobox/plugin.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 
 ##################################
-# ZattooBox v1.0.6
+# ZattooBox v1.0.8
 # Kodi Addon for Zattoo
-# (c) 2014-2020 Pascal Nançoz
+# (c) 2014-2021 Pascal Nançoz
 # nancpasc@gmail.com
 ##################################
 

--- a/plugin.video.zattoobox/resources/lib/extensions/livetv.py
+++ b/plugin.video.zattoobox/resources/lib/extensions/livetv.py
@@ -62,7 +62,7 @@ class LiveTV(ZBExtension):
 		self.ZBProxy.add_directoryItems(items)
 
 	def watch(self, args):
-		params = {'cid': args['id'], 'stream_type': 'hls'}
+		params = {'cid': args['id'], 'stream_type': 'hls5'}
 		resultData = self.ZapiSession.exec_zapiCall('/zapi/watch', params)
 		if resultData is not None:
 			url = resultData['stream']['watch_urls'][0]['url']

--- a/plugin.video.zattoobox/resources/lib/extensions/recordings.py
+++ b/plugin.video.zattoobox/resources/lib/extensions/recordings.py
@@ -53,7 +53,7 @@ class Recordings(ZBExtension):
 		self.ZBProxy.add_directoryItems(recordings)
 
 	def watch(self, args):
-		params = {'recording_id': args['id'], 'stream_type': 'hls'}
+		params = {'recording_id': args['id'], 'stream_type': 'hls5'}
 		resultData = self.ZapiSession.exec_zapiCall('/zapi/watch', params)
 		if resultData is not None:
 			url = resultData['stream']['url']


### PR DESCRIPTION
### Description
Updated stream format to hls5.
This is a mandatory adjustment to keep the addon working.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
