### PR TITLE
[plugin.video.rtpplay@matrix] 5.0.14

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.14+matrix.1" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="5.0.14" provider-name="enen92, guipenedo">
     <requires>
-        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
         <import addon="script.module.requests" version="2.12.4"/>
         <import addon="script.module.inputstreamhelper" version="0.4.2"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 5.0.14
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 5.0.14
                - Minor version fix (py2)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
