### PR TITLE
[plugin.video.tvvlaanderen@leia] 1.0.4

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.4](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.4) (2021-06-25)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.3...v1.0.4)
+
+**Fixed bugs:**
+
+- Set a user-agent [\#34](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/34) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.0.3](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.3) (2021-02-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.2...v1.0.3)

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.3" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.4" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -22,8 +22,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.3 (2021-02-04)
-- Add HTTP Proxy support.</news>
+        <news>v1.0.4 (2021-06-27)
+- Fix playback of some channels.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/lib/kodiutils.py
+++ b/plugin.video.tvvlaanderen/resources/lib/kodiutils.py
@@ -218,6 +218,7 @@ def play(stream, license_key=None, title=None, art_dict=None, info_dict=None, pr
     else:
         play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
     play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+    play_item.setProperty('inputstream.adaptive.stream_headers', 'user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36')
     play_item.setMimeType('application/dash+xml')
     play_item.setContentLookup(False)
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.4
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen
  
This add-on gives access to the live tv channels and the video-on-demand content available in your TV Vlaanderen subscription.

### Description of changes:

v1.0.4 (2021-06-27)
- Fix playback of some channels.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
