### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.3+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.3 (2021-05-13)
+- Fix watching age restricted content (@mediaminister)
+
 ### v2.5.2 (2021-04-21)
 - Fix broken menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.2+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.3+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.2 (2021-05-13)
+- Fix watching age restricted content
+
 v2.5.2 (2021-04-21)
 - Fix broken menu listings
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -1042,3 +1042,7 @@ msgstr ""
 msgctxt "#30989"
 msgid "Failed to load a compatible stream, please try toggling 'Use Widevine DRM' in the add-on Playback settings."
 msgstr ""
+
+msgctxt "#30990"
+msgid "This program cannot be played. Your VRT NU account is not allowed to access 12+ content. Please check your VRT NU account details at https://www.vrt.be/vrtnu/"
+msgstr ""

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -1042,3 +1042,7 @@ msgstr "InputStream Adaptive is niet geïnstalleerd, daarom kan het pauzeren en 
 msgctxt "#30989"
 msgid "Failed to load a compatible stream, please try toggling 'Use Widevine DRM' in the add-on Playback settings."
 msgstr "Kan geen compatibele stream laden, probeer 'Gebruik Widevine DRM' in of uit te schakelen in de add-on afspeelinstellingen."
+
+msgctxt "#30990"
+msgid "This program cannot be played. Your VRT NU account is not allowed to access 12+ content. Please check your VRT NU account details at https://www.vrt.be/vrtnu/"
+msgstr "Dit programma kan niet afgespeeld worden. Je VRT NU-account heeft geen toegang tot 12+ content. Controleer je VRT NU-account details op https://www.vrt.be/vrtnu/"

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -277,12 +277,10 @@ FEATURED = [
     dict(name='Exclusief online', id='exclusief-online', msgctxt=30100),
     dict(name='Volledig seizoen', id='volledig-seizoen', msgctxt=30101),
     dict(name='Volledige reeks', id='volledige-reeks', msgctxt=30102),
-    dict(name='Uit het archief', id='uit-het-archief', msgctxt=30103),
     # Inhoudsgerelateerd
     dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
     # Thema
     dict(name='Klimaat', id='klimaat', msgctxt=30129),
-    dict(name='Koers', id='koers', msgctxt=30130),
 ]
 
 RELATIVE_DATES = [

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -313,6 +313,9 @@ class StreamService:
             container_reload()
             message = localize(30987)  # No stream found
             return self._handle_stream_api_error(message, stream_json)
+        if stream_json.get('code') == 'ERROR_AGE_RESTRICTED':
+            message = localize(30990)  # Cannot be played, VRT NU account not allowed to access 12+ content
+            return self._handle_stream_api_error(message, stream_json)
 
         # Failed to get stream, handle error
         message = localize(30954)  # Whoops something went wrong

--- a/plugin.video.vrt.nu/resources/lib/tokenresolver.py
+++ b/plugin.video.vrt.nu/resources/lib/tokenresolver.py
@@ -288,7 +288,8 @@ class TokenResolver:
                 delete_cache(cache_file, self._TOKEN_CACHE_DIR)
                 xvrttoken = self.get_token('X-VRT-Token', 'roaming')
             elif variant == 'ondemand':
-                xvrttoken = self.get_token('X-VRT-Token')
+                # We need a user X-VRT-Token because the birthdate in the VRT NU profile is checked when watching age restricted content
+                xvrttoken = self.get_token('X-VRT-Token', 'user')
             if xvrttoken is None:
                 return None
             payload = dict(identityToken=xvrttoken)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu

v2.4.5 (2021-02-05)
- Fix watching livestreams with DRM enabled
- Warn user that InputStream Adaptive is needed for timeshifting

v2.4.4 (2021-01-25)
- Fix watching VRT NU abroad

v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support

v2.4.0 (2020-07-18)
- Show error messages when connections fail
- Improve user authentication cache
- Fix missing "Worldview" category
- Improve playing programs using the TV guide
- Improve IPTV Manager support
- Add user setting to update the VRT NU add-on easily
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
