### PR TITLE
[repo-plugins][matrix] Add addon-checker via github actions

### DIFF
--- a/.github/workflows/addon-checker.yml
+++ b/.github/workflows/addon-checker.yml
@@ -1,0 +1,30 @@
+name: Kodi Addon-Checker
+
+on: [pull_request]
+
+jobs:
+  kodi-addon-checker:
+    runs-on: ubuntu-latest
+    name: Kodi Addon-Checker
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip3 install --user kodi-addon-checker
+
+    - name: Extract job variables
+      shell: bash
+      run: echo "##[set-output name=addon;]$(git diff --diff-filter=d --name-only HEAD~ | grep / | cut -d / -f1 | sort | uniq)"
+      id: extract_vars
+
+    - name: Addon-Check
+      run: $HOME/.local/bin/kodi-addon-checker --branch=${{ github.event.pull_request.base.ref }} --PR ${{ steps.extract_vars.outputs.addon }}


### PR DESCRIPTION
This PR provides a common action to be added to each branch to run Kodi addon checker with github actions as an alternative to Travis.
It was written to mimic what is currently implemented in Travis and in a way it can be easily copied to each branch without requiring any adjustment or modification.

I'd like to have this approved first and then port to every other branch in all repos (repo-plugins, repo-scripts, repo-scrapers and repo-resources). 

The only thing left is something similar to travis buddy (which is broken atm anyway). I've tried adding it to the action but github does not allow it for security reasons on forked repos (see: https://github.com/thollander/actions-comment-pull-request/issues/10). I think the way to go is to use a standalone app we can host and configure the repo with webhooks.

Note we might want to add https://github.com/xbmc/repository-generator/pull/17 to the repository-generator at some point. It doesn't crash at the moment but it does log an exception, which can be a source of confusion in the future.

pinging @yol or @wsnipex 

At the moment the repo is blocked for new additions as we are out of travis credits. I'd like to have this in as soon as possible.