### PR TITLE
[plugin.video.vtm.go@matrix] 1.2.10+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.2.10](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.10) (2021-07-14)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.9...v1.2.10)
+
+**Implemented enhancements:**
+
+- Restore support for anvato streams and use a new API key [\#294](https://github.com/add-ons/plugin.video.vtm.go/pull/294) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Fix play from EPG by datetime [\#293](https://github.com/add-ons/plugin.video.vtm.go/pull/293) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.2.9](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.9) (2021-06-17)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.8...v1.2.9)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.9+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.10+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,8 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.9 (2021-06-17)
-- Fix playback of Video On Demand content.</news>
+	<news>v1.2.10 (2021-07-14)
+- Fix playback of advertisements on VOD streams</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoepg.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoepg.py
@@ -171,7 +171,7 @@ class VtmGoEpg:
 
         # Find a matching broadcast
         for broadcast in epg.broadcasts:
-            if timestamp <= broadcast.time < (broadcast.time + timedelta(seconds=broadcast.duration)):
+            if broadcast.time <= timestamp < (broadcast.time + timedelta(seconds=broadcast.duration)):
                 return broadcast
 
         return None


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.10+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.10 (2021-07-14)
- Fix playback of advertisements on VOD streams

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
