### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2021.7.31

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2020.11.6+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.7.31" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />
@@ -15,7 +15,7 @@
     <summary lang="en_GB">Watch NBCSN Live Extra</summary>
     <description lang="en_GB">NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network</description>
     <news>
-        - Updates for python 3 compatibility
+        - Fix for streams not playing
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.nbcsnliveextra/nbcsn.py
+++ b/plugin.video.nbcsnliveextra/nbcsn.py
@@ -86,6 +86,7 @@ def build_video_link(item):
         elif 'iosStreamUrl' in item['videoSources'][0]:
             url = item['videoSources'][0]['iosStreamUrl']
 
+    pid = item['pid']
     menu_name = item['title']
     title = menu_name
     desc = item['info']
@@ -116,12 +117,14 @@ def build_video_link(item):
 
     requestor_id = 'nbcsports'
     channel = ''
+
     # if 'requestorId' in item and item['requestorId'] != 'nbcentertainment':
     #     requestor_id = item['requestorId']
     # if 'channel' in item:
     #     channel = item['channel']
-
+    #
     stream_info = {
+        'pid': pid,
         'requestor_id': requestor_id,
         'channel': channel
     }
@@ -154,19 +157,15 @@ def build_video_link(item):
             add_dir(menu_name + ' ' + start_date, '/disabled', 0, imgurl, FANART, False, info)
 
 
-def sign_stream(stream_url, stream_name, stream_icon, requestor_id, channel):
-    SERVICE_VARS['requestor_id'] = requestor_id
-    # SERVICE_VARS['requestor_id'] = 'nbcsports'
+def sign_stream(stream_url, stream_name, stream_icon, pid):
+    SERVICE_VARS['requestor_id'] = 'nbcsports'
     resource_id = get_resource_id()
-    # resource_id = "<rss version='2.0'><channel><title>" + channel + "</title></channel></rss>"
     SERVICE_VARS['resource_id'] = urllib.quote(resource_id)
     adobe = ADOBE(SERVICE_VARS)
     if adobe.check_authn():
         if adobe.authorize():
-            #resource_id = get_resource_id()
             media_token = adobe.media_token()
-            stream_url = tv_sign(media_token, resource_id, stream_url)
-            #stream_url = set_stream_quality(stream_url)
+            stream_url = get_tokenized_url(media_token, resource_id, stream_url, pid)
             stream_url += "|User-Agent=" + UA_NBCSN
             play_stream(stream_url)
         else:
@@ -176,31 +175,35 @@ def sign_stream(stream_url, stream_name, stream_icon, requestor_id, channel):
         answer = dialog.yesno(LOCAL_STRING(30010), LOCAL_STRING(30011))
         if answer:
             adobe.register_device()
-            sign_stream(stream_url, stream_name, stream_icon, requestor_id, channel)
+            sign_stream(stream_url, stream_name, stream_icon, pid)
         else:
             sys.exit()
 
 
-def tv_sign(media_token, resource_id, stream_url):
-    url = 'http://sp.auth.adobe.com/tvs/v1/sign'
+def get_tokenized_url(media_token, resource_id, stream_url, pid):
+    url = 'https://token.playmakerservices.com/cdn'
     headers = {
         "Accept": "*/*",
         "Accept-Language": "en;q=1",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": UA_NBCSN
+        "Content-Type": "application/json",
+        "User-Agent": "okhttp/3.11.0"
     }
 
     payload = {
+        'resourceId': base64.b64encode(codecs.encode(resource_id)).decode("ascii"),
+        'requestorId': 'nbcsports',
+        'token': media_token,
         'cdn': 'akamai',
-        'mediaToken': media_token,
-        'resource': base64.b64encode(codecs.encode(resource_id)),
-        'url': stream_url
+        'url': stream_url,
+        'pid': pid,
+        'application': 'NBCSports',
+        'version': 'v1',
+        'platform': 'desktop'
     }
 
-    r = requests.post(url, headers=headers, cookies=load_cookies(), data=payload, verify=VERIFY)
+    r = requests.post(url, headers=headers, cookies=load_cookies(), json=payload, verify=VERIFY)
     save_cookies(r.cookies)
-
-    return r.text
+    return r.json()['tokenizedUrl']
 
 
 def logout():
@@ -240,6 +243,7 @@ mode = None
 icon_image = None
 requestor_id = ''
 channel = ''
+pid = ''
 
 if 'url' in params: url = urllib.unquote_plus(params["url"])
 if 'name' in params: name = urllib.unquote_plus(params["name"])
@@ -247,6 +251,7 @@ if 'mode' in params: mode = int(params["mode"])
 if 'icon_image' in params: icon_image = urllib.unquote_plus(params["icon_image"])
 if 'requestor_id' in params: requestor_id = urllib.unquote_plus(params['requestor_id'])
 if 'channel' in params: channel = urllib.unquote_plus(params['channel'])
+if 'pid' in params: pid = urllib.unquote_plus(params['pid'])
 
 if mode is None or url is None or len(url) < 1:
     categories()
@@ -258,7 +263,7 @@ elif mode == 4:
     scrape_videos(url)
 
 elif mode == 5:
-    sign_stream(url, name, icon_image, requestor_id, channel)
+    sign_stream(url, name, icon_image, pid)
 
 elif mode == 6:
     # Set quality level based on user settings

--- a/plugin.video.nbcsnliveextra/resources/globals.py
+++ b/plugin.video.nbcsnliveextra/resources/globals.py
@@ -207,7 +207,7 @@ def add_premium_link(name, link_url, icon, stream_info, fanart=None, info=None):
     ok = True
     u = sys.argv[0] + "?url=" + urllib.quote_plus(link_url) + "&mode=5&icon_image=" + urllib.quote_plus(
         icon) + "&requestor_id=" + urllib.quote_plus(stream_info['requestor_id']) + "&channel=" \
-        + urllib.quote_plus(stream_info['channel'])
+        + urllib.quote_plus(stream_info['channel']) + "&pid=" + urllib.quote_plus(stream_info['pid'])
 
     liz = xbmcgui.ListItem(name)
     if icon is None: icon = ICON


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2021.7.31
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix for streams not playing
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
