### PR TITLE
[plugin.video.vtm.go@leia] 1.2.7

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,10 +1,21 @@
 # Changelog
 
+## [v1.2.7](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.7) (2021-05-25)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.6...v1.2.7)
+
+**Implemented enhancements:**
+
+- Remove all default\_KIDs from MPEG-DASH manifest [\#287](https://github.com/add-ons/plugin.video.vtm.go/pull/287) ([mediaminister](https://github.com/mediaminister))
+- Remove bad default\_kid from MPD manifest [\#286](https://github.com/add-ons/plugin.video.vtm.go/pull/286) ([mediaminister](https://github.com/mediaminister))
+- Allow to clear tokens from settings [\#285](https://github.com/add-ons/plugin.video.vtm.go/pull/285) ([michaelarnauts](https://github.com/michaelarnauts))
+- Improve detection of outdated auth tokens [\#282](https://github.com/add-ons/plugin.video.vtm.go/pull/282) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.2.6](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.6) (2021-05-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.5...v1.2.6)
 
-**Merged pull requests:**
+**Fixed bugs:**
 
 - Fix authentication and use API v10 [\#276](https://github.com/add-ons/plugin.video.vtm.go/pull/276) ([mediaminister](https://github.com/mediaminister))
 
@@ -14,8 +25,8 @@
 
 **Implemented enhancements:**
 
-- Improve artwork [\#269](https://github.com/add-ons/plugin.video.vtm.go/pull/269) ([michaelarnauts](https://github.com/michaelarnauts))
 - Don't depend on credentials to populate IPTV Manager data [\#266](https://github.com/add-ons/plugin.video.vtm.go/pull/266) ([michaelarnauts](https://github.com/michaelarnauts))
+- Improve artwork [\#269](https://github.com/add-ons/plugin.video.vtm.go/pull/269) ([michaelarnauts](https://github.com/michaelarnauts))
 - Add more metadata to movies and programs [\#267](https://github.com/add-ons/plugin.video.vtm.go/pull/267) ([michaelarnauts](https://github.com/michaelarnauts))
 
 **Fixed bugs:**
@@ -343,7 +354,6 @@
 - separate mpeg dash manifest and api json downloads [\#32](https://github.com/add-ons/plugin.video.vtm.go/pull/32) ([mediaminister](https://github.com/mediaminister))
 - Add proxy support [\#31](https://github.com/add-ons/plugin.video.vtm.go/pull/31) ([dagwieers](https://github.com/dagwieers))
 - Assorted set of fixes [\#30](https://github.com/add-ons/plugin.video.vtm.go/pull/30) ([dagwieers](https://github.com/dagwieers))
-- Add days remaining to plot [\#27](https://github.com/add-ons/plugin.video.vtm.go/pull/27) ([michaelarnauts](https://github.com/michaelarnauts))
 - Fix ordering. [\#25](https://github.com/add-ons/plugin.video.vtm.go/pull/25) ([michaelarnauts](https://github.com/michaelarnauts))
 - Add '\* All seasons' support [\#24](https://github.com/add-ons/plugin.video.vtm.go/pull/24) ([dagwieers](https://github.com/dagwieers))
 - Assorted list of improvements [\#21](https://github.com/add-ons/plugin.video.vtm.go/pull/21) ([dagwieers](https://github.com/dagwieers))

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.6" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.7" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,8 +25,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.6 (2021-05-04)
-- Fix authentication and use API v10.</news>
+	<news>v1.2.7 (2021-05-25)
+- Improve authentication.
+- Improve playback with new version of Inputstream Adaptive.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
@@ -265,6 +265,10 @@ msgctxt "#30705"
 msgid "The VTM GO Service has been updated, but this add-on hasn't been modified yet for these changes. Please check for an update."
 msgstr ""
 
+msgctxt "#30706"
+msgid "The authentication tokens are removed."
+msgstr ""
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr ""
@@ -505,4 +509,12 @@ msgstr ""
 
 msgctxt "#30893"
 msgid "Open Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30894"
+msgid "Authentication"
+msgstr ""
+
+msgctxt "#30895"
+msgid "Clear authentication tokens…"
 msgstr ""

--- a/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
@@ -266,6 +266,10 @@ msgctxt "#30705"
 msgid "The VTM GO Service has been updated, but this add-on hasn't been modified yet for these changes. Please check for an update."
 msgstr "De VTM GO Service is geüpdate, maar deze add-on is helaas nog niet aangepast hiervoor. Gelieve te controleren of er een update beschikbaar is."
 
+msgctxt "#30706"
+msgid "The authentication tokens are removed."
+msgstr "De authenticatietokens zijn gewist."
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
@@ -507,3 +511,11 @@ msgstr "Installeer Kodi Logfile Uploader…"
 msgctxt "#30893"
 msgid "Open Kodi Logfile Uploader…"
 msgstr "Open Kodi Logfile Uploader…"
+
+msgctxt "#30894"
+msgid "Authentication"
+msgstr "Authenticatie"
+
+msgctxt "#30895"
+msgid "Clear authentication tokens…"
+msgstr "Verwijder authenticatietokens…"

--- a/plugin.video.vtm.go/resources/lib/addon.py
+++ b/plugin.video.vtm.go/resources/lib/addon.py
@@ -69,6 +69,13 @@ def select_profile(key=None):
     Authentication().select_profile(key)
 
 
+@routing.route('/auth/clear-tokens')
+def auth_clear_tokens():
+    """ Update the metadata for the listings (called from settings) """
+    from resources.lib.modules.authentication import Authentication
+    Authentication().clear_tokens()
+
+
 @routing.route('/channels')
 def show_channels():
     """ Shows Live TV channels """

--- a/plugin.video.vtm.go/resources/lib/modules/authentication.py
+++ b/plugin.video.vtm.go/resources/lib/modules/authentication.py
@@ -37,8 +37,8 @@ class Authentication:
             return
 
         except InvalidTokenException:
-            self._auth.delete_cache()
-            kodiutils.redirect(kodiutils.url_for('show_main_menu'))
+            self._auth.logout()
+            kodiutils.redirect(kodiutils.url_for('select_profile'))
             return
 
         except LoginErrorException as exc:
@@ -91,6 +91,11 @@ class Authentication:
         ]
 
         kodiutils.show_listing(listing, sort=['unsorted'], category=30057)  # Select Profile
+
+    def clear_tokens(self):
+        """ Clear the authentication tokens """
+        self._auth.logout()
+        kodiutils.notification(message=kodiutils.localize(30706))
 
     @staticmethod
     def _get_profile_name(profile):

--- a/plugin.video.vtm.go/resources/settings.xml
+++ b/plugin.video.vtm.go/resources/settings.xml
@@ -59,5 +59,7 @@
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
         <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
         <setting label="30893" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
+        <setting label="30894" type="lsep"/> <!-- Authentication -->
+        <setting label="30895" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/auth/clear-tokens)"/>
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.7
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.7 (2021-05-25)
- Improve authentication.
- Improve playback with new version of Inputstream Adaptive.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
