### PR TITLE
[plugin.video.vtm.go@leia] 1.2.11

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.2.11](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.11) (2021-08-12)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.10...v1.2.11)
+
+**Fixed bugs:**
+
+- Refresh token before trying to login again [\#297](https://github.com/add-ons/plugin.video.vtm.go/pull/297) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.2.10](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.10) (2021-07-14)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.9...v1.2.10)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.10" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.11" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,8 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.10 (2021-07-14)
-- Fix playback of advertisements on VOD streams</news>
+	<news>v1.2.11 (2021-08-12)
+- Fix authentication (Error 406) for existing users. There is still an issue with the login for new users, see issue #296 on GitHub for more information and a workaround.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
@@ -160,7 +160,12 @@ class VtmGoAuth:
         if new_hash:
             _LOGGER.debug('Credentials have changed, forcing a new login.')
             self._account.hash = new_hash
-            force = True
+            self._account.jwt_token = None
+            self._save_cache()
+
+        # If we have an (old) token, but it isn't valid anymore, refresh it.
+        if self._account.jwt_token and not self._account.is_valid_token():
+            self._android_refesh()
 
         # Use cached token if it is still valid
         if force or not self._account.is_valid_token():
@@ -196,6 +201,9 @@ class VtmGoAuth:
             'sdkVersion': '0.13.1',
             'state': 'dnRtLWdvLWFuZHJvaWQ=',  # vtm-go-android
             'redirect_uri': 'https://login2.vtm.be/continue',
+        }, headers={
+            'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0.1; MotoG3 Build/MPIS24.107-55-2-17; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/91.0.4472.88 Mobile Safari/537.36',
+            'X-Requested-With': 'be.vmma.vtm.zenderapp',
         })
 
         # Send login credentials
@@ -238,6 +246,20 @@ class VtmGoAuth:
         # Okay, final stage. We now need to authorize our id_token so we get a valid JWT.
         response = util.http_post('https://lfvp-api.dpgmedia.net/vtmgo/tokens', data={
             'idToken': id_token,
+        })
+
+        # Get JWT from reply
+        self._account.jwt_token = json.loads(response.text).get('lfvpToken')
+
+        self._save_cache()
+
+        return self._account
+
+    def _android_refesh(self):
+
+        # We can refresh our old token so it's valid again
+        response = util.http_post('https://lfvp-api.dpgmedia.net/vtmgo/tokens/refresh', data={
+            'lfvpToken': self._account.jwt_token,
         })
 
         # Get JWT from reply


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.11
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.11 (2021-08-12)
- Fix authentication (Error 406) for existing users. There is still an issue with the login for new users, see issue #296 on GitHub for more information and a workaround.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
