### PR TITLE
[plugin.video.cbcolympics] 2.0.0

### DIFF
--- a/plugin.video.cbcolympics/README.md
+++ b/plugin.video.cbcolympics/README.md
@@ -5,33 +5,6 @@ A Kodi/XBMC plugin for watching the CBC Olympics streams
 
 Behaviour
 ============
-When loading videos, if an English audio stream is available it prefers that.
+By default only the highest bitrate streams are used (typically 720p30 ~3 Mbit/s) however the addon features a setting that can be set to limit this in case you're on a limited bandwidth connection. Available stream choices are 3 Mbit/s (default), 2 Mbit/s, 1.2 Mbit/s, 700 kbit/s, 400 kbit/s, and 256 kbit/s. Incredibly, it's still watchable at the lowest setting though the resolution is 416x234.
 
-By default only the highest bitrate streams are used (typically 720p 3.4 Mbit/s) however the addon features a setting that can be set to limit this in case you're on a limited bandwidth connection. Available stream choices are 3.5 Mbit/s (default), 2.2 Mbit/s, 1.4 Mbit/s, 950 kbit/s, 600 kbit/s, 400 kbit/s, 250 kbit/s, and 150 kbit/s. Incredibly, it's still watchable at the lowest setting though the resolution is 256x144.
-
-Until this gets added to the official repository, installation must be done manually. Follow the steps below for a manual installation.
-
-To install
-============
-
-1. Download this .zip into your Kodi's downloads folder (/storage/downloads/)
-
-2. Navigate to Add-Ons
-![screenshot000](https://user-images.githubusercontent.com/31328055/36081530-0290d314-0f55-11e8-9ebd-f6e7d866ac84.png)
-
-3. Select the "Install" box icon at the top left of the Add-ons menu
-![screenshot001](https://user-images.githubusercontent.com/31328055/36081513-da9b30e8-0f54-11e8-95a0-ff5f0169a5bf.png)
-
-4. Select "Install from zip file"
-![screenshot002](https://user-images.githubusercontent.com/31328055/36081542-2e26b156-0f55-11e8-987a-b9a07275ca28.png)
-
-_The file selection dialog opens_
-
-5. Select Home folder
-![screenshot003](https://user-images.githubusercontent.com/31328055/36081543-300b03fa-0f55-11e8-98aa-9f25f161e8f6.png)
-
-6. Select downloads
-![screenshot004](https://user-images.githubusercontent.com/31328055/36081544-31c86a3e-0f55-11e8-8e4d-aee81531871b.png)
-
-7. Select the zip file and click OK to install
-![screenshot005](https://user-images.githubusercontent.com/31328055/36081548-3457e7de-0f55-11e8-94d1-86bc95f7794d.png)
+The best way to install this is from the official Kodi repository. If you need to install it manually, follow [the steps outlined in the Kodi documentation](https://kodi.wiki/view/Add-on_manager#How_to_install_from_a_ZIP_file).

--- a/plugin.video.cbcolympics/addon.xml
+++ b/plugin.video.cbcolympics/addon.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cbcolympics"
        name="CBC Olympics"
-       version="1.0.1"
+       version="2.0.0"
        provider-name="fourpointsix">
   <requires>
+    <!-- Enable this for Kodi 16.x through 18.x -->
     <import addon="xbmc.python" version="2.24.0"/>
+    <!-- Enable this for Kodi 19.x and newer -->
+    <!--<import addon="xbmc.python" version="3.0.0"/>-->
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
     <provides>video</provides>
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">CBC Olympics</summary>
-    <description lang="en">2018 Winter Olympic streams from the CBC. Streams are geo-blocked so you must be on a Canadian IP for this to work.</description>
+    <description lang="en">Tokyo 2020 Summer Olympics streams from the CBC. Streams are geo-blocked so you must be on a Canadian IP for this to work.</description>
     <platform>all</platform>
     <language>en</language>
-    <news>v1.0.1
-- Added bitrate limit setting
-- Changed Python dependency to 2.24 for Kodi 16 compatibility
-- Added durations to video listing
-- Added start times to upcoming events</news>
+    <news>v2.0.0 (2021-07-29)
+- Re-written for Tokyo 2020</news>
+    <assets>
+      <icon>icon.png</icon>
+      <fanart>fanart.jpg</fanart>
+    </assets>
   </extension>
-  <assets>
-    <icon>icon.png</icon>
-    <fanart>fanart.jpg</fanart>
-  </assets>
 </addon>

--- a/plugin.video.cbcolympics/changelog.txt
+++ b/plugin.video.cbcolympics/changelog.txt
@@ -6,3 +6,6 @@ v1.0.1
 - Changed Python dependency to 2.24 for Kodi 16 compatibility
 - Added durations to video listing
 - Added start times to upcoming events
+
+v2.0.0
+- Re-written for the Tokyo 2020 Summer Olympics

--- a/plugin.video.cbcolympics/resources/language/English/strings.po
+++ b/plugin.video.cbcolympics/resources/language/English/strings.po
@@ -4,188 +4,212 @@
 msgid ""
 msgstr ""
 
+# General
+msgctxt "#30999"
+msgid "CBC Olympics"
+msgstr ""
+
 # Sport names
+msgctxt "#30000"
+msgid "All Sports"
+msgstr ""
+
 msgctxt "#30001"
-msgid "Alpine Skiing"
+msgid "Artistic Swimming"
 msgstr ""
 
 msgctxt "#30002"
-msgid "Biathlon"
+msgid "Archery"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Bobsleigh"
+msgid "Badminton"
 msgstr ""
 
 msgctxt "#30004"
-msgid "Curling"
+msgid "Baseball"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Cross Country"
+msgid "Basketball"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Figure Skating"
+msgid "Beach Volleyball"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Freestyle Skiing"
+msgid "Boxing"
 msgstr ""
 
 msgctxt "#30008"
-msgid "Hockey"
+msgid "Canoe / Kayak"
 msgstr ""
 
 msgctxt "#30009"
-msgid "Luge"
+msgid "Cycling"
 msgstr ""
 
 msgctxt "#30010"
-msgid "Nordic Combined"
+msgid "Diving"
 msgstr ""
 
 msgctxt "#30011"
-msgid "Snowboard"
+msgid "Equestrian"
 msgstr ""
 
 msgctxt "#30012"
-msgid "Ski Jumping"
+msgid "Fencing"
 msgstr ""
 
 msgctxt "#30013"
-msgid "Skeleton"
+msgid "Field Hockey"
 msgstr ""
 
 msgctxt "#30014"
-msgid "Speed Skating"
+msgid "Golf"
 msgstr ""
 
 msgctxt "#30015"
-msgid "Short Track"
+msgid "Gymnastics"
 msgstr ""
 
-# Day names
-msgctxt "#30099"
-msgid "Feb 7-8, Olympic Day -1"
+msgctxt "#30016"
+msgid "Handball"
 msgstr ""
 
-msgctxt "#30100"
-msgid "Feb 8-9, Olympic Day 0"
+msgctxt "#30017"
+msgid "Judo"
 msgstr ""
 
-msgctxt "#30101"
-msgid "Feb 9-10, Olympic Day 1,"
+msgctxt "#30018"
+msgid "Karate"
 msgstr ""
 
-msgctxt "#30102"
-msgid "Feb 10-11, Olympic Day 2"
+msgctxt "#30019"
+msgid "Modern Pentathlon"
 msgstr ""
 
-msgctxt "#30103"
-msgid "Feb 11-12, Olympic Day 3"
+msgctxt "#30020"
+msgid "Rowing"
 msgstr ""
 
-msgctxt "#30104"
-msgid "Feb 12-13, Olympic Day 4"
+msgctxt "#30021"
+msgid "Rugby"
 msgstr ""
 
-msgctxt "#30105"
-msgid "Feb 13-14, Olympic Day 5"
+msgctxt "#30022"
+msgid "Sailing"
 msgstr ""
 
-msgctxt "#30106"
-msgid "Feb 14-15, Olympic Day 6"
+msgctxt "#30023"
+msgid "Shooting"
 msgstr ""
 
-msgctxt "#30107"
-msgid "Feb 15-16, Olympic Day 7"
+msgctxt "#30024"
+msgid "Skateboarding"
 msgstr ""
 
-msgctxt "#30108"
-msgid "Feb 16-17, Olympic Day 8"
+msgctxt "#30025"
+msgid "Soccer"
 msgstr ""
 
-msgctxt "#30109"
-msgid "Feb 17-18, Olympic Day 9"
+msgctxt "#30026"
+msgid "Softball"
 msgstr ""
 
-msgctxt "#30110"
-msgid "Feb 18-19, Olympic Day 10"
+msgctxt "#30027"
+msgid "Sport Climbing"
 msgstr ""
 
-msgctxt "#30111"
-msgid "Feb 19-20, Olympic Day 11"
+msgctxt "#30028"
+msgid "Surfing"
 msgstr ""
 
-msgctxt "#30112"
-msgid "Feb 20-21, Olympic Day 12"
+msgctxt "#30029"
+msgid "Swimming"
 msgstr ""
 
-msgctxt "#30113"
-msgid "Feb 21-22, Olympic Day 13"
+msgctxt "#30030"
+msgid "Table Tennis"
 msgstr ""
 
-msgctxt "#30114"
-msgid "Feb 22-23, Olympic Day 14"
+msgctxt "#30031"
+msgid "Taekwondo"
 msgstr ""
 
-msgctxt "#30115"
-msgid "Feb 23-24, Olympic Day 15"
+msgctxt "#30032"
+msgid "Tennis"
 msgstr ""
 
-msgctxt "#30116"
-msgid "Feb 24-25, Olympic Day 16"
+msgctxt "#30033"
+msgid "Track and Field"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Triathlon"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Volleyball"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Water Polo"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Weightlifting"
+msgstr ""
+
+msgctxt "#30038"
+msgid "Wrestling"
 msgstr ""
 
 # Static categories
 msgctxt "#30200"
-msgid "Condensed Events by Sport"
+msgid "Live Now & Upcoming"
 msgstr ""
 
 msgctxt "#30201"
-msgid "Condensed Events by Date"
+msgid "Replays"
 msgstr ""
 
 msgctxt "#30202"
-msgid "Full Event Replays by Sport"
+msgid "Sports"
 msgstr ""
 
 msgctxt "#30203"
-msgid "Full Event Replays by Date"
+msgid "Highlights"
 msgstr ""
 
 msgctxt "#30204"
-msgid "Highlights by Sport"
+msgid "Team Canada"
 msgstr ""
 
 msgctxt "#30205"
-msgid "Highlights by Date"
+msgid "Features - Kraft While You Were Sleeping"
 msgstr ""
 
 msgctxt "#30206"
-msgid "Must See"
+msgid "Features - Petro Canada The Bond"
 msgstr ""
 
 msgctxt "#30207"
-msgid "Schedule by Sport"
+msgid "Features - RBC Spotlight"
 msgstr ""
 
 msgctxt "#30208"
-msgid "Schedule by Date"
+msgid "Features - Toyota Breakthrough"
 msgstr ""
 
 msgctxt "#30209"
-msgid "What's on TV by Sport"
-msgstr ""
-
-msgctxt "#30210"
-msgid "What's on TV by Date"
+msgid "Features - VISA Olympic Moments"
 msgstr ""
 
 # General
 msgctxt "#30300"
-msgid "Root"
+msgid ""
 msgstr ""
 
 msgctxt "#30301"
@@ -208,6 +232,10 @@ msgctxt "#30305"
 msgid "Replay"
 msgstr ""
 
+msgctxt "#30306"
+msgid "{0} page {1}..."
+msgstr ""
+
 # Errors
 msgctxt "#30900"
 msgid "No URL or ID provided for video"
@@ -215,4 +243,24 @@ msgstr ""
 
 msgctxt "#30901"
 msgid "Invalid paramstring: {0}"
+msgstr ""
+
+msgctxt "#30902"
+msgid "The server did not return a valid stream. Please try again later."
+msgstr ""
+
+msgctxt "#30903"
+msgid "The server has denied the request. This is typically due to geoblocking. Be sure that you're on a Canadian IP address."
+msgstr ""
+
+msgctxt "#30904"
+msgid "The stream for this upcoming event is not yet available. Please wait and try again closer to its scheduled start time."
+msgstr ""
+
+msgctxt "#30905"
+msgid "This stream was not found."
+msgstr ""
+
+msgctxt "#30906"
+msgid "HTTP error {0}: {1}"
 msgstr ""

--- a/plugin.video.cbcolympics/resources/settings.xml
+++ b/plugin.video.cbcolympics/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
   <category label="30301">
-    <setting id="bitrateLimitKbps" type="select" label="30302" default="Unlimited" values="Unlimited|3500|2200|1400|950|600|400|250|150" />
+    <setting id="bitrateLimitKbps" type="select" label="30302" default="Unlimited" values="Unlimited|3000|2000|1200|700|400|256" />
   </category>
 </settings>


### PR DESCRIPTION
### Description
A near rewrite of my 2018 addon for watching CBC's Tokyo 2020 streams.
### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
