### PR TITLE
[plugin.video.videomediaset@matrix] 2.0.7+matrix.1

### DIFF
--- a/plugin.video.videomediaset/addon.xml
+++ b/plugin.video.videomediaset/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.videomediaset" name="Mediaset Play Infinity" provider-name="phate89, aracnoz" version="2.0.6+matrix.1">
+<addon id="plugin.video.videomediaset" name="Mediaset Play Infinity" provider-name="phate89, aracnoz" version="2.0.7+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.phate89" version="1.2.1+matrix.1"/>
@@ -19,9 +19,8 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=292876</forum>
         <source>https://github.com/phate89/plugin.video.videomediaset</source>
         <reuselanguageinvoker>true</reuselanguageinvoker>
-        <news>2.0.6
-- update name and branding after mediaset branding change
-- Fix assets request after site change
+        <news>2.0.7
+- fix mistake in code refactoring
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.videomediaset/changelog.txt
+++ b/plugin.video.videomediaset/changelog.txt
@@ -1,3 +1,7 @@
+[B]2.0.7[/B]
+- fix mistake in code refactoring
+
+
 [B]2.0.6[/B]
 - update name and branding after mediaset branding change
 - Fix assets request after site change

--- a/plugin.video.videomediaset/resources/main.py
+++ b/plugin.video.videomediaset/resources/main.py
@@ -280,7 +280,7 @@ class KodiMediaset(object):
 
     def elenco_video_list(self, subBrandId, start):
         els = self.med.OttieniVideoSezione(
-            subBrandId, sort='mediasetprogram$publishInfo_lastPublished', range=self.__imposta_range(start))
+            subBrandId, sort='mediasetprogram$publishInfo_lastPublished', erange=self.__imposta_range(start))
         self.__analizza_elenco(els, True)
         if len(els) == self.iperpage:
             kodiutils.addListItem(kodiutils.LANGUAGE(32130),


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Mediaset Play Infinity
  - Add-on ID: plugin.video.videomediaset
  - Version number: 2.0.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/phate89/plugin.video.videomediaset
  
All your favorite shows are available to you the day after the airing Tv. Last night you missed your favorite TV drama? No problem, you can finally see her comfortably on KODI whenever you want.

### Description of changes:

2.0.7
- fix mistake in code refactoring
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
