### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2021.8.6+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.7.31+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.8.6+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />

--- a/plugin.video.nbcsnliveextra/nbcsn.py
+++ b/plugin.video.nbcsnliveextra/nbcsn.py
@@ -86,7 +86,10 @@ def build_video_link(item):
         elif 'iosStreamUrl' in item['videoSources'][0]:
             url = item['videoSources'][0]['iosStreamUrl']
 
-    pid = item['pid']
+    if 'pid' in item:
+        pid = item['pid']
+    else:
+        pid = ""
     menu_name = item['title']
     title = menu_name
     desc = item['info']


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2021.8.6+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix for streams not playing
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
