### PR TITLE
[plugin.program.autocompletion@matrix] 2.0.1

### DIFF
--- a/plugin.program.autocompletion/addon.xml
+++ b/plugin.program.autocompletion/addon.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.autocompletion" name="AutoCompletion for virtual keyboard" version="2.0.0" provider-name="Philipp Temminghoff (phil65),sualfred">
+<addon id="plugin.program.autocompletion" name="AutoCompletion for virtual keyboard" version="2.0.1" provider-name="Philipp Temminghoff (phil65),sualfred">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.autocompletion" version="2.0.0"/>
     </requires>
-    <extension point="xbmc.python.pluginsource" library="plugin.py" />
     <extension point="xbmc.python.script" library="default.py">
         <provides>executable</provides>
     </extension>
+    <extension point="xbmc.python.pluginsource" library="plugin.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">AutoCompletion for the virtual keyboard (needs skin support)</summary>
         <description lang="en_GB">AutoCompletion for the virtual keyboard (needs skin support)</description>

--- a/plugin.program.autocompletion/plugin.py
+++ b/plugin.program.autocompletion/plugin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf8 -*-
-
 # Copyright (C) 2015 - Philipp Temminghoff <phil65@kodi.tv>
 # This program is Free Software see LICENSE file for details
 

--- a/plugin.program.autocompletion/resources/settings.xml
+++ b/plugin.program.autocompletion/resources/settings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Kodi settings -->
 <settings>
     <category label="32001">
         <setting label="32003" type="select" values="google|youtube|local|bing" id="autocomplete_provider" default="youtube"/>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: AutoCompletion for virtual keyboard
  - Add-on ID: plugin.program.autocompletion
  - Version number: 2.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/phil65/plugin.program.autocompletion
  
AutoCompletion for the virtual keyboard (needs skin support)

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
