### PR TITLE
[plugin.audio.radio_de@matrix] 3.0.6+matrix.1

### DIFF
--- a/plugin.audio.radio_de/addon.xml
+++ b/plugin.audio.radio_de/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.5+matrix.0">
+<addon id="plugin.audio.radio_de" name="Radio" provider-name="Tristan Fischer, enen92" version="3.0.6+matrix.1">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.xbmcswift2" version="19.0.4" />
@@ -12,10 +12,8 @@
         <source>https://github.com/XBMC-Addons/plugin.audio.radio_de</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=119362</forum>
         <license>GPL-2.0-only</license>
-        <news>v3.0.5+matrix.0 (8/12/2020)
-            [new] Add support to offscreen=True in Listitems
-            [cosmetics] License headers
-            [cleanup] Cleanup unused init files
+        <news>v3.0.6+matrix.1 (4/5/2021)
+            [new] Also set the station name property on the final resolved item
         </news>
         <summary lang="be_BY">Access &gt;30000 radio broadcasts</summary>
         <summary lang="ca_ES">accedeix a mes de 30000 emissores de radio</summary>

--- a/plugin.audio.radio_de/resources/lib/plugin.py
+++ b/plugin.audio.radio_de/resources/lib/plugin.py
@@ -520,17 +520,16 @@ def get_stream_url(station_id):
             current_track = station['current_track']
     if station:
         __log('get_stream_url result: %s' % stream_url)
-        return plugin.set_resolved_url(
-            listitem.ListItem(
-                label=station['name'],
-                label2=current_track,
-                path=stream_url,
-                icon=station['thumbnail'],
-                thumbnail=station['thumbnail'],
-                fanart=__get_plugin_fanart(),
-                offscreen=True
-            )
-        )
+        resolved_listitem = listitem.ListItem(
+                        label=station['name'],
+                        label2=current_track,
+                        path=stream_url,
+                        icon=station['thumbnail'],
+                        thumbnail=station['thumbnail'],
+                        fanart=__get_plugin_fanart(),
+                        offscreen=True)
+        resolved_listitem.set_property('StationName', station['name'])
+        return plugin.set_resolved_url(resolved_listitem)
 
 
 def __add_stations(stations, add_custom=False, browse_more=None):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Radio
  - Add-on ID: plugin.audio.radio_de
  - Version number: 3.0.6+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/XBMC-Addons/plugin.audio.radio_de
  
Music plugin to access over 30000 international radio broadcasts from rad.io, radio.de, radio.fr, radio.pt and radio.es[CR]Currently features[CR]- English, german, french translated[CR]- Browse stations by location, genre, topic, country, city and language[CR]- Search for stations[CR]- 115 genres, 59 topics, 94 countrys, 1010 citys, 63 languages

### Description of changes:

v3.0.6+matrix.1 (4/5/2021)
            [new] Also set the station name property on the final resolved item
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
