### PR TITLE
[plugin.audio.podcasts] 2.0.1

### DIFF
--- a/plugin.audio.podcasts/addon.xml
+++ b/plugin.audio.podcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.0.0" provider-name="Heckie">
+<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.0.1" provider-name="Heckie">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.requests" version="2.25.1" />
@@ -18,7 +18,10 @@
 		<website>https://github.com/Heckie75/kodi-addon-podcast</website>
 		<source>https://github.com/Heckie75/kodi-addon-podcast</source>
 		<news>
-v2.0.0 (2021-02-20)
+v2.0.1 (2021-05-12)
+- Bugfix for Kodi v19 which has no order by date. Only availble in Kodi v20
+
+v2.0.0 (2021-05-11)
 - Migration to Kodi 19 (Matrix)</news>
 		<assets>
 			<icon>resources/assets/icon.png</icon>


### PR DESCRIPTION
### Description

Unfortunately the previous code uses a method `setDateTime` of listitem which is available in Kodi v20 but not in v19.x. This has been fixed to that addon also works with v19.x. 

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0