### PR TITLE
[plugin.audio.bbcpodcasts] v2.0.1 

### DIFF
--- a/plugin.audio.bbcpodcasts/addon.xml
+++ b/plugin.audio.bbcpodcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.bbcpodcasts" name="BBC Podcasts" version="2.0.0" provider-name="Heckie">
+<addon id="plugin.audio.bbcpodcasts" name="BBC Podcasts" version="2.0.1" provider-name="Heckie">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" version="2.25.1" />
@@ -23,6 +23,9 @@
         <website>https://github.com/Heckie75/kodi-addon-bbc-podcasts</website>
         <source>https://github.com/Heckie75/kodi-addon-bbc-podcasts/tree/main/plugin.audio.bbcpodcasts</source>
         <news>
+v2.0.1 (2021-09-12)
+- Fixed exception so that 'all podcasts' menu didn't work caused by NoneType
+
 v2.0.0 (2021-08-14)
 - Changes after relaunch of BBC podcasts website
 

--- a/plugin.audio.bbcpodcasts/resources/lib/bbcpodcasts/bbcpodcastsaddon.py
+++ b/plugin.audio.bbcpodcasts/resources/lib/bbcpodcasts/bbcpodcastsaddon.py
@@ -79,7 +79,9 @@ class BbcPodcastsAddon(AbstractRssAddon):
 
         entries = list()
         for _tile in soup.select("article"):
-            entries.append(self._parse_podcast_tile(_tile))
+            entry = self._parse_podcast_tile(_tile)
+            if entry:
+                entries.append(entry)
 
         pager_next = _parse_pager(soup)
         if pager_next:


### PR DESCRIPTION
### Description
Fixed exception so that 'all podcasts' menu didn't work caused by NoneType

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
