### PR TITLE
[plugin.video.hbogoeu@leia] 2.7.1

### DIFF
--- a/plugin.video.hbogoeu/README.md
+++ b/plugin.video.hbogoeu/README.md
@@ -2,7 +2,6 @@
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/arvvoid/plugin.video.hbogoeu)](https://github.com/arvvoid/plugin.video.hbogoeu/blob/master/README.md#install-instructions) 
 [![Kodi Version](https://img.shields.io/badge/kodi-18%20%7C%2019%2B-blue)](https://kodi.tv/)
 [![All Contributors](https://img.shields.io/badge/all_contributors-37-orange.svg?style=flat-square)](#contributors-)
-[![HitCount](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu.svg)](http://hits.dwyl.io/arvvoid/pluginvideohbogoeu)
 [![HowToSupport](https://img.shields.io/badge/How%20to-support%20the%20add--on-orange)](https://github.com/arvvoid/plugin.video.hbogoeu#support-the-add-on)
 
 

--- a/plugin.video.hbogoeu/addon.xml
+++ b/plugin.video.hbogoeu/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.7.0">
+<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.7.1">
   <requires>
     <import addon="xbmc.python" version="2.26.0" />
     <import addon="script.module.kodi-six" version="0.1.0" />
@@ -44,10 +44,7 @@ If an official app is available for your platform, use it instead of this.
     <source>https://github.com/arvvoid/plugin.video.hbogoeu</source>
     <website>https://arvvoid.github.io/plugin.video.hbogoeu</website>
     <news>
-- Hot Fix: new retrieve method for home lists [EU region]
-- This fix avoid the "a new version of the application should be used" error message coming from HBO Go
-- The additional home lists (recommendation, featured, various editor lists, ecc... are fully functional again)
-- Minor fixes
+- Hot Fix: fix kids category [EU region]
     </news>
     <assets>
      <icon>resources/icon.png</icon>

--- a/plugin.video.hbogoeu/hbogolib/handlereu.py
+++ b/plugin.video.hbogoeu/hbogolib/handlereu.py
@@ -144,7 +144,7 @@ class HbogoHandler_eu(HbogoHandler):
         self.API_URL_AUTH_OPERATOR = 'https://' + self.COUNTRY_CODE_SHORT + 'gwapi.hbogo.eu/v2.1/Authentication/json/' + self.LANGUAGE_CODE + '/' + \
                                      self.API_PLATFORM
         self.API_URL_CUSTOMER_GROUP = 'https://' + self.API_HOST + '/v8/CustomerGroup/json/' + self.LANGUAGE_CODE + '/' + self.API_PLATFORM + '/'
-        self.API_URL_GROUP = 'https://' + self.API_HOST + '/v8/Group/json/' + self.LANGUAGE_CODE + '/ANMO/'
+        self.API_URL_GROUP = 'https://' + self.API_HOST + '/v8/Group/json/' + self.LANGUAGE_CODE + '/APTV/'
         self.API_URL_GROUPS = 'https://' + self.API_HOST + '/v8/Groups/json/' + self.LANGUAGE_CODE + '/ANMO/0/True'
         self.API_URL_MENU = 'https://' + self.API_HOST + '/v8/Menu/json/ENG/APTV/0/False'
         self.API_URL_CONTENT = 'https://' + self.API_HOST + '/v8/Content/json/' + self.LANGUAGE_CODE + '/' + self.API_PLATFORM + '/'

--- a/plugin.video.hbogoeu/main.py
+++ b/plugin.video.hbogoeu/main.py
@@ -6,9 +6,10 @@
 from __future__ import absolute_import, division
 
 import sys
-from hbogolib.base import hbogo
+
 from kodi_six import xbmc, xbmcaddon  # type: ignore
 
+from hbogolib.base import hbogo
 
 # Setup plugin
 PLUGIN_HANDLE = int(sys.argv[1])
@@ -16,9 +17,9 @@ BASE_URL = sys.argv[0]
 # We use string slicing to trim the leading ? from the plugin call paramstring
 REQUEST_PARAMS = sys.argv[2][1:]
 
-
 if __name__ == '__main__':
     add_on = xbmcaddon.Addon()
-    xbmc.log("[" + add_on.getAddonInfo('id') + "]  STARTING VERSION: " + add_on.getAddonInfo('version'), xbmc.LOGDEBUG)
+    xbmc.log("[" + add_on.getAddonInfo('id') + "]  STARTING VERSION: " + add_on.getAddonInfo('version') + " provided by " + add_on.getAddonInfo('author'),
+             xbmc.LOGDEBUG)
     addon_main = hbogo(PLUGIN_HANDLE, BASE_URL)
     addon_main.router(REQUEST_PARAMS)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: hGO EU
  - Add-on ID: plugin.video.hbogoeu
  - Version number: 2.7.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/arvvoid/plugin.video.hbogoeu
  

Simple, Kodi add-on to access HBO® Go EU content. (This add-on is not officially commissioned/supported by HBO®.)

Important, HBO® Go must be paid for!!!  You need a valid account!
Register on the official HBO® Go website for your region.

Read the disclaimer!

Curently support: Bosnia and Herzegovina, Bulgaria, Croatia, Czech Republic, Hungary, Macedonia, Montenegro, Polonia, Portugal, Romania, Serbia, Slovakia, Slovenija, Spain, Norway, Denmark, Sweden, Finland

To report bugs or request assistence with the add-on go to: https://github.com/arvvoid/plugin.video.hbogoeu
    

### Description of changes:


- Hot Fix: fix kids category [EU region]
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
