### PR TITLE
[plugin.video.rocketbeans@matrix] 1.2.4

### DIFF
--- a/plugin.video.rocketbeans/addon.xml
+++ b/plugin.video.rocketbeans/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rocketbeans" version="1.2.3" name="Rocket Beans TV" provider-name="Razzeee">
+<addon id="plugin.video.rocketbeans" version="1.2.4" name="Rocket Beans TV" provider-name="Razzeee">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="plugin.video.youtube" version="5.2.1" />
@@ -31,6 +31,8 @@ Wir machen nur, auf was wir Bock haben – und das mit Erfolg! Egal ob spannende
             <screenshot>resources/screenshot-01.png</screenshot>
             <screenshot>resources/screenshot-02.png</screenshot>
         </assets>
-        <news>- More python 3.9 and kodi deprecation fixes</news>
+        <news>- Fixed error with Livestream not existing
+- Reordered channels
+- Fix game string</news>
     </extension>
 </addon>

--- a/plugin.video.rocketbeans/resources/lib/plugin.py
+++ b/plugin.video.rocketbeans/resources/lib/plugin.py
@@ -11,7 +11,7 @@ from xbmcaddon import Addon
 
 
 plugin = routing.Plugin()
-setContent(plugin.handle, 'videos')
+setContent(plugin.handle, "videos")
 
 livestream_thumbnail = None
 livestream_url = None
@@ -20,98 +20,72 @@ __addon__ = Addon()
 
 
 def getString(string_id):
-    return __addon__.getLocalizedString(string_id).encode('utf-8', 'ignore')
+    return __addon__.getLocalizedString(string_id)
 
 
 def get_livestream():
     if __addon__.getSetting("stream") == 0:
         t = TwitchStream(config.TWITCH_USER_LOGIN)
-        livestream_url, title, livestream_thumbnail = t.url, t.title, t.thumbnail
+        return t.url, t.title, t.thumbnail
     else:
-        livestream_url, title, livestream_thumbnail = YoutubeStream(
-        ).get_live_video_info_from_channel_id(config.CHANNEL_ID)
-    return livestream_url, livestream_thumbnail, title
+        return YoutubeStream().get_live_video_info_from_channel_id(config.CHANNEL_ID)
 
 
-@plugin.route('/')
+@plugin.route("/")
 def index():
     livestream_url, livestream_thumbnail, title = get_livestream()
-    li = createListItem(
-        ('Live | %s' % title),
-        livestream_thumbnail,
-        True,
-        getString(32001),
-        0
-    )
-    addDirectoryItem(
-        plugin.handle,
-        livestream_url,
-        li
-    )
+    if livestream_url:
+        li = createListItem(
+            ("Live | %s" % title), livestream_thumbnail, True, getString(32001), 0
+        )
+        addDirectoryItem(plugin.handle, livestream_url, li)
 
     url = "plugin://plugin.video.youtube/user/%s/" % config.CHANNEL_ID
-    addDirectoryItem(
-        plugin.handle,
-        url,
-        ListItem(getString(32007)),
-        True
-    )
-
-    url = "plugin://plugin.video.youtube/channel/%s/" % config.ROCKET_BEANS_GAMING_CHANNEL_ID
-    addDirectoryItem(
-        plugin.handle,
-        url,
-        ListItem(getString(32006)),
-        True
-    )
+    addDirectoryItem(plugin.handle, url, ListItem(getString(32007)), True)
 
     addDirectoryItem(
         plugin.handle,
-        "plugin://plugin.video.youtube/channel/%s/" % config.KINO_PLUS_CHANNEL_ID,
-        ListItem(getString(32009)),
-        True
+        "plugin://plugin.video.twitch/?mode=channel_video_list&broadcast_type=upload&channel_id=%s"
+        % (config.TWITCH_CHANNEL_ID),
+        ListItem(getString(32004)),
+        True,
     )
+
+    url = (
+        "plugin://plugin.video.youtube/channel/%s/"
+        % config.ROCKET_BEANS_GAMING_CHANNEL_ID
+    )
+    addDirectoryItem(plugin.handle, url, ListItem(getString(32006)), True)
 
     addDirectoryItem(
         plugin.handle,
         "plugin://plugin.video.youtube/channel/%s/" % config.GAME_TWO_CHANNEL_ID,
         ListItem(getString(32005)),
-        True
-    )
-
-    addDirectoryItem(
-        plugin.handle,
-        "plugin://plugin.video.youtube/channel/%s/" % config.KINO_PLUS_CHANNEL_ID,
-        ListItem(getString(32009)),
-        True
+        True,
     )
 
     addDirectoryItem(
         plugin.handle,
         "plugin://plugin.video.youtube/channel/%s/" % config.LETS_PLAY_CHANNEL_ID,
         ListItem(getString(32008)),
-        True
+        True,
     )
 
     addDirectoryItem(
         plugin.handle,
-        "plugin://plugin.video.twitch/?mode=channel_video_list&broadcast_type=upload&channel_id=%s" % (
-            config.TWITCH_CHANNEL_ID),
-        ListItem(getString(32004)),
-        True
+        "plugin://plugin.video.youtube/channel/%s/" % config.KINO_PLUS_CHANNEL_ID,
+        ListItem(getString(32009)),
+        True,
     )
 
     addDirectoryItem(
-        plugin.handle,
-        plugin.url_for(guide),
-        ListItem(getString(32003)),
-        True
+        plugin.handle, plugin.url_for(guide), ListItem(getString(32003)), True
     )
 
     endOfDirectory(plugin.handle)
 
 
-@plugin.route('/guide')
+@plugin.route("/guide")
 def guide():
     guide_items = show_guide()
 
@@ -119,50 +93,26 @@ def guide():
         title, video_id, duration, game, is_live_now = guide_item
         if video_id:
             url = "plugin://plugin.video.youtube/play/?video_id=%s" % video_id
-            thumbnail = "https://i.ytimg.com/vi/%s/hqdefault.jpg" % (
-                video_id)
+            thumbnail = "https://i.ytimg.com/vi/%s/hqdefault.jpg" % (video_id)
 
             li = createListItem(
                 title,
                 thumbnail,
                 True,
-                '[B]' + str(getString(32002)) + '[/B]: ' +
-                game if game else '',
-                duration
+                "[B]" + str(getString(32002)) + "[/B]: " + game if game else "",
+                duration,
             )
-            addDirectoryItem(
-                plugin.handle,
-                url,
-                li
-            )
+            addDirectoryItem(plugin.handle, url, li)
         else:
             if is_live_now:
                 livestream_url, livestream_thumbnail, _ = get_livestream()
                 li = createListItem(
-                    title,
-                    livestream_thumbnail,
-                    True,
-                    getString(32001),
-                    0
+                    title, livestream_thumbnail, True, getString(32001), 0
                 )
-                addDirectoryItem(
-                    plugin.handle,
-                    livestream_url,
-                    li
-                )
+                addDirectoryItem(plugin.handle, livestream_url, li)
             else:
-                li = createListItem(
-                    title,
-                    '',
-                    False,
-                    '',
-                    0
-                )
-                addDirectoryItem(
-                    plugin.handle,
-                    '',
-                    li
-                )
+                li = createListItem(title, "", False, "", 0)
+                addDirectoryItem(plugin.handle, "", li)
     endOfDirectory(plugin.handle)
 
 
@@ -171,17 +121,17 @@ def createListItem(label, thumbnailImage, isPlayable, plot, duration):
         label=label,
     )
 
-    li.setArt({'thumb': thumbnailImage})
+    li.setArt({"thumb": thumbnailImage})
 
     if isPlayable:
         infoLabels = {}
-        infoLabels['plot'] = plot
+        infoLabels["plot"] = plot
 
         if duration > 0:
-            infoLabels['duration'] = duration
+            infoLabels["duration"] = duration
 
-        li.setInfo(type='video', infoLabels=infoLabels)
-        li.setProperty('isPlayable', 'true')
+        li.setInfo(type="video", infoLabels=infoLabels)
+        li.setProperty("isPlayable", "true")
 
     return li
 

--- a/plugin.video.rocketbeans/resources/lib/youtube.py
+++ b/plugin.video.rocketbeans/resources/lib/youtube.py
@@ -9,22 +9,30 @@ import urllib.parse
 class YoutubeStream:
     def get_live_video_info_from_channel_id(self, channel_id):
         request = urllib.request.Request(
-            "https://www.youtube.com/c/%s/live" % channel_id)
+            "https://www.youtube.com/c/%s/live" % channel_id
+        )
         video_id, title = self.get_video_info(request)
+        if not video_id:
+            return (None, None, None)
+
         livestream_url = "plugin://plugin.video.youtube/play/?video_id=%s" % video_id
         livestream_thumbnail = "https://i.ytimg.com/vi/%s/hqdefault_live.jpg#%s" % (
-            video_id, time.localtime())
+            video_id,
+            time.localtime(),
+        )
         return livestream_url, title, livestream_thumbnail
 
     def get_video_info(self, request):
         response = urllib.request.urlopen(request)
         string_data = response.read()
-        lines = string_data.decode('utf-8').splitlines()
+        lines = string_data.decode("utf-8").splitlines()
 
         re_video_url = re.compile(
-            r'https://i.ytimg.com/vi/(?P<video_id>[^\/]+)/maxresdefault_live.jpg')
+            r"https://i.ytimg.com/vi/(?P<video_id>[^\/]+)/maxresdefault_live.jpg"
+        )
         re_video_title = re.compile(
-            r'"title":"(?P<title>[^\?]+)","lengthSeconds":".","isLive":true')
+            r'"title":"(?P<title>[^\?]+)","lengthSeconds":".","isLive":true'
+        )
 
         re_video_url_match = ""
         re_video_title_match = ""
@@ -37,5 +45,7 @@ class YoutubeStream:
                 re_video_title_match = re.search(re_video_title, line)
 
             if re_video_url_match and re_video_title_match:
-                title = re_video_title_match.group('title')
-                return (re_video_url_match.group('video_id'), title)
+                title = re_video_title_match.group("title")
+                return (re_video_url_match.group("video_id"), title)
+
+        return (None, None)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Rocket Beans TV
  - Add-on ID: plugin.video.rocketbeans
  - Version number: 1.2.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/Razzeee/plugin.video.rocketbeans
  
Rocket Beans TV is 24/7 Entertainment focusing on digital topics like gaming and digital popculture.

### Description of changes:

- Fixed error with Livestream not existing
- Reordered channels
- Fix game string

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
