### PR TITLE
[plugin.audio.podcasts] 2.0.2

### DIFF
--- a/plugin.audio.podcasts/addon.xml
+++ b/plugin.audio.podcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.0.1" provider-name="Heckie">
+<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.0.2" provider-name="Heckie">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.requests" version="2.25.1" />
@@ -18,6 +18,12 @@
 		<website>https://github.com/Heckie75/kodi-addon-podcast</website>
 		<source>https://github.com/Heckie75/kodi-addon-podcast</source>
 		<news>
+v2.0.2 (2021-05-14)
+- Bugfix according missing HTTP header and improved exception handling:
+  - see https://github.com/Heckie75/kodi-addon-podcast/issues/4
+  - see https://github.com/Heckie75/kodi-addon-podcast/issues/5
+- new setting for anchor for latest item in order to turn it on/off   
+
 v2.0.1 (2021-05-12)
 - Bugfix for Kodi v19 which has no order by date. Only availble in Kodi v20
 

--- a/plugin.audio.podcasts/resources/language/resource.language.de_de/strings.po
+++ b/plugin.audio.podcasts/resources/language/resource.language.de_de/strings.po
@@ -140,3 +140,15 @@ msgstr "Podcast 9"
 msgctxt "#32040"
 msgid "Podcast 10"
 msgstr "Podcast 10"
+
+msgctxt "#32050"
+msgid "General"
+msgstr "Allgemein"
+
+msgctxt "#32051"
+msgid "Anchor for most recent podcast, e.g. for bookmarking"
+msgstr "Anker für neueste Sendung, z.B. zum Bookmarken"
+
+msgctxt "#32052"
+msgid "Newest episode"
+msgstr "neueste Sendung"

--- a/plugin.audio.podcasts/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.audio.podcasts/resources/language/resource.language.en_gb/strings.po
@@ -140,3 +140,15 @@ msgstr "Podcast 9"
 msgctxt "#32040"
 msgid "Podcast 10"
 msgstr "Podcast 10"
+
+msgctxt "#32050"
+msgid "General"
+msgstr "General"
+
+msgctxt "#32051"
+msgid "Anchor for most recent podcast, e.g. for bookmarking"
+msgstr "Anchor for most recent podcast, e.g. for bookmarking"
+
+msgctxt "#32052"
+msgid "Newest episode"
+msgstr "Newest episode"

--- a/plugin.audio.podcasts/resources/settings.xml
+++ b/plugin.audio.podcasts/resources/settings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
 
+  <category label="32050">
+    <setting label="32051" type="bool" id="anchor" default="false" />
+  </category>
+
   <category label="32021">
 
     <setting label="32011" type="file" id="opml_file_0" />


### PR DESCRIPTION
### Description
- Bugfix according missing HTTP header and improved exception handling:
  - see https://github.com/Heckie75/kodi-addon-podcast/issues/4
  - see https://github.com/Heckie75/kodi-addon-podcast/issues/5
- new setting for anchor for latest item in order to turn it on/off 
 
### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0