### PR TITLE
[plugin.video.vtm.go@matrix] 1.2.5+matrix.1+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v1.2.5](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.5) (2021-03-22)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.4...v1.2.5)
+
+**Implemented enhancements:**
+
+- Improve artwork [\#269](https://github.com/add-ons/plugin.video.vtm.go/pull/269) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add more metadata to movies and programs [\#267](https://github.com/add-ons/plugin.video.vtm.go/pull/267) ([michaelarnauts](https://github.com/michaelarnauts))
+- Don't depend on credentials to populate IPTV Manager data [\#266](https://github.com/add-ons/plugin.video.vtm.go/pull/266) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix authentication and use API v9 [\#270](https://github.com/add-ons/plugin.video.vtm.go/pull/270) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.2.4](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.4) (2021-03-01)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.3...v1.2.4)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.4+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.5+matrix.1+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,8 +25,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.4 (2021-03-01)
-- Rename CAZ 2 to VTM Gold.</news>
+	<news>v1.2.5 (2021-03-22)
+- Fix issue with authentication for new users.
+- Improve descriptions and images.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
 from resources.lib.vtmgo.vtmgo import VtmGo
-from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 from resources.lib.vtmgo.vtmgoepg import VtmGoEpg
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,12 +23,7 @@ class IPTVManager:
         """ Initialise object
         :type port: int
         """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
-        self._vtm_go = VtmGo(self._auth)
+        self._vtm_go = VtmGo()
         self._vtm_go_epg = VtmGoEpg()
         self.port = port
 
@@ -105,7 +99,7 @@ class IPTVManager:
                         # season=None,  # Not available in the API
                         # epsiode=None,  # Not available in the API
                         genre=broadcast.genre,
-                        image=broadcast.image,
+                        image=broadcast.thumb,
                         stream=kodiutils.url_for('play',
                                                  category=broadcast.playable_type,
                                                  item=broadcast.playable_uuid) if broadcast.playable_uuid else None)

--- a/plugin.video.vtm.go/resources/lib/modules/library.py
+++ b/plugin.video.vtm.go/resources/lib/modules/library.py
@@ -38,7 +38,7 @@ class Library:
                 items = self._api.get_items(content_filter=Movie, cache=CACHE_AUTO)
             else:
                 # Only favourites, use cache if available, fetch from api otherwise
-                items = self._api.get_swimlane('my-list', content_filter=Movie)
+                items = self._api.get_mylist(content_filter=Movie)
         else:
             items = [self._api.get_movie(movie)]
 
@@ -63,7 +63,7 @@ class Library:
             else:
                 # Only favourites, don't use cache, fetch from api
                 # If we use CACHE_AUTO, we will miss updates until the user manually opens the program in the Add-on
-                items = self._api.get_swimlane('my-list', content_filter=Program, cache=CACHE_PREVENT)
+                items = self._api.get_mylist(content_filter=Program, cache=CACHE_PREVENT)
         else:
             # Fetch only a single program
             items = [self._api.get_program(program, cache=CACHE_PREVENT)]

--- a/plugin.video.vtm.go/resources/lib/modules/menu.py
+++ b/plugin.video.vtm.go/resources/lib/modules/menu.py
@@ -226,8 +226,10 @@ class Menu:
         :rtype TitleItem
         """
         art_dict = {
-            'thumb': item.cover,
-            'cover': item.cover,
+            'poster': item.poster,
+            'landscape': item.thumb,
+            'thumb': item.thumb,
+            'fanart': item.fanart,
         }
         info_dict = {
             'title': item.name,
@@ -254,9 +256,6 @@ class Menu:
                     kodiutils.url_for('mylist_add', video_type=CONTENT_TYPE_MOVIE, content_id=item.movie_id)
                 )]
 
-            art_dict.update({
-                'fanart': item.image,
-            })
             info_dict.update({
                 'mediatype': 'movie',
                 'duration': item.duration,
@@ -298,11 +297,9 @@ class Menu:
                     kodiutils.url_for('mylist_add', video_type=CONTENT_TYPE_PROGRAM, content_id=item.program_id)
                 )]
 
-            art_dict.update({
-                'fanart': item.image,
-            })
             info_dict.update({
                 'mediatype': 'tvshow',
+                'year': item.year,
                 'season': len(item.seasons),
             })
             prop_dict.update({
@@ -330,9 +327,6 @@ class Menu:
                     kodiutils.url_for('show_catalog_program', program=item.program_id)
                 )]
 
-            art_dict.update({
-                'fanart': item.cover,
-            })
             info_dict.update({
                 'mediatype': 'episode',
                 'tvshowtitle': item.program_name,

--- a/plugin.video.vtm.go/resources/lib/modules/metadata.py
+++ b/plugin.video.vtm.go/resources/lib/modules/metadata.py
@@ -7,6 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.vtmgo import Movie, Program
+from resources.lib.vtmgo.exceptions import NoLoginException
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
@@ -18,11 +19,14 @@ class Metadata:
 
     def __init__(self):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
+        try:
+            self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                                   kodiutils.get_setting('password'),
+                                   'VTM',
+                                   kodiutils.get_setting('profile'),
+                                   kodiutils.get_tokens_path())
+        except NoLoginException:
+            self._auth = None
         self._vtm_go = VtmGo(self._auth)
 
     def update(self):

--- a/plugin.video.vtm.go/resources/lib/modules/player.py
+++ b/plugin.video.vtm.go/resources/lib/modules/player.py
@@ -7,7 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.kodiplayer import KodiPlayer
-from resources.lib.vtmgo.exceptions import StreamGeoblockedException, StreamUnavailableException, UnavailableException
+from resources.lib.vtmgo.exceptions import NoLoginException, StreamGeoblockedException, StreamUnavailableException, UnavailableException
 from resources.lib.vtmgo.vtmgo import VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 from resources.lib.vtmgo.vtmgostream import VtmGoStream
@@ -20,13 +20,17 @@ class Player:
 
     def __init__(self):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
+        try:
+            self._auth = VtmGoAuth(kodiutils.get_setting('username'),
+                                   kodiutils.get_setting('password'),
+                                   'VTM',
+                                   kodiutils.get_setting('profile'),
+                                   kodiutils.get_tokens_path())
+        except NoLoginException:
+            self._auth = None
+
         self._vtm_go = VtmGo(self._auth)
-        self._vtm_go_stream = VtmGoStream()
+        self._vtm_go_stream = VtmGoStream(self._auth)
 
     def play_or_live(self, category, item, channel):
         """ Ask to play the requested item or switch to the live channel
@@ -220,7 +224,9 @@ class Player:
                 tvshowid=current_episode.program_id,
                 title=current_episode.name,
                 art={
-                    'thumb': current_episode.cover,
+                    'poster': current_episode.poster,
+                    'landscape': current_episode.thumb,
+                    'fanart': current_episode.fanart,
                 },
                 season=current_episode.season,
                 episode=current_episode.number,
@@ -236,7 +242,9 @@ class Player:
                 tvshowid=next_episode.program_id,
                 title=next_episode.name,
                 art={
-                    'thumb': next_episode.cover,
+                    'poster': next_episode.poster,
+                    'landscape': next_episode.thumb,
+                    'fanart': next_episode.fanart,
                 },
                 season=next_episode.season,
                 episode=next_episode.number,

--- a/plugin.video.vtm.go/resources/lib/modules/tvguide.py
+++ b/plugin.video.vtm.go/resources/lib/modules/tvguide.py
@@ -89,8 +89,7 @@ class TvGuide:
                 title=title,
                 path=path,
                 art_dict=dict(
-                    icon=broadcast.image,
-                    thumb=broadcast.image,
+                    thumb=broadcast.thumb,
                 ),
                 info_dict=dict(
                     title=title,

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 API_ENDPOINT = 'https://lfvp-api.dpgmedia.net'
+API_ANDROID_ENDPOINT = 'https://lfvp-android-api.dpgmedia.net'
 
 # These seem to be hardcoded
 STOREFRONT_MAIN = '9620cc0b-0f97-4d96-902a-827dcfd0b227'
@@ -100,15 +101,16 @@ class Category:
 class Movie:
     """ Defines a Movie """
 
-    def __init__(self, movie_id=None, name=None, description=None, year=None, cover=None, image=None, duration=None,
+    def __init__(self, movie_id=None, name=None, description=None, year=None, poster=None, thumb=None, fanart=None, duration=None,
                  remaining=None, geoblocked=None, channel=None, legal=None, aired=None, my_list=None):
         """
         :type movie_id: str
         :type name: str
         :type description: str
         :type year: int
-        :type cover: str
-        :type image: str
+        :type poster: str
+        :type thumb: str
+        :type fanart: str
         :type duration: int
         :type remaining: str
         :type geoblocked: bool
@@ -121,8 +123,9 @@ class Movie:
         self.name = name
         self.description = description if description else ''
         self.year = year
-        self.cover = cover
-        self.image = image
+        self.poster = poster
+        self.thumb = thumb
+        self.fanart = fanart
         self.duration = duration
         self.remaining = remaining
         self.geoblocked = geoblocked
@@ -138,14 +141,16 @@ class Movie:
 class Program:
     """ Defines a Program """
 
-    def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
+    def __init__(self, program_id=None, name=None, description=None, year=None, poster=None, thumb=None, fanart=None, seasons=None,
                  geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None):
         """
         :type program_id: str
         :type name: str
         :type description: str
-        :type cover: str
-        :type image: str
+        :type year: int
+        :type poster: str
+        :type thumb: str
+        :type fanart: str
         :type seasons: dict[int, Season]
         :type geoblocked: bool
         :type channel: str
@@ -156,8 +161,10 @@ class Program:
         self.program_id = program_id
         self.name = name
         self.description = description if description else ''
-        self.cover = cover
-        self.image = image
+        self.year = year
+        self.poster = poster
+        self.thumb = thumb
+        self.fanart = fanart
         self.seasons = seasons if seasons else {}
         self.geoblocked = geoblocked
         self.channel = channel
@@ -172,19 +179,15 @@ class Program:
 class Season:
     """ Defines a Season """
 
-    def __init__(self, number=None, episodes=None, cover=None, geoblocked=None, channel=None, legal=None):
+    def __init__(self, number=None, episodes=None, channel=None, legal=None):
         """
         :type number: str
         :type episodes: dict[int, Episode]
-        :type cover: str
-        :type geoblocked: bool
         :type channel: str
         :type legal: str
         """
         self.number = int(number)
         self.episodes = episodes if episodes else {}
-        self.cover = cover
-        self.geoblocked = geoblocked
         self.channel = channel
         self.legal = legal
 
@@ -195,9 +198,9 @@ class Season:
 class Episode:
     """ Defines an Episode """
 
-    def __init__(self, episode_id=None, program_id=None, program_name=None, number=None, season=None, name=None,
-                 description=None, cover=None, duration=None, remaining=None, geoblocked=None, channel=None, legal=None,
-                 aired=None, progress=None, watched=False, next_episode=None):
+    def __init__(self, episode_id=None, program_id=None, program_name=None, number=None, season=None, name=None, description=None, poster=None, thumb=None,
+                 fanart=None, duration=None, remaining=None, geoblocked=None, channel=None, legal=None, aired=None, progress=None, watched=False,
+                 next_episode=None):
         """
         :type episode_id: str
         :type program_id: str
@@ -206,7 +209,9 @@ class Episode:
         :type season: str
         :type name: str
         :type description: str
-        :type cover: str
+        :type poster: str
+        :type thumb: str
+        :type fanart: str
         :type duration: int
         :type remaining: int
         :type geoblocked: bool
@@ -228,7 +233,9 @@ class Episode:
         else:
             self.name = name
         self.description = description if description else ''
-        self.cover = cover
+        self.poster = poster
+        self.thumb = thumb
+        self.fanart = fanart
         self.duration = int(duration) if duration else None
         self.remaining = int(remaining) if remaining is not None else None
         self.geoblocked = geoblocked

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -16,8 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTMGO/6.11.18 (be.vmma.vtm.zenderapp; build:12648; Android 25) okhttp/4.7.2',
-    'x-app-version': '8',
+    'User-Agent': 'VTMGO/9.10 (be.vmma.vtm.zenderapp; build:13200; Android 25) okhttp/4.9.0',
+    'x-app-version': '9',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '25',

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoepg.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoepg.py
@@ -40,7 +40,7 @@ class EpgChannel:
 class EpgBroadcast:
     """ Defines an EPG broadcast"""
 
-    def __init__(self, uuid=None, playable_type=None, title=None, time=None, duration=None, image=None, description=None, live=None, rerun=None, tip=None,
+    def __init__(self, uuid=None, playable_type=None, title=None, time=None, duration=None, thumb=None, description=None, live=None, rerun=None, tip=None,
                  program_uuid=None, playable_uuid=None, channel_uuid=None, airing=None, genre=None):
         """
         :type uuid: str
@@ -48,7 +48,7 @@ class EpgBroadcast:
         :type title: str
         :type time: datetime
         :type duration: int
-        :type image: str
+        :type thumb: str
         :type description: str
         :type live: str
         :type rerun: str
@@ -64,7 +64,7 @@ class EpgBroadcast:
         self.title = title
         self.time = time
         self.duration = duration
-        self.image = image
+        self.thumb = thumb
         self.description = description
         self.live = live
         self.rerun = rerun
@@ -203,7 +203,7 @@ class VtmGoEpg:
             title=broadcast_json.get('title'),
             time=start,
             duration=duration,
-            image=broadcast_json.get('imageUrl'),
+            thumb=broadcast_json.get('imageUrl'),
             description=broadcast_json.get('synopsis'),
             live=broadcast_json.get('live'),
             rerun=broadcast_json.get('rerun'),

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 
 from resources.lib import kodiutils
 from resources.lib.vtmgo import ResolvedStream, util
-from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,14 +20,10 @@ class VtmGoStream:
 
     _API_KEY = 'jL3yNhGpDsaew9CqJrDPq2UzMrlmNVbnadUXVOET'
 
-    def __init__(self):
+    def __init__(self, auth=None):
         """ Initialise object """
-        self._auth = VtmGoAuth(kodiutils.get_setting('username'),
-                               kodiutils.get_setting('password'),
-                               'VTM',
-                               kodiutils.get_setting('profile'),
-                               kodiutils.get_tokens_path())
-        self._tokens = self._auth.get_tokens()
+        self._auth = auth
+        self._tokens = self._auth.get_tokens() if self._auth else None
 
     def _mode(self):
         """ Return the mode that should be used for API calls """


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.5+matrix.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.5 (2021-03-22)
- Fix issue with authentication for new users.
- Improve descriptions and images.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
