### PR TITLE
[plugin.library.node.editor@matrix] 2.0.3

### DIFF
--- a/plugin.library.node.editor/addon.xml
+++ b/plugin.library.node.editor/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.library.node.editor" name="Library Node Editor" version="2.0.1" provider-name="Unfledged, Team-Kodi">
+<addon id="plugin.library.node.editor" name="Library Node Editor" version="2.0.3" provider-name="Unfledged, Team-Kodi">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.unidecode" version="1.1.1"/>
@@ -41,8 +41,8 @@
             <icon>icon.png</icon>
         </assets>
         <news>
-            2.0.1 (03/3/2021)
-            - xbmc.translatePath -> xbmcvfs.translatePath
+            2.0.2 / 2.0.3 (05/3/2021)
+            - Fix wrong method import
         </news>
     </extension>
 </addon>

--- a/plugin.library.node.editor/resources/lib/common.py
+++ b/plugin.library.node.editor/resources/lib/common.py
@@ -1,7 +1,7 @@
 
 import sys
 import os
-import xbmc, xmbcvfs, xbmcaddon
+import xbmc, xbmcvfs, xbmcaddon
 
 ADDON        = xbmcaddon.Addon()
 ADDONID      = ADDON.getAddonInfo('id')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Library Node Editor
  - Add-on ID: plugin.library.node.editor
  - Version number: 2.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.library.node.editor
  
Create and edit custom library nodes.

### Description of changes:


            2.0.2 / 2.0.3 (05/3/2021)
            - Fix wrong method import
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
