### PR TITLE
[plugin.video.regiotv@leia] 0.1.3

### DIFF
--- a/plugin.video.regiotv/README.md
+++ b/plugin.video.regiotv/README.md
@@ -27,6 +27,10 @@ In Kodi, simply search the add-ons for `Regio TV` and install the Regio TV video
 You can report issues at [our GitHub project](https://github.com/add-ons/plugin.video.regiotv).
 
 ## Releases
+### v0.1.3 (2021-03-04)
+- Fix an exception on Matrix when syncing channel/tvguide from IPTV Manager
+- Remove WTV, combine with Focus TV
+
 ### v0.1.2 (2020-08-01)
 - Add support for IPTV Manager
 - Add support for referer

--- a/plugin.video.regiotv/addon.xml
+++ b/plugin.video.regiotv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.regiotv" name="Regio TV" version="0.1.2" provider-name="dagwieers">
+<addon id="plugin.video.regiotv" name="Regio TV" version="0.1.3" provider-name="dagwieers">
 <requires>
   <import addon="script.module.routing" version="0.2.3"/>
   <import addon="xbmc.python" version="2.25.0"/>
@@ -29,6 +29,10 @@ Beschikbare zenders: ATV, BRUZZ, Focus TV, ROB-tv, TVL, TV Oost, WTV
   <source>https://github.com/add-ons/plugin.video.regiotv</source>
   <forum>https://github.com/add-ons/plugin.video.regiotv/issues</forum>
   <news>
+v0.1.3 (2021-03-04)
+- Fix an exception on Matrix when syncing channel/tvguide from IPTV Manager
+- Remove WTV, combine with Focus TV
+
 v0.1.2 (2020-08-01)
 - Add support for IPTV Manager
 - Add support for referer

--- a/plugin.video.regiotv/resources/lib/addon.py
+++ b/plugin.video.regiotv/resources/lib/addon.py
@@ -30,6 +30,7 @@ def main_menu():
         label = '{name} [COLOR gray]| {label}[/COLOR]'.format(**channel)
         plot = '[B]{name}[/B]\nRegio {label}\n\n[I]{description}[/I]\n\n[COLOR yellow]{website}[/COLOR]'.format(**channel)
         list_item = ListItem(label=label, label2=channel.get('label'), offscreen=True)
+        list_item.setProperty(key='IsInternetStream', value='true' if is_playable else 'false')
         list_item.setProperty(key='IsPlayable', value='true' if is_playable else 'false')
         list_item.setInfo(type='video', infoLabels=dict(
             lastplayed='',

--- a/plugin.video.regiotv/resources/lib/data.py
+++ b/plugin.video.regiotv/resources/lib/data.py
@@ -26,14 +26,14 @@ CHANNELS = [
         preset=203,
     ),
     dict(
-        name='Focus TV',
+        name='Focus & WTV',
         label='West-Vlaanderen',
         description='Het meest belangwekkende nieuws uit West-Vlaanderen.',
         # live_stream='https://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/ARXpX7.smil/playlist.m3u8?',
         live_stream='https://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/ARXpX7.smil/playlist.m3u8',
         referer='http://player.clevercast.com/players/video-js/',
         logo='https://i.imgur.com/aGORIN8.png',
-        website='https://www.focustv.be/',
+        website='https://www.focus-wtv.be/',
         preset=204,
     ),
     dict(
@@ -62,16 +62,5 @@ CHANNELS = [
         logo='http://static.tvoost.be/tvoostbe/meta/android-chrome-192x192.png',
         website='https://tvoost.be/',
         preset=209,
-    ),
-    dict(
-        name='WTV',
-        label='West-Vlaanderen',
-        description='Het meest belangwekkende nieuws uit West-Vlaanderen.',
-        # live_stream='https://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/AG1G1l.smil/playlist.m3u8',
-        live_stream='http://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/ARXpX7.smil/playlist.m3u8',
-        referer='http://player.clevercast.com/players/video-js/',
-        logo='https://i.imgur.com/aGORIN8.png',
-        website='https://www.wtv.be/',
-        preset=210,
     ),
 ]

--- a/plugin.video.regiotv/resources/lib/iptvmanager.py
+++ b/plugin.video.regiotv/resources/lib/iptvmanager.py
@@ -24,7 +24,7 @@ class IPTVManager(object):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('127.0.0.1', self.port))
             try:
-                sock.sendall(json.dumps(func()))  # pylint: disable=not-callable
+                sock.sendall(json.dumps(func()).encode())  # pylint: disable=not-callable
             finally:
                 sock.close()
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Regio TV
  - Add-on ID: plugin.video.regiotv
  - Version number: 0.1.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.regiotv
  
The Regio TV add-on lists all available Flemish regional television stations.

Available channels: ATV, BRUZZ, Focus TV, ROB-tv, TVL, TV Oost, WTV

[I]This add-on is not endorsed by any television station, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v0.1.3 (2021-03-04)
- Fix an exception on Matrix when syncing channel/tvguide from IPTV Manager
- Remove WTV, combine with Focus TV

v0.1.2 (2020-08-01)
- Add support for IPTV Manager
- Add support for referer
- Add RegioTV artwork

v0.1.1 (2020-02-11)
- Fix regional channels BRUZZ, Focus TV and WTV

v0.1.0 (2019-11-08)
- Initial public release
  

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
