### PR TITLE
[plugin.video.vtm.go@leia] 1.2.6

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.2.6](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.6) (2021-05-04)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.5...v1.2.6)
+
+**Merged pull requests:**
+
+- Fix authentication and use API v10 [\#276](https://github.com/add-ons/plugin.video.vtm.go/pull/276) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.2.5](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.5) (2021-03-22)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.4...v1.2.5)
@@ -7,8 +15,8 @@
 **Implemented enhancements:**
 
 - Improve artwork [\#269](https://github.com/add-ons/plugin.video.vtm.go/pull/269) ([michaelarnauts](https://github.com/michaelarnauts))
-- Add more metadata to movies and programs [\#267](https://github.com/add-ons/plugin.video.vtm.go/pull/267) ([michaelarnauts](https://github.com/michaelarnauts))
 - Don't depend on credentials to populate IPTV Manager data [\#266](https://github.com/add-ons/plugin.video.vtm.go/pull/266) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add more metadata to movies and programs [\#267](https://github.com/add-ons/plugin.video.vtm.go/pull/267) ([michaelarnauts](https://github.com/michaelarnauts))
 
 **Fixed bugs:**
 

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.5" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.6" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,9 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.5 (2021-03-22)
-- Fix issue with authentication for new users.
-- Improve descriptions and images.</news>
+	<news>v1.2.6 (2021-05-04)
+- Fix authentication and use API v10.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/modules/authentication.py
+++ b/plugin.video.vtm.go/resources/lib/modules/authentication.py
@@ -8,6 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.vtmgo.vtmgo import ApiUpdateRequired, VtmGo
 from resources.lib.vtmgo.vtmgoauth import InvalidLoginException, LoginErrorException, VtmGoAuth
+from resources.lib.vtmgo.exceptions import InvalidTokenException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ class Authentication:
                                kodiutils.get_tokens_path())
         self._vtm_go = VtmGo(self._auth)
 
-    def select_profile(self, key=None):
+    def select_profile(self, key=None):  # pylint: disable=too-many-return-statements
         """ Show your profiles
         :type key: str
         """
@@ -33,6 +34,11 @@ class Authentication:
         except InvalidLoginException:
             kodiutils.ok_dialog(message=kodiutils.localize(30203))  # Your credentials are not valid!
             kodiutils.open_settings()
+            return
+
+        except InvalidTokenException:
+            self._auth.delete_cache()
+            kodiutils.redirect(kodiutils.url_for('show_main_menu'))
             return
 
         except LoginErrorException as exc:

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -16,8 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTMGO/9.10 (be.vmma.vtm.zenderapp; build:13200; Android 25) okhttp/4.9.0',
-    'x-app-version': '9',
+    'User-Agent': 'VTMGO/10.3 (be.vmma.vtm.zenderapp; build:13259; Android 25) okhttp/4.9.0',
+    'x-app-version': '10',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '25',
@@ -159,7 +159,7 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
         headers = {}
 
     if token:
-        headers['x-dpp-jwt'] = token
+        headers['lfvp-auth'] = token
 
     if profile:
         headers['x-dpp-profile'] = profile

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
@@ -213,13 +213,12 @@ class VtmGoAuth:
         id_token = params['id_token'][0]
 
         # Okay, final stage. We now need to authorize our id_token so we get a valid JWT.
-        response = util.http_post('https://lfvp-api.dpgmedia.net/authorize/idToken', data={
-            'clientId': 'vtm-go-android',
-            'pipIdToken': id_token,
+        response = util.http_post('https://lfvp-api.dpgmedia.net/vtmgo/tokens', data={
+            'idToken': id_token,
         })
 
         # Get JWT from reply
-        self._account.jwt_token = json.loads(response.text).get('jsonWebToken')
+        self._account.jwt_token = json.loads(response.text).get('lfvpToken')
 
         self._save_cache()
 
@@ -301,3 +300,7 @@ class VtmGoAuth:
 
         with open(os.path.join(self._token_path, self.TOKEN_FILE), 'w') as fdesc:
             json.dump(self._account.__dict__, fdesc, indent=2)
+
+    def delete_cache(self):
+        """ Delete tokens from cache """
+        os.remove(os.path.join(self._token_path, self.TOKEN_FILE))


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.6
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.6 (2021-05-04)
- Fix authentication and use API v10.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
