### PR TITLE
[plugin.audio.bbcpodcasts] 2.0.0

### DIFF
--- a/plugin.audio.bbcpodcasts/addon.xml
+++ b/plugin.audio.bbcpodcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.bbcpodcasts" name="BBC Podcasts" version="1.0.0" provider-name="Heckie">
+<addon id="plugin.audio.bbcpodcasts" name="BBC Podcasts" version="2.0.0" provider-name="Heckie">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" version="2.25.1" />
@@ -23,6 +23,12 @@
         <website>https://github.com/Heckie75/kodi-addon-bbc-podcasts</website>
         <source>https://github.com/Heckie75/kodi-addon-bbc-podcasts/tree/main/plugin.audio.bbcpodcasts</source>
         <news>
+v2.0.0 (2021-08-14)
+- Changes after relaunch of BBC podcasts website
+
+v1.0.1 (2021-08-01)
+- migrated to new settings format
+
 v1.0.0 (2021-05-24)
 - Initial version
         </news>

--- a/plugin.audio.bbcpodcasts/resources/lib/rssaddon/abstract_rss_addon.py
+++ b/plugin.audio.bbcpodcasts/resources/lib/rssaddon/abstract_rss_addon.py
@@ -23,14 +23,12 @@ class AbstractRssAddon:
 
     addon = None
     addon_handle = None
-    plugin_id = None
     addon_dir = None
     anchor_for_latest = True
 
-    def __init__(self, plugin_id, addon_handle):
+    def __init__(self, addon_handle):
 
-        self.plugin_id = plugin_id
-        self.addon = xbmcaddon.Addon(id=plugin_id)
+        self.addon = xbmcaddon.Addon()
         self.addon_handle = addon_handle
         self.addon_dir = xbmcvfs.translatePath(self.addon.getAddonInfo('path'))
 
@@ -65,6 +63,10 @@ class AbstractRssAddon:
 
         pass
 
+    def is_force_http(self):
+
+        return False
+
     def _load_rss(self, url):
 
         def _parse_item(_ci, fallback_image):
@@ -75,7 +77,7 @@ class AbstractRssAddon:
             item = {
                 "name": _ci["title"],
                 "description": _ci["description"] if "description" in _ci else "",
-                "stream_url": _ci["enclosure"]["@url"],
+                "stream_url": _ci["enclosure"]["@url"] if not self.is_force_http() else _ci["enclosure"]["@url"].replace("https://", "http://"),
                 "type": "video" if _ci["enclosure"]["@type"].split("/")[0] == "video" else "music",
                 "icon": _ci["itunes:image"]["@href"] if "itunes:image" in _ci and "@href" in _ci["itunes:image"] else fallback_image
             }
@@ -214,7 +216,7 @@ class AbstractRssAddon:
 
         else:
             url = "".join(
-                ["plugin://", self.plugin_id, item_path, param_string])
+                ["plugin://", self.addon.getAddonInfo("id"), item_path, param_string])
 
         is_folder = "node" in entry
         li.setProperty("IsPlayable", "false" if is_folder else "true")

--- a/plugin.audio.bbcpodcasts/resources/settings.xml
+++ b/plugin.audio.bbcpodcasts/resources/settings.xml
@@ -1,8 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings>
-  <category label="32005">
-    <setting type="lsep" default="false" label="32005" />
-    <setting type="label" default="false" label="32010" />
-    <setting id="agreement" type="enum" default="0" lvalues="32006|32007" label="32008" enable="False" />
-  </category>
+<settings version="1">
+	<section id="plugin.audio.bbcpodcasts">
+		<category id="general" label="32005" help="">
+			<group id="1" label="32005">
+				<setting id="label" type="string" label="32010" help="">
+					<level>0</level>
+					<default/>
+					<enable>false</enable>
+				</setting>
+				<setting id="agreement" type="integer" label="32008" help="">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="32006">0</option>
+							<option label="32007">1</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+			</group>
+		</category>
+	</section>
 </settings>


### PR DESCRIPTION
### Description
BBC has relaunched its website so that screen scraping didn't work anymore which results in empty playlists. This PR re-enables to listen to BBC podcasts again.

However, there are less podcasts than before since not all programs are listed anymore and not all of them have rss feeds. I hope that I find the time in future in order to provide the rich offer of BBS Sounds. 

Versions included in this PR:

v2.0.0 (2021-08-14)
- Changes after relaunch of BBC podcasts website

v1.0.1 (2021-08-01)
- migrated to new settings format

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0