### PR TITLE
[plugin.video.youtube] 6.8.14+matrix.1

### DIFF
--- a/plugin.video.youtube/addon.xml
+++ b/plugin.video.youtube/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="6.8.13+matrix.1" provider-name="anxdpanic, bromix">
+<addon id="plugin.video.youtube" name="YouTube" version="6.8.14+matrix.1" provider-name="anxdpanic, bromix">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.six" version="1.11.0"/>
@@ -13,6 +13,11 @@
     <extension point="xbmc.python.module" library="resources/lib/"/>
     <extension point="xbmc.addon.metadata">
         <news>
+6.8.14
+[fixup] playback of some streams due to encoding issues
+[fixup] default player response type
+
+6.8.13
 [fix] player config and client discovery
 [fix] No Streams Found |contrib: 14mRh4X0r|
 [fix] capability map to contain unversioned capabilities |contrib: jmbreuer|

--- a/plugin.video.youtube/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/plugin.video.youtube/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -576,7 +576,7 @@ class VideoInfo(object):
 
     @staticmethod
     def get_player_response(html):
-        response = None
+        response = {}
 
         found = re.search(
                 r'ytInitialPlayerResponse\s*=\s*(?P<response>{.+?})\s*;\s*(?:var\s+meta|</script|\n)', html
@@ -769,9 +769,12 @@ class VideoInfo(object):
         meta_info['channel']['author'] = meta_info['channel']['author'].encode('raw_unicode_escape')
 
         if PY2:
-            meta_info['video']['title'] = meta_info['video']['title'].decode('utf-8')
-            meta_info['channel']['author'] = meta_info['channel']['author'].decode('utf-8')
-
+            try:
+                meta_info['video']['title'] = meta_info['video']['title'].decode('utf-8')
+                meta_info['channel']['author'] = meta_info['channel']['author'].decode('utf-8')
+            except UnicodeDecodeError:
+                meta_info['video']['title'] = meta_info['video']['title'].decode('raw_unicode_escape')
+                meta_info['channel']['author'] = meta_info['channel']['author'].decode('raw_unicode_escape')
         else:
             meta_info['video']['title'] = meta_info['video']['title'].decode('raw_unicode_escape')
             meta_info['channel']['author'] = meta_info['channel']['author'].decode('raw_unicode_escape')


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Sorry for the back to back update

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
