### PR TITLE
[plugin.video.videomediaset@krypton] 2.0.3

### DIFF
--- a/plugin.video.videomediaset/addon.xml
+++ b/plugin.video.videomediaset/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.videomediaset" name="Mediaset Play" provider-name="phate89, aracnoz" version="2.0.2">
+<addon id="plugin.video.videomediaset" name="Mediaset Play" provider-name="phate89, aracnoz" version="2.0.3">
     <requires>
         <import addon="xbmc.python" version="2.25.0" />
         <import addon="script.module.phate89" version="1.2.1"/>
@@ -19,17 +19,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=292876</forum>
         <source>https://github.com/phate89/plugin.video.videomediaset</source>
         <reuselanguageinvoker>true</reuselanguageinvoker>
-        <news>2.0.1
-- removed letter sorting (not available anymore) and fixed endpoints after website change (thx to typhoon51280)
-- added support for live restart (manually jump to start after you start play right now)
-- added brand title in episode and clip search to have better info
-- added details of live event in  live channels section
-- improved performance reusing python env
-- improved element sorting
-- added editions visualization for programs
-- fixed case of valid video without media info (no way to play it)
-- improved media type and info detection
-- fixed next page search
+        <news>2.0.3
+- fixed live channel list loading in pre-matrix with spechial characters (thx to madpilot78)
+- added paging for videos
+- added range in url requests (thx to thinkingmik)
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.videomediaset/changelog.txt
+++ b/plugin.video.videomediaset/changelog.txt
@@ -1,3 +1,9 @@
+[B]2.0.3[/B]
+- fixed live channel list loading in pre-matrix with spechial characters (thx to madpilot78)
+- added paging for videos
+- added range in url requests (thx to thinkingmik)
+
+
 [B]2.0.1[/B]
 - removed letter sorting (not available anymore) and fixed endpoints after website change (thx to typhoon51280)
 - added support for live restart (manually jump to start after you start play right now)

--- a/plugin.video.videomediaset/resources/lib/mediaset.py
+++ b/plugin.video.videomediaset/resources/lib/mediaset.py
@@ -329,36 +329,45 @@ class Mediaset(rutils.RUtils):
             pageels=pageels, page=page, args={'platform': 'pc', 'uxReference': self.uxReferenceMapping[gid]})
         return self.__getElsFromUrl(url)
 
-    def OttieniStagioni(self, seriesId, sort=None):
+    def OttieniStagioni(self, seriesId, sort=None, range=None):
         self.log('Trying to get the seasons from series id {}'.format(seriesId), 4)
         url = 'https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-tv-seasons/feed'
         args = {'bySeriesId': seriesId}
         if sort:
             args['sort'] = sort
+        if range:
+            args['range'] = range
         return self.__getEntriesFromUrl(url, args)
 
-    def OttieniSezioniProgramma(self, brandId, sort=None):
+    def OttieniSezioniProgramma(self, brandId, sort=None, range=None):
         self.log('Trying to get the sections from brand id {}'.format(brandId), 4)
         url = 'https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-brands?'
         args = {'byCustomValue': '{{brandId}}{{{brandId}}}'.format(brandId=brandId)}
         if sort:
             args['sort'] = sort
+        if range:
+            args['range'] = range
         return self.__getEntriesFromUrl(url, args)
 
-    def OttieniVideoSezione(self, subBrandId, sort=None):
+    def OttieniVideoSezione(self, subBrandId, sort=None, range=None):
         self.log('Trying to get the videos from section {}'.format(subBrandId), 4)
         url = 'https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-programs'
         args = {'byCustomValue': '{{subBrandId}}{{{subBrandId}}}'.format(subBrandId=subBrandId)}
         if sort:
             args['sort'] = sort
+        if range:
+            args['range'] = range
         return self.__getEntriesFromUrl(url, args)
 
-    def OttieniCanaliLive(self, sort=None):
+    def OttieniCanaliLive(self, sort=None, range=None):
         self.log('Trying to get the live channels list', 4)
         url = ('https://feed.entertainment.tv.theplatform.eu/f/PR1GhC/mediaset-prod-all-stations?')
+        args = {}
         if sort:
-            return self.__getEntriesFromUrl(url, {'sort': sort})
-        return self.__getEntriesFromUrl(url)
+            args['sort'] = sort
+        if range:
+            args['range'] = range
+        return self.__getEntriesFromUrl(url, args)
 
     def Cerca(self, query, section=None, pageels=100, page=None):
         args = {'query': query, 'platform': 'pc'}
@@ -381,7 +390,7 @@ class Mediaset(rutils.RUtils):
             return {}
         return res
 
-    def OttieniProgrammiLive(self, sort=None):
+    def OttieniProgrammiLive(self, sort=None, range=None):
         self.log('Trying to get the live programs', 4)
         now = staticutils.get_timestamp()
         args = {'byListingTime': '{s}~{f}'.format(s=str(now - 1001), f=str(now))}

--- a/plugin.video.videomediaset/resources/main.py
+++ b/plugin.video.videomediaset/resources/main.py
@@ -10,9 +10,13 @@ class KodiMediaset(object):
     def __init__(self):
         self.med = Mediaset()
         self.med.log = kodiutils.log
-        self.iperpage = kodiutils.getSetting('itemsperpage')
+        self.iperpage = int(kodiutils.getSetting('itemsperpage'))
         self.ua = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
                    '(KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36')
+
+    def __imposta_range(self, start):
+        limit = '{}-{}'.format(start, start + self.iperpage-1)
+        return limit
 
     def __imposta_tipo_media(self, prog):
         kodiutils.setContent(_gather_media_type(prog) + 's')
@@ -270,18 +274,23 @@ class KodiMediaset(object):
                 self.elenco_sezioni_list(brandId)
 
     def elenco_sezioni_list(self, brandId):
-        els = self.med.OttieniSezioniProgramma(brandId, sort='mediasetprogram$order')
+        els = self.med.OttieniSezioniProgramma(
+            brandId, sort='mediasetprogram$order')
         if len(els) == 2:
-            self.elenco_video_list(els[1]['mediasetprogram$subBrandId'])
+            self.elenco_video_list(els[1]['mediasetprogram$subBrandId'], 1)
         else:
             els.pop(0)
             self.__analizza_elenco(els)
         kodiutils.endScript()
 
-    def elenco_video_list(self, subBrandId):
+    def elenco_video_list(self, subBrandId, start):
         els = self.med.OttieniVideoSezione(
-            subBrandId, sort='mediasetprogram$publishInfo_lastPublished')
+            subBrandId, sort='mediasetprogram$publishInfo_lastPublished', range=self.__imposta_range(start))
         self.__analizza_elenco(els, True)
+        if len(els) == self.iperpage:
+            kodiutils.addListItem(kodiutils.LANGUAGE(32130),
+                                  {'mode': 'programma', 'sub_brand_id': subBrandId,
+                                   'start': start + self.iperpage})
         kodiutils.endScript()
 
     def guida_tv_root(self):
@@ -340,7 +349,7 @@ class KodiMediaset(object):
                 for prog in chan['listings']:
                     if prog['startTime'] <= now <= prog['endTime']:
                         guid = chan['guid']
-                        chans[guid] = {'title': '{} - {}'.format(chan['title'],
+                        chans[guid] = {'title': '{} - {}'.format(kodiutils.py2_encode(chan['title']),
                                                                  kodiutils.py2_encode(
                                                                      prog["mediasetlisting$epgTitle"])),
                                        'infos': _gather_info(prog),
@@ -518,7 +527,10 @@ class KodiMediaset(object):
                 if 'series_id' in params:
                     self.elenco_stagioni_list(params['series_id'], params['title'])
                 elif 'sub_brand_id' in params:
-                    self.elenco_video_list(params['sub_brand_id'])
+                    if 'start' in params:
+                        self.elenco_video_list(params['sub_brand_id'], int(params['start']))
+                    else:
+                        self.elenco_video_list(params['sub_brand_id'], 1)
                 elif 'brand_id' in params:
                     self.elenco_sezioni_list(params['brand_id'])
             if params['mode'] == "video":


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Mediaset Play
  - Add-on ID: plugin.video.videomediaset
  - Version number: 2.0.3
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/phate89/plugin.video.videomediaset
  
All your favorite shows are available to you the day after the airing Tv. Last night you missed your favorite TV drama? No problem, you can finally see her comfortably on KODI whenever you want.

### Description of changes:

2.0.3
- fixed live channel list loading in pre-matrix with spechial characters (thx to madpilot78)
- added paging for videos
- added range in url requests (thx to thinkingmik)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
