### PR TITLE
[plugin.video.hbogoeu@leia] 2.7.8

### DIFF
--- a/plugin.video.hbogoeu/README.md
+++ b/plugin.video.hbogoeu/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/arvvoid/plugin.video.hbogoeu/workflows/CI/badge.svg)](https://github.com/arvvoid/plugin.video.hbogoeu/actions)
+[![CodeQL](https://github.com/arvvoid/plugin.video.hbogoeu/workflows/CodeQL/badge.svg)](https://github.com/arvvoid/plugin.video.hbogoeu/actions/workflows/codeql-analysis.yml)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/arvvoid/plugin.video.hbogoeu)](https://github.com/arvvoid/plugin.video.hbogoeu/blob/master/README.md#install-instructions) 
 [![Kodi Version](https://img.shields.io/badge/kodi-18%20%7C%2019%2B-blue)](https://kodi.tv/)
 [![All Contributors](https://img.shields.io/badge/all_contributors-37-orange.svg?style=flat-square)](#contributors-)

--- a/plugin.video.hbogoeu/addon.xml
+++ b/plugin.video.hbogoeu/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.7.4">
+<addon id="plugin.video.hbogoeu" name="hGO EU" provider-name="arvvoid" version="2.7.8">
   <requires>
     <import addon="xbmc.python" version="2.26.0" />
     <import addon="script.module.kodi-six" version="0.1.0" />
@@ -44,12 +44,7 @@ If an official app is available for your platform, use it instead of this.
     <source>https://github.com/arvvoid/plugin.video.hbogoeu</source>
     <website>https://arvvoid.github.io/plugin.video.hbogoeu</website>
     <news>
-- Hot Fix: fix playback going throu TV Shows or Movies category [EU region]
-- Remove obsolete non standard login redirect methods (no longer needed and abandoned by all operators) [EU region]
-- Change fallback icon url
-- Add-on integrity hash output to debug log if debug logging is active
-- Debug mode has to be explicitly enabled in add-on config
-- Translations updates
+- Fixes "new version" errors on series/season listings
     </news>
     <assets>
      <icon>resources/icon.png</icon>

--- a/plugin.video.hbogoeu/hbogolib/handlereu.py
+++ b/plugin.video.hbogoeu/hbogolib/handlereu.py
@@ -520,24 +520,25 @@ class HbogoHandler_eu(HbogoHandler):
             try:
                 if jsonrsp['ErrorMessage']:
                     self.log("Get " + py2_encode(hbo_go_cat_url) + " exclude index Error: " + py2_encode(jsonrsp['ErrorMessage']))
-                    pass
             except KeyError:
                 pass  # all is ok no error message just pass
             except Exception:
                 self.log("Unexpected error: " + traceback.format_exc())
-                pass
             # find watchlist and continue watching positions for exclusion
-            if len(jsonrsp['Container']) > 1:
-                for container_index in range(0, len(jsonrsp['Container'])):
-                    container_item = jsonrsp['Container'][container_index]
-                    if py2_encode(container_item['Name']) in list_of_items_to_exlude:
-                        excludeindex.append(container_index)
-                    if len(excludeindex) == len(list_of_items_to_exlude):
-                        break
-            if return_as_string:
-                return ','.join(str(e) for e in excludeindex)
-            else:
-                return excludeindex
+            try:
+                if len(jsonrsp['Container']) > 1:
+                    for container_index in range(0, len(jsonrsp['Container'])):
+                        container_item = jsonrsp['Container'][container_index]
+                        if py2_encode(container_item['Name']) in list_of_items_to_exlude:
+                            excludeindex.append(container_index)
+                        if len(excludeindex) == len(list_of_items_to_exlude):
+                            break
+            except Exception:
+                self.log("Unexpected error: " + traceback.format_exc())
+        if return_as_string:
+            return ','.join(str(e) for e in excludeindex)
+        else:
+            return excludeindex
 
     def categories(self):
         if not self.chk_login():
@@ -674,6 +675,13 @@ class HbogoHandler_eu(HbogoHandler):
         if not self.chk_login():
             self.login()
         self.log("Season: " + str(url))
+        # replace alien platform url with current set API platform
+        # temp fix for "new version" errors in series/season listings
+        url = url.replace("APTV", self.API_PLATFORM)
+        url = url.replace("ANMO", self.API_PLATFORM)
+        self.log("Season url fix: " + str(url))
+        # end fix
+
         jsonrsp = self.get_from_hbogo(url)
         if jsonrsp is False:
             return
@@ -716,7 +724,12 @@ class HbogoHandler_eu(HbogoHandler):
         self.log("Episode: " + str(url))
 
         self.reset_media_type_counters()
-
+        # replace alien platform url with current set API platform
+        # temp fix for "new version" errors in series/season listings
+        url = url.replace("APTV", self.API_PLATFORM)
+        url = url.replace("ANMO", self.API_PLATFORM)
+        self.log("Episode url fix: " + str(url))
+        # end fix
         jsonrsp = self.get_from_hbogo(url)
         if jsonrsp is False:
             return


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: hGO EU
  - Add-on ID: plugin.video.hbogoeu
  - Version number: 2.7.8
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/arvvoid/plugin.video.hbogoeu
  

Simple, Kodi add-on to access HBO® Go EU content. (This add-on is not officially commissioned/supported by HBO®.)

Important, HBO® Go must be paid for!!!  You need a valid account!
Register on the official HBO® Go website for your region.

Read the disclaimer!

Curently support: Bosnia and Herzegovina, Bulgaria, Croatia, Czech Republic, Hungary, Macedonia, Montenegro, Polonia, Portugal, Romania, Serbia, Slovakia, Slovenija, Spain, Norway, Denmark, Sweden, Finland

To report bugs or request assistence with the add-on go to: https://github.com/arvvoid/plugin.video.hbogoeu
    

### Description of changes:


- Fixes "new version" errors on series/season listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
