### PR TITLE
[plugin.video.yelo@matrix] 1.0.2+matrix.1

### DIFF
--- a/plugin.video.yelo/README.md
+++ b/plugin.video.yelo/README.md
@@ -59,6 +59,8 @@ Big thanks to [peak3d](https://github.com/peak3d) for his plugin and all the sup
 also to [basrieter](https://bitbucket.org/basrieter/xbmc-online-tv/src/master/) for helping to debug my plugin!
 
 # Changelog #
+### v1.0.2 (2021-03-04)
+- Fix an exception on Matrix when using IPTV Manager (@dagwieers)
 
 ### v1.0.1 (2020-11-02)
 - Load EPG in the background (@shycoderX)

--- a/plugin.video.yelo/addon.xml
+++ b/plugin.video.yelo/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.yelo" name="Yelo" version="1.0.1+matrix.1" provider-name="shycoderX">
+<addon id="plugin.video.yelo" name="Yelo" version="1.0.2+matrix.1" provider-name="shycoderX">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.4.2"/>
@@ -32,6 +32,9 @@
             <fanart>resources/fanart.jpg</fanart>
         </assets>
         <news>
+v1.0.2 (2021-03-04)
+- Fix an exception on Matrix when using IPTV Manager (@dagwieers)
+
 v1.0.1 (2020-11-02)
 - Add Kodi 19 checks @shycoderX)
 - Load EPG in the background (@shycoderX)

--- a/plugin.video.yelo/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.yelo/resources/language/resource.language.nl_nl/strings.po
@@ -85,7 +85,7 @@ msgid "You need to fill in your credentials in settings."
 msgstr "Je aanmeldgegevens moeten ingevuld worden in de add-on instellingen."
 
 msgctxt "#32016"
-msgid "Extra"
+msgid "InputStream Helper"
 msgstr "InputStream Helper"
 
 msgctxt "#32017"

--- a/plugin.video.yelo/resources/lib/helpers/helperclasses.py
+++ b/plugin.video.yelo/resources/lib/helpers/helperclasses.py
@@ -48,7 +48,7 @@ class EPG:
         data.update(json_data)
 
         with open(os.path.join(path, cls.EPG_CACHE_FILE_NAME), "w") as json_file:
-            json.dump(data, json_file)
+            json.dump(data, json_file, sort_keys=True, indent=True)
 
     @classmethod
     def get_from_cache(cls):
@@ -119,7 +119,7 @@ class PluginCache:  # pylint: disable=no-init
         data.update(json_data)
 
         with open(os.path.join(path, cls.CACHE_FILE_NAME), "w") as json_file:
-            json.dump(data, json_file)
+            json.dump(data, json_file, sort_keys=True, indent=True)
 
     @classmethod
     def get_by_key(cls, key):

--- a/plugin.video.yelo/resources/lib/iptvmanager.py
+++ b/plugin.video.yelo/resources/lib/iptvmanager.py
@@ -9,6 +9,7 @@ import json
 
 _LOGGER = logging.getLogger('iptv-manager')
 
+
 class IPTVManager:
     """Interface to IPTV Manager"""
 
@@ -26,7 +27,7 @@ class IPTVManager:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('127.0.0.1', self.port))
             try:
-                sock.sendall(json.dumps(func(self)))  # pylint: disable=not-callable
+                sock.sendall(json.dumps(func(self)).encode())  # pylint: disable=not-callable
             finally:
                 sock.close()
 

--- a/plugin.video.yelo/resources/lib/kodiutils.py
+++ b/plugin.video.yelo/resources/lib/kodiutils.py
@@ -52,13 +52,16 @@ def get_setting_as_int(setting):
 def get_string(string_id):
     return ADDON.getLocalizedString(string_id).encode('utf-8', 'ignore')
 
+
 def kodi_version():
     """Returns full Kodi version as string"""
     return xbmc.getInfoLabel('System.BuildVersion').split(' ')[0]
 
+
 def kodi_version_major():
     """Returns major Kodi version as integer"""
     return int(kodi_version().split('.')[0])
+
 
 def kodi_json_request(params):
     data = json.dumps(params)

--- a/plugin.video.yelo/resources/lib/yelo.py
+++ b/plugin.video.yelo/resources/lib/yelo.py
@@ -11,7 +11,7 @@ from data import USER_AGENT
 from helpers.helperclasses import PluginCache
 from helpers.helpermethods import widevine_payload_package
 from yelo_api import YeloApi
-from kodiutils import *
+from kodiutils import kodi_version_major
 
 try:  # Python 3
     from urllib.parse import quote

--- a/plugin.video.yelo/resources/lib/yelo_bg_service.py
+++ b/plugin.video.yelo/resources/lib/yelo_bg_service.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, unicode_literals
 
 import logging


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Yelo
  - Add-on ID: plugin.video.yelo
  - Version number: 1.0.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.yelo
  
This plugin makes it possible to watch live streams that are available on the Telenet Yelo application for your region.

### Description of changes:


v1.0.2 (2021-03-04)
- Fix an exception on Matrix when using IPTV Manager (@dagwieers)

v1.0.1 (2020-11-02)
- Add Kodi 19 checks @shycoderX)
- Load EPG in the background (@shycoderX)
- Add device registration for Play subscription (@fripsy)
- Use sock.sendall instead of sock.send (@michaelarnauts)

### v1.0.0 (2020-05-22)
- Add Dutch translations (@dagwieers)
- Add support for IPTV Manager (@shycoderX, @dagwieers)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
