### PR TITLE
[plugin.video.viervijfzes@leia] 0.4.5

### DIFF
--- a/plugin.video.viervijfzes/CHANGELOG.md
+++ b/plugin.video.viervijfzes/CHANGELOG.md
@@ -1,12 +1,26 @@
 # Changelog
 
+## [v0.4.5](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.5) (2021-10-21)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.4...v0.4.5)
+
+**Fixed bugs:**
+
+- Remove dependency on inputstream.adaptive [\#98](https://github.com/add-ons/plugin.video.viervijfzes/pull/98) ([michaelarnauts](https://github.com/michaelarnauts))
+- Various fixes due to layout changes [\#97](https://github.com/add-ons/plugin.video.viervijfzes/pull/97) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.4.4](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.4) (2021-09-15)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.3...v0.4.4)
 
 **Fixed bugs:**
 
-- Fix catalogue and recommendations menu [\#93](https://github.com/add-ons/plugin.video.viervijfzes/pull/93) ([mediaminister](https://github.com/mediaminister))
+- Fix tests [\#94](https://github.com/add-ons/plugin.video.viervijfzes/pull/94) ([mediaminister](https://github.com/mediaminister))
+- Fix menu [\#93](https://github.com/add-ons/plugin.video.viervijfzes/pull/93) ([mediaminister](https://github.com/mediaminister))
+
+**Merged pull requests:**
+
+- Prepare for v0.4.4 [\#95](https://github.com/add-ons/plugin.video.viervijfzes/pull/95) ([mediaminister](https://github.com/mediaminister))
 
 ## [v0.4.3](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.3) (2021-04-24)
 

--- a/plugin.video.viervijfzes/addon.xml
+++ b/plugin.video.viervijfzes/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.4" provider-name="Michaël Arnauts">
+<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.5" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.dateutil" version="2.6.0"/>
@@ -7,7 +7,6 @@
         <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
         <import addon="script.module.requests" version="2.22.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="inputstream.adaptive" version="2.4.3"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
@@ -22,8 +21,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by SBS Belgium and is provided 'as is' without any warranty of any kind. The Play4, Play5 and Play6 logos are property of SBS Belgium.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	    <news>v0.4.4 (2021-09-15)
-- Fix catalogue and recommendations menu</news>
+	    <news>v0.4.5 (2021-10-21)
+- Various fixes due to changes on the GoPlay website.</news>
         <source>https://github.com/add-ons/plugin.video.viervijfzes</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.viervijfzes/resources/lib/modules/catalog.py
+++ b/plugin.video.viervijfzes/resources/lib/modules/catalog.py
@@ -113,7 +113,7 @@ class Catalog:
                     },
                     info_dict={
                         'tvshowtitle': program.title,
-                        'title': kodiutils.localize(30205, season=season.number),  # Season {season}
+                        'title': kodiutils.localize(30205, season=season.number) if season.number else season.title,  # Season {season}
                         'plot': season.description or program.description,
                         'set': program.title,
                     }
@@ -243,7 +243,8 @@ class Catalog:
         listing = []
         for episode in episodes:
             title_item = Menu.generate_titleitem(episode)
-            title_item.info_dict['title'] = episode.program_title + ' - ' + title_item.title
+            if episode.program_title:
+                title_item.info_dict['title'] = episode.program_title + ' - ' + title_item.title
             listing.append(title_item)
 
         for program in programs:

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
@@ -454,7 +454,7 @@ class ContentApi:
 
         # Categories regexes
         regex_articles = re.compile(r'<article[^>]+>(.*?)</article>', re.DOTALL)
-        regex_category = re.compile(r'<h1.*?>(.*?)</h1>(?:.*?<div class=\"visually-hidden\">(.*?)</div>)?', re.DOTALL)
+        regex_category = re.compile(r'<h2.*?>(.*?)</h2>(?:.*?<div class="visually-hidden">(.*?)</div>)?', re.DOTALL)
 
         categories = []
         for result in regex_articles.finditer(raw_html):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: GoPlay
  - Add-on ID: plugin.video.viervijfzes
  - Version number: 0.4.5
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.viervijfzes
  
This add-on gives access to video-on-demand content available on the websites of Play4, Play5 and Play6.

### Description of changes:

v0.4.5 (2021-10-21)
- Various fixes due to changes on the GoPlay website.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
