### PR TITLE
[plugin.video.cbcolympics] 2.1.0

### DIFF
--- a/plugin.video.cbcolympics/addon.xml
+++ b/plugin.video.cbcolympics/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cbcolympics"
        name="CBC Olympics"
-       version="2.0.0+matrix.1"
+       version="2.1.0+matrix.1"
        provider-name="fourpointsix">
   <requires>
     <!-- Enable this for Kodi 16.x through 18.x -->
@@ -20,7 +20,13 @@
     <license>GPL-3.0-only</license>
     <source>https://github.com/fourpointsix/plugin.video.cbcolympics</source>
     <news>v2.0.0 (2021-07-29)
-- Re-written for Tokyo 2020</news>
+- Re-written for Tokyo 2020
+
+v2.1.0 (2021-08-04)
+- Better handling of M3U8 files and bitrate selection since 7 Mbit 1080p streams were added.
+- More consistent handling of URLs containing Unicode characters
+- Added five more "features" categories
+</news>
     <assets>
       <icon>icon.png</icon>
       <fanart>fanart.jpg</fanart>

--- a/plugin.video.cbcolympics/changelog.txt
+++ b/plugin.video.cbcolympics/changelog.txt
@@ -9,3 +9,8 @@ v1.0.1
 
 v2.0.0
 - Re-written for the Tokyo 2020 Summer Olympics
+
+v2.1.0
+- Better handling of M3U8 files and bitrate selection since 7 Mbit 1080p streams were added.
+- More consistent handling of URLs containing Unicode characters
+- Added five more "features" categories

--- a/plugin.video.cbcolympics/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.cbcolympics/resources/language/resource.language.en_gb/strings.po
@@ -207,6 +207,26 @@ msgctxt "#30209"
 msgid "Features - VISA Olympic Moments"
 msgstr ""
 
+msgctxt "#30210"
+msgid "Features - Bell Faster Higher Stronger"
+msgstr ""
+
+msgctxt "#30211"
+msgid "Features - Sobeys Family Album"
+msgstr ""
+
+msgctxt "#30212"
+msgid "Features - Uber Go Getters"
+msgstr ""
+
+msgctxt "#30213"
+msgid "Features - OLG The Quest"
+msgstr ""
+
+msgctxt "#30214"
+msgid "Features - Sugoi Tokyo"
+msgstr ""
+
 # General
 msgctxt "#30300"
 msgid ""


### PR DESCRIPTION
### Description
- Better handling of M3U8 files and bitrate selection since 7 Mbit 1080p streams were added.
- More consistent handling of URLs containing Unicode characters
- Added five more "features" categories
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
