### PR TITLE
[plugin.video.nhlgcl@matrix] 2021.5.17+matrix.1

### DIFF
--- a/plugin.video.nhlgcl/addon.xml
+++ b/plugin.video.nhlgcl/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2021.3.23+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2021.5.17+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -20,8 +20,7 @@
             restrictions apply, including national blackouts.
         </disclaimer>
         <news>
-            - Fix for past game not showing in Kodi 19 (thanks mrawji)
-            - Squashed some bugs and other minor fixes
+            - Fix games not showing up because OT field missing
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.nhlgcl/resources/lib/nhl_tv.py
+++ b/plugin.video.nhlgcl/resources/lib/nhl_tv.py
@@ -107,10 +107,14 @@ def create_game_listitem(game, game_day, show_date=False):
     else:
         name = '%s %s - %s at %s - %s' % \
                (game_line_header, away_team, game['teams']['away']['score'], home_team, game['teams']['home']['score'])
-
-        desc = '%s %s-%s-%s\n%s %s-%s-%s' % (away_team, str(away_record['wins']), str(away_record['losses']),
-                                             str(away_record['ot']), home_team, str(home_record['wins']),
-                                             str(home_record['losses']), str(home_record['ot']))
+        away_wins = away_record['wins'] if 'wins' in away_record else '0'
+        away_losses = away_record['losses'] if 'losses' in away_record else '0'
+        away_ot = away_record['ot'] if 'ot' in away_record else '0'
+        home_wins = home_record['wins'] if 'wins' in home_record else '0'
+        home_losses = home_record['losses'] if 'losses' in home_record else '0'
+        home_ot = home_record['ot'] if 'ot' in home_record else '0'
+        desc = '%s %s-%s-%s\n%s %s-%s-%s' % (away_team, away_wins, away_losses, away_ot,
+                                             home_team, home_wins, home_losses, home_ot)
 
     fanart = 'http://nhl.bamcontent.com/images/arena/default/%s@2x.jpg' % home['id']
     try:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NHL TV™
  - Add-on ID: plugin.video.nhlgcl
  - Version number: 2021.5.17+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nhlgcl
  
With NHL.TV you can access revolutionary 60fps (frames per second) video through Kodi
        

### Description of changes:


            - Fix games not showing up because OT field missing
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
