### PR TITLE
[plugin.video.vtm.go@leia] 1.2.8

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.2.8](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.8) (2021-06-10)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.7...v1.2.8)
+
+**Fixed bugs:**
+
+- Fix authentication [\#291](https://github.com/add-ons/plugin.video.vtm.go/pull/291) ([michaelarnauts](https://github.com/michaelarnauts))
+- Set zero default value for season and episode [\#289](https://github.com/add-ons/plugin.video.vtm.go/pull/289) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.2.7](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.7) (2021-05-25)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.6...v1.2.7)
@@ -354,6 +363,7 @@
 - separate mpeg dash manifest and api json downloads [\#32](https://github.com/add-ons/plugin.video.vtm.go/pull/32) ([mediaminister](https://github.com/mediaminister))
 - Add proxy support [\#31](https://github.com/add-ons/plugin.video.vtm.go/pull/31) ([dagwieers](https://github.com/dagwieers))
 - Assorted set of fixes [\#30](https://github.com/add-ons/plugin.video.vtm.go/pull/30) ([dagwieers](https://github.com/dagwieers))
+- Add days remaining to plot [\#27](https://github.com/add-ons/plugin.video.vtm.go/pull/27) ([michaelarnauts](https://github.com/michaelarnauts))
 - Fix ordering. [\#25](https://github.com/add-ons/plugin.video.vtm.go/pull/25) ([michaelarnauts](https://github.com/michaelarnauts))
 - Add '\* All seasons' support [\#24](https://github.com/add-ons/plugin.video.vtm.go/pull/24) ([dagwieers](https://github.com/dagwieers))
 - Assorted list of improvements [\#21](https://github.com/add-ons/plugin.video.vtm.go/pull/21) ([dagwieers](https://github.com/dagwieers))

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.7" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.8" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,9 +25,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.7 (2021-05-25)
-- Improve authentication.
-- Improve playback with new version of Inputstream Adaptive.</news>
+	<news>v1.2.8 (2021-06-10)
+- Fix authentication.
+- Fix playing of certain episodes with bad metadata.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -198,7 +198,7 @@ class Season:
 class Episode:
     """ Defines an Episode """
 
-    def __init__(self, episode_id=None, program_id=None, program_name=None, number=None, season=None, name=None, description=None, poster=None, thumb=None,
+    def __init__(self, episode_id=None, program_id=None, program_name=None, number=0, season=0, name=None, description=None, poster=None, thumb=None,
                  fanart=None, duration=None, remaining=None, geoblocked=None, channel=None, legal=None, aired=None, progress=None, watched=False,
                  next_episode=None):
         """
@@ -206,7 +206,7 @@ class Episode:
         :type program_id: str
         :type program_name: str
         :type number: int
-        :type season: str
+        :type season: int
         :type name: str
         :type description: str
         :type poster: str
@@ -226,8 +226,8 @@ class Episode:
         self.episode_id = episode_id
         self.program_id = program_id
         self.program_name = program_name
-        self.number = int(number) if number else None
-        self.season = int(season) if season else None
+        self.number = int(number)
+        self.season = int(season)
         if number:
             self.name = re.compile('^%d. ' % number).sub('', name)  # Strip episode from name
         else:

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
@@ -222,10 +222,14 @@ class VtmGoAuth:
         if 'OIDC-999' in response.text:  # Ongeldige login.
             raise InvalidLoginException()
 
+        # Extract redirect
+        match = re.search(r"window.location.href = '([^']+)'", response.text)
+        if not match:
+            raise LoginErrorException(code=103)
+        redirect_url = match.group(1)
+
         # Follow login
-        response = util.http_get('https://login2.vtm.be/authorize/continue', params={
-            'client_id': 'vtm-go-android'
-        })
+        response = util.http_get(redirect_url)
 
         # We are redirected and our id_token is in the fragment of the redirected url
         params = parse_qs(urlparse(response.url).fragment)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.8
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.8 (2021-06-10)
- Fix authentication.
- Fix playing of certain episodes with bad metadata.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
