### PR TITLE
[plugin.video.vtm.go@matrix] 1.2.12+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.2.12](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.12) (2021-09-08)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.11...v1.2.12)
+
+**Merged pull requests:**
+
+- Update anvato URL [\#304](https://github.com/add-ons/plugin.video.vtm.go/pull/304) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix tests [\#303](https://github.com/add-ons/plugin.video.vtm.go/pull/303) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.2.11](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.2.11) (2021-08-12)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.10...v1.2.11)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.11+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.2.12+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -25,8 +25,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.2.11 (2021-08-12)
-- Fix authentication (Error 406) for existing users. There is still an issue with the login for new users, see issue #296 on GitHub for more information and a workaround.</news>
+	<news>v1.2.12 (2021-09-08)
+- Fix playback of VOD content.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.vtm.go/resources/lib/modules/iptvmanager.py
@@ -70,7 +70,7 @@ class IPTVManager:
     @via_socket
     def send_epg(self):
         """ Report EPG data """
-        results = dict()
+        results = {}
 
         # Fetch EPG data
         for date in ['yesterday', 'today', 'tomorrow']:

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -147,7 +147,7 @@ def _request(method, url, params=None, form=None, data=None, token=None, profile
     """
     if form or data:
         # Make sure we don't log the password
-        debug_data = dict()
+        debug_data = {}
         debug_data.update(form or data)
         if 'password' in debug_data:
             debug_data['password'] = '**redacted**'

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -162,7 +162,7 @@ class VtmGoStream:
         :type stream_info: dict
         :rtype list[dict]
         """
-        subtitles = list()
+        subtitles = []
         if stream_info.get('video').get('subtitles'):
             for _, subtitle in enumerate(stream_info.get('video').get('subtitles')):
                 name = subtitle.get('language')
@@ -191,7 +191,7 @@ class VtmGoStream:
         if not kodiutils.exists(temp_dir):
             kodiutils.mkdirs(temp_dir)
 
-        downloaded_subtitles = list()
+        downloaded_subtitles = []
         for subtitle in subtitles:
             output_file = temp_dir + subtitle.get('name')
             webvtt_content = util.http_get(subtitle.get('url')).text
@@ -207,7 +207,7 @@ class VtmGoStream:
         :type ad_breaks: list[dict]
         :rtype str
         """
-        sub_timings = list()
+        sub_timings = []
         for timestamp in match.groups():
             hours, minutes, seconds, millis = (int(x) for x in [timestamp[:-10], timestamp[-9:-7], timestamp[-6:-4], timestamp[-3:]])
             sub_timings.append(timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=millis))
@@ -247,8 +247,8 @@ class VtmGoStream:
         if not kodiutils.exists(temp_dir):
             kodiutils.mkdirs(temp_dir)
 
-        ad_breaks = list()
-        delayed_subtitles = list()
+        ad_breaks = []
+        delayed_subtitles = []
         webvtt_timing_regex = re.compile(r'\n(\d{2}:\d{2}:\d{2}\.\d{3}) --> (\d{2}:\d{2}:\d{2}\.\d{3})\s')
 
         # Get advertising breaks info from json manifest
@@ -273,7 +273,7 @@ class VtmGoStream:
         :type stream_info: dict
         :rtype dict
         """
-        url = 'https://tkx.apis.anvato.net/rest/v2/mcp/video/{video}'.format(**anvato_info)
+        url = 'https://tkx.mp.lura.live/rest/v2/mcp/video/{video}'.format(**anvato_info)
         _LOGGER.debug('Getting stream info from %s with access_key %s and token %s', url, anvato_info['accessKey'], anvato_info['token'])
         response = util.http_post(url,
                                   data={


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.2.12+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go
  
This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### Description of changes:

v1.2.12 (2021-09-08)
- Fix playback of VOD content.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
