### PR TITLE
[plugin.video.hbogoeu@matrix] 2.7.0+matrix.1

### DIFF
--- a/plugin.video.hbogoeu/addon.xml
+++ b/plugin.video.hbogoeu/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.6.3+matrix.1">
+<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.7.0+matrix.1">
   <requires>
     <import addon="xbmc.python" version="3.0.0" />
     <import addon="script.module.kodi-six" version="0.1.0" />
@@ -44,9 +44,10 @@ If an official app is available for your platform, use it instead of this.
     <source>https://github.com/arvvoid/plugin.video.hbogoeu</source>
     <website>https://arvvoid.github.io/plugin.video.hbogoeu</website>
     <news>
-- Fix minor subtitle offset (sp/no handler)
-- Translations updates
-- Minor fixes and optimizations
+- Hot Fix: new retrieve method for home lists [EU region]
+- This fix avoid the "a new version of the application should be used" error message coming from HBO Go
+- The additional home lists (recommendation, featured, various editor lists, ecc... are fully functional again)
+- Minor fixes
     </news>
     <assets>
      <icon>resources/icon.png</icon>

--- a/plugin.video.hbogoeu/hbogolib/base.py
+++ b/plugin.video.hbogoeu/hbogolib/base.py
@@ -92,6 +92,7 @@ class hbogo(object):
         content_id = None
         mode = None
         vote = None
+        exclude_list = None
 
         try:
             url = unquote(params["url"])
@@ -128,6 +129,15 @@ class hbogo(object):
             xbmc.log("[" + str(self.addon_id) + "] " + "ROUTER - vote warning: " + traceback.format_exc(),
                      xbmc.LOGDEBUG)
 
+        try:
+            exclude_list = str(params["exclude"])
+            exclude_list = [int(e) if e.isdigit() else e for e in exclude_list.split(',')]
+        except KeyError:
+            pass
+        except Exception:
+            xbmc.log("[" + str(self.addon_id) + "] " + "ROUTER - exclude list warning: " + traceback.format_exc(),
+                     xbmc.LOGDEBUG)
+
         if mode is None or url is None or len(url) < 1:
             self.start()
             self.handler.categories()
@@ -135,7 +145,10 @@ class hbogo(object):
         elif mode == HbogoConstants.ACTION_LIST:
             self.start()
             self.handler.setDispCat(name)
-            self.handler.list(url)
+            if exclude_list is None:
+                self.handler.list(url)
+            else:
+                self.handler.list(url, False, exclude_list)
 
         elif mode == HbogoConstants.ACTION_SEASON:
             self.start()

--- a/plugin.video.hbogoeu/hbogolib/handler.py
+++ b/plugin.video.hbogoeu/hbogolib/handler.py
@@ -579,7 +579,7 @@ class HbogoHandler(object):
     def categories(self):
         pass
 
-    def list(self, url, simple=False):
+    def list(self, url, simple=False, exclude_list=None):
         pass
 
     def season(self, url):

--- a/plugin.video.hbogoeu/hbogolib/handlersp.py
+++ b/plugin.video.hbogoeu/hbogolib/handlersp.py
@@ -323,7 +323,7 @@ class HbogoHandler_sp(HbogoHandler):
             self.log('List pages calling next page... max: ' + str(max_items) + ' offset: ' + str(offset + max_items))
             self.list_pages(url, max_items, offset + max_items)
 
-    def list(self, url, simple=False):
+    def list(self, url, simple=False, exclude_list=None):
         if not self.chk_login():
             self.login()
         self.log("List: " + str(url))

--- a/plugin.video.hbogoeu/resources/settings.xml
+++ b/plugin.video.hbogoeu/resources/settings.xml
@@ -30,7 +30,7 @@
         <setting label="30732" type="bool" id="show_continue" default="true"/>
         <setting label="30729" type="bool" id="show_kids" default="true"/>
         <setting label="30737" type="bool" id="enforce_kids" default="false"/>
-        <setting label="30697" type="bool" id="group_home" default="false"/>
+        <setting label="30697" type="bool" id="group_home" default="true"/>
     </category>
     <!-- Streaming -->
     <category label="30660">


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: hGO EU
  - Add-on ID: plugin.video.hbogoeu
  - Version number: 2.7.0+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/arvvoid/plugin.video.hbogoeu
  

Simple, Kodi add-on to access HBO® Go EU content. (This add-on is not officially commissioned/supported by HBO®.)

Important, HBO® Go must be paid for!!!  You need a valid account!
Register on the official HBO® Go website for your region.

Read the disclaimer!

Curently support: Bosnia and Herzegovina, Bulgaria, Croatia, Czech Republic, Hungary, Macedonia, Montenegro, Polonia, Portugal, Romania, Serbia, Slovakia, Slovenija, Spain, Norway, Denmark, Sweden, Finland

To report bugs or request assistence with the add-on go to: https://github.com/arvvoid/plugin.video.hbogoeu
    

### Description of changes:


- Hot Fix: new retrieve method for home lists [EU region]
- This fix avoid the "a new version of the application should be used" error message coming from HBO Go
- The additional home lists (recommendation, featured, various editor lists, ecc... are fully functional again)
- Minor fixes
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
