### PR TITLE
[plugin.whereareyou] v0.4.2

### DIFF
--- a/plugin.whereareyou/addon.xml
+++ b/plugin.whereareyou/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.4.1+matrix.1">
+<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.4.2+matrix.1">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.kodi-six" version="0.1.3.1" />
@@ -10,8 +10,8 @@
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<news>
-v.0.4.1
-- fix for "no next item in playlist" error
+v.0.4.2
+- fix for logging issue with Python3
 		</news>
 		<assets>
 			<icon>icon.png</icon>

--- a/plugin.whereareyou/changelog.txt
+++ b/plugin.whereareyou/changelog.txt
@@ -1,3 +1,6 @@
+v.0.4.2
+- fix for logging issue with Python3
+
 v.0.4.1
 - fix for "no next item in playlist" error
 

--- a/plugin.whereareyou/resources/lib/xlogger.py
+++ b/plugin.whereareyou/resources/lib/xlogger.py
@@ -1,4 +1,4 @@
-#v.0.4.13
+#v.0.4.14
 
 try:
     from kodi_six import xbmc
@@ -46,8 +46,6 @@ class Logger( object ):
                 loglevel = self.logger.debug
         for line in loglines:
             try:
-                if isinstance(line, unicode):
-                    line = line.encode('utf-8')
                 str_line = line.__str__()
             except Exception as e:
                 str_line = ''


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
- fix for Python3 logging issue

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
