### PR TITLE
[plugin.video.rtpplay@matrix] 5.0.14+matrix.1

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.13+matrix.1" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.14+matrix.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -23,8 +23,8 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            Version 5.0.13
-                - Fix live and ondemand
+            Version 5.0.14
+                - Minor version fix (py2)
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/lib/kodiutils.py
+++ b/plugin.video.rtpplay/resources/lib/kodiutils.py
@@ -24,16 +24,18 @@ else:
 
 # read settings
 ADDON = xbmcaddon.Addon()
-PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
-TEMP = os.path.join(PROFILE, 'temp', '')
+
 
 if PY3:
     ICON = xbmcvfs.translatePath(ADDON.getAddonInfo("icon"))
     FANART = xbmcvfs.translatePath(ADDON.getAddonInfo("fanart"))
+    PROFILE = xbmcvfs.translatePath(ADDON.getAddonInfo('profile'))
 else:
     ICON = xbmc.translatePath(ADDON.getAddonInfo("icon"))
     FANART = xbmc.translatePath(ADDON.getAddonInfo("fanart"))
+    PROFILE = xbmc.translatePath(ADDON.getAddonInfo('profile'))
 
+TEMP = os.path.join(PROFILE, 'temp', '')
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.13+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 5.0.14
                - Minor version fix (py2)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
