### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.6

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,11 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.6 (2021-12-22)
+- Fix watching VRT NU abroad (@mediaminister)
+- Fix resumepoints (@mediaminister)
+- Update featured menu (@mediaminister)
+
 ### v2.5.5 (2021-09-09)
 - Fix broken menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.5" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.6" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,11 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.6 (2021-12-22)
+- Fix watching VRT NU abroad
+- Fix resumepoints
+- Update featured menu
+
 v2.5.5 (2021-09-09)
 - Fix broken menu listings
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -274,8 +274,16 @@ msgctxt "#30103"
 msgid "From the archive"
 msgstr ""
 
+msgctxt "#30104"
+msgid "Last chance"
+msgstr ""
+
 msgctxt "#30120"
 msgid "Short film"
+msgstr ""
+
+msgctxt "#30121"
+msgid "12+"
 msgstr ""
 
 msgctxt "#30128"
@@ -993,6 +1001,10 @@ msgstr ""
 
 msgctxt "#30972"
 msgid "There is a problem authenticating at VRT NU to enable favorites. Please check your VRT NU account at https://www.vrt.be/vrtnu/ or disable favorites in the add-on settings."
+msgstr ""
+
+msgctxt "#30973"
+msgid "This program can only be played from an European Union member state. It is blocked on your geographical location based on your IP address. More info at https://www.vrt.be/vrtnu/help/country/"
 msgstr ""
 
 msgctxt "#30975"

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -274,9 +274,17 @@ msgctxt "#30103"
 msgid "From the archive"
 msgstr "Uit het archief"
 
+msgctxt "#30104"
+msgid "Last chance"
+msgstr "Laatste kans"
+
 msgctxt "#30120"
 msgid "Short film"
 msgstr "Kortfilm"
+
+msgctxt "#30121"
+msgid "12+"
+msgstr "12+"
 
 msgctxt "#30128"
 msgid "Kies19"
@@ -994,6 +1002,10 @@ msgstr "Er is een onbekend probleem bij het verifiëren van je gebruikersgegeven
 msgctxt "#30972"
 msgid "There is a problem authenticating at VRT NU to enable favorites. Please check your VRT NU account at https://www.vrt.be/vrtnu/ or disable favorites in the add-on settings."
 msgstr "Er is een probleem met de authenticatie bij VRT NU om favorieten in te schakelen. Controleer je VRT NU-account op https://www.vrt.be/vrtnu/ of schakel favorieten uit in de add-on-instellingen."
+
+msgctxt "#30973"
+msgid "This program can only be played from an European Union member state. It is blocked on your geographical location based on your IP address. More info at https://www.vrt.be/vrtnu/help/country/"
+msgstr "Dit programma kan alleen afgespeeld worden vanuit een lidstaat van de Europese Unie. Het wordt geblokkeerd op jouw geografische locatie op basis van je IP-adres. Meer info op https://www.vrt.be/vrtnu/help/country/"
 
 msgctxt "#30975"
 msgid "Failed to get user token from VRT NU"

--- a/plugin.video.vrt.nu/resources/lib/apihelper.py
+++ b/plugin.video.vrt.nu/resources/lib/apihelper.py
@@ -547,14 +547,14 @@ class ApiHelper:
                 params['facets[programType]'] = 'oneoff'
 
             if variety == 'watchlater':
-                self._resumepoints.refresh(ttl=ttl('direct'))
+                self._resumepoints.refresh_watchlater(ttl=ttl('direct'))
                 episode_urls = self._resumepoints.watchlater_urls()
                 params['facets[url]'] = '[%s]' % (','.join(episode_urls))
 
             if variety == 'continue':
-                self._resumepoints.refresh(ttl=ttl('direct'))
-                episode_urls = self._resumepoints.resumepoints_urls()
-                params['facets[url]'] = '[%s]' % (','.join(episode_urls))
+                self._resumepoints.refresh_resumepoints(ttl=ttl('direct'))
+                episode_ids = self._resumepoints.resumepoints_ids()
+                params['facets[videoId]'] = '[%s]' % (','.join(episode_ids))
 
             if use_favorites:
                 program_urls = [program_to_url(p, 'medium') for p in self._favorites.programs()]

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -277,9 +277,10 @@ FEATURED = [
     dict(name='Exclusief online', id='exclusief-online', msgctxt=30100),
     dict(name='Volledig seizoen', id='volledig-seizoen', msgctxt=30101),
     dict(name='Volledige reeks', id='volledige-reeks', msgctxt=30102),
-    dict(name='Uit het archief', id='uit-het-archief', msgctxt=30103),
+    dict(name='Laatste kans', id='laatste-kans', msgctxt=30104),
     # Inhoudsgerelateerd
     dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
+    dict(name='12+', id='12+', msgctxt=30121),
     # Thema
     dict(name='Kies19', id='kies-19', msgctxt=30128),
     dict(name='Klimaat', id='klimaat', msgctxt=30129),

--- a/plugin.video.vrt.nu/resources/lib/kodiutils.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiutils.py
@@ -1218,7 +1218,7 @@ def get_cached_url_json(url, cache, headers=None, ttl=None, fail=None):  # pylin
 
 def refresh_caches(cache_file=None):
     """Invalidate the needed caches and refresh container"""
-    files = ['favorites.json', 'oneoff.json', 'resume_points.json']
+    files = ['favorites.json', 'oneoff.json', 'resume_points.json', 'resume_points_ddt.json']
     if cache_file and cache_file not in files:
         files.append(cache_file)
     invalidate_caches(*files)

--- a/plugin.video.vrt.nu/resources/lib/resumepoints.py
+++ b/plugin.video.vrt.nu/resources/lib/resumepoints.py
@@ -16,11 +16,17 @@ from kodiutils import (container_refresh, get_cache, get_setting_bool, get_url_j
 
 
 class ResumePoints:
-    """Track, cache and manage VRT resume points and watch list"""
+    """Track, cache and manage VRT resume points and watchLater status"""
+
+    RESUMEPOINTS_URL = 'https://ddt.profiel.vrt.be/resumePoints'
+    RESUMEPOINTS_CACHE_FILE = 'resume_points_ddt.json'
+    WATCHLATER_URL = 'https://video-user-data.vrt.be/resume_points'
+    WATCHLATER_CACHE_FILE = 'resume_points.json'
 
     def __init__(self):
         """Initialize resumepoints, relies on XBMC vfs and a special VRT token"""
-        self._data = {}  # Our internal representation
+        self._watchlater = {}  # Our internal watchLater status representation
+        self._resumepoints = {}  # Our internal Resumepoints representation
 
     @staticmethod
     def is_activated():
@@ -28,16 +34,16 @@ class ResumePoints:
         return get_setting_bool('usefavorites', default=True) and get_setting_bool('useresumepoints', default=True) and has_credentials()
 
     @staticmethod
-    def resumepoint_headers(url=None):
-        """Generate http headers for VRT NU Resumepoints API"""
+    def watchlater_headers(url=None):
+        """Generate http headers for VRT NU watchLater API"""
         from tokenresolver import TokenResolver
         xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
         headers = {}
         if xvrttoken:
             url = 'https://www.vrt.be' + url if url else 'https://www.vrt.be/vrtnu'
             headers = {
-                'authorization': 'Bearer ' + xvrttoken,
-                'content-type': 'application/json',
+                'Authorization': 'Bearer ' + xvrttoken,
+                'Content-Type': 'application/json',
                 'Referer': url,
             }
         else:
@@ -47,159 +53,250 @@ class ResumePoints:
 
     def refresh(self, ttl=None):
         """Get a cached copy or a newer resumepoints from VRT, or fall back to a cached file"""
+        self.refresh_resumepoints(ttl)
+        self.refresh_watchlater(ttl)
+
+    def refresh_watchlater(self, ttl=None):
+        """Get a cached copy or a newer watchLater list from VRT, or fall back to a cached file"""
         if not self.is_activated():
             return
-        resumepoints_json = get_cache('resume_points.json', ttl)
-        if not resumepoints_json:
-            resumepoints_url = 'https://video-user-data.vrt.be/resume_points'
-            headers = self.resumepoint_headers()
+        watchlater_json = get_cache(self.WATCHLATER_CACHE_FILE, ttl)
+        if not watchlater_json:
+            headers = self.watchlater_headers()
             if not headers:
                 return
-            resumepoints_json = get_url_json(url=resumepoints_url, cache='resume_points.json', headers=headers)
-        if resumepoints_json is not None:
-            self._data = resumepoints_json
+            watchlater_json = get_url_json(url=self.WATCHLATER_URL, cache=self.WATCHLATER_CACHE_FILE, headers=headers)
+        if watchlater_json is not None:
+            self._watchlater = watchlater_json
 
-    def update(self, asset_id, title, url, watch_later=None, position=None, total=None, whatson_id=None, path=None):
-        """Set program resumepoint or watchLater status and update local copy"""
+    def refresh_resumepoints(self, ttl=None):
+        """Get a cached copy or a newer resumepoints from VRT, or fall back to a cached file"""
+        if not self.is_activated():
+            return
+        resumepoints_json = get_cache(self.RESUMEPOINTS_CACHE_FILE, ttl)
+        if not resumepoints_json:
+            resumepoints_url = self.RESUMEPOINTS_URL + '?max=500&sortBy=-updated'
+            headers = self.resumepoints_headers()
+            if not headers:
+                return
+            resumepoints_json = get_url_json(url=resumepoints_url, cache=self.RESUMEPOINTS_CACHE_FILE, headers=headers)
+        if resumepoints_json is not None:
+            self._resumepoints = resumepoints_json
+
+    @staticmethod
+    def resumepoints_headers():
+        """Generate http headers for VRT NU Resumepoint API"""
+        from tokenresolver import TokenResolver
+        vrtlogin_at = TokenResolver().get_token('vrtlogin-at')
+        headers = {}
+        if vrtlogin_at:
+            headers = {
+                'Authorization': 'Bearer ' + vrtlogin_at,
+                'Content-Type': 'application/json',
+            }
+        else:
+            log_error('Failed to get access token from VRT NU')
+            notification(message=localize(30975))
+        return headers
+
+    def update_resumepoint(self, video_id, asset_str, title, position=None, total=None, path=None):
+        """Set program resumepoint and update local copy"""
+
+        if video_id is None:
+            return True
 
         menu_caches = []
-        self.refresh(ttl=5)
+        self.refresh_resumepoints(ttl=5)
 
         # Add existing position and total if None
-        if asset_id in self._data and position is None and total is None:
-            position = self.get_position(asset_id)
-            total = self.get_total(asset_id)
+        if video_id in self._resumepoints and position is None and total is None:
+            position = self.get_position(video_id)
+            total = self.get_total(video_id)
 
         # Update
-        if (self.still_watching(position, total) or watch_later is True
-                or (path and path.startswith('plugin://plugin.video.vrt.nu/play/upnext'))):
+        if (self.still_watching(position, total) or (path and path.startswith('plugin://plugin.video.vrt.nu/play/upnext'))):
             # Normally, VRT NU resumepoints are deleted when an episode is (un)watched and Kodi GUI automatically sets
             # the (un)watched status when Kodi Player exits. This mechanism doesn't work with "Up Next" episodes because
             # these episodes are not initiated from a ListItem in Kodi GUI.
             # For "Up Next" episodes, we should never delete the VRT NU resumepoints to make sure the watched status
             # can be forced in Kodi GUI using the playcount infolabel.
-            log(3, "[Resumepoints] Update resumepoint '{asset_id}' {position}/{total}", asset_id=asset_id, position=position, total=total)
+            log(3, "[Resumepoints] Update resumepoint '{video_id}' {position}/{total}", video_id=video_id, position=position, total=total)
 
-            if asset_id is None:
-                return True
-
-            if watch_later is not None and position is None and total is None and watch_later is self.is_watchlater(asset_id):
-                # watchLater status is not changed, nothing to do
-                return True
-
-            if watch_later is None and position == self.get_position(asset_id) and total == self.get_total(asset_id):
+            if position == self.get_position(video_id) and total == self.get_total(video_id):
                 # Resumepoint is not changed, nothing to do
                 return True
 
             menu_caches.append('continue-*.json')
 
-            if asset_id in self._data:
-                # Update existing resumepoint values
-                payload = self._data[asset_id]['value']
-                payload['url'] = url
-            else:
-                # Create new resumepoint values
-                payload = dict(position=0, total=100, url=url)
+            # Update online
+            gdpr = '{asset_str} gekeken tot {at} seconden.'.format(asset_str=asset_str, at=position)
+            payload = dict(
+                at=position,
+                total=total,
+                gdpr=gdpr,
+            )
+            from json import dumps
+            try:
+                resumepoint_json = get_url_json('{api}/{video_id}'.format(api=self.RESUMEPOINTS_URL, video_id=video_id),
+                                                headers=self.resumepoints_headers(), data=dumps(payload).encode())
+            except HTTPError as exc:
+                log_error('Failed to update resumepoint of {title} at VRT NU ({error})', title=title, error=exc)
+                notification(message=localize(30977, title=title))
+                return False
 
-            if watch_later is not None:
-                payload['watchLater'] = watch_later
-                menu_caches.append('watchlater-*.json')
-
-            if position is not None:
-                payload['position'] = position
-
-            if total is not None:
-                payload['total'] = total
-
-            if whatson_id is not None:
-                payload['whatsonId'] = whatson_id
-
-            # First update resumepoints to a fast local cache because online resumpoints take a longer time to take effect
-            self.update_local(asset_id, dict(value=payload), menu_caches)
-
-            # Asynchronously update online
-            from threading import Thread
-            Thread(target=self.update_online, name='ResumePointsUpdate', args=(asset_id, title, url, payload)).start()
-
+            # Update local
+            for idx, item in enumerate(self._resumepoints.get('items')):
+                if item.get('mediaId') == video_id:
+                    self._resumepoints.get('items')[idx] = resumepoint_json
+                    break
+            update_cache(self.RESUMEPOINTS_CACHE_FILE, dumps(self._resumepoints))
+            if menu_caches:
+                invalidate_caches(*menu_caches)
         else:
 
             # Delete
-            log(3, "[Resumepoints] Delete resumepoint '{asset_id}' {position}/{total}", asset_id=asset_id, position=position, total=total)
+            log(3, "[Resumepoints] Delete resumepoint '{asset_str}' {position}/{total}", asset_str=asset_str, position=position, total=total)
 
-            # Do nothing if there is no resumepoint for this asset_id
-            if not self._data.get(asset_id):
-                log(3, "[Resumepoints] '{asset_id}' not present, nothing to delete", asset_id=asset_id)
+            # Do nothing if there is no resumepoint for this video_id
+            from json import dumps
+            if video_id not in dumps(self._resumepoints):
+                log(3, "[Resumepoints] '{video_id}' not present, nothing to delete", video_id=video_id)
                 return True
 
             # Add menu caches
             menu_caches.append('continue-*.json')
 
-            if self.is_watchlater(asset_id):
-                menu_caches.append('watchlater-*.json')
+            # Delete online
+            try:
+                result = open_url('{api}/{video_id}'.format(api=self.RESUMEPOINTS_URL, video_id=video_id),
+                                  headers=self.resumepoints_headers(), method='DELETE', raise_errors='all')
+                log(3, "[Resumepoints] '{video_id}' online deleted: {code}", video_id=video_id, code=result.getcode())
+            except HTTPError as exc:
+                log_error("Failed to remove resumepoint of '{video_id}': {error}", video_id=video_id, error=exc)
+                return False
 
             # Delete local representation and cache
-            self.delete_local(asset_id, menu_caches)
+            for item in self._resumepoints.get('items'):
+                if item.get('mediaId') == video_id:
+                    self._resumepoints.get('items').remove(item)
+                    break
+
+            update_cache(self.RESUMEPOINTS_CACHE_FILE, dumps(self._resumepoints))
+            if menu_caches:
+                invalidate_caches(*menu_caches)
+        return True
+
+    def update_watchlater(self, asset_id, title, url, watch_later=None):
+        """Set program watchLater status and update local copy"""
+
+        menu_caches = []
+        self.refresh_watchlater(ttl=5)
+
+        # Update
+        if watch_later is True:
+            log(3, "[watchLater] Update {asset_id} watchLater status", asset_id=asset_id)
+
+            if asset_id is None:
+                return True
+
+            if watch_later is not None and watch_later is self.is_watchlater(asset_id):
+                # watchLater status is not changed, nothing to do
+                return True
+
+            if asset_id in self._watchlater:
+                # Update existing watchLater values
+                payload = self._watchlater[asset_id]['value']
+                payload['url'] = url
+            else:
+                # Create new watchLater values
+                payload = dict(position=0, total=100, url=url)
+
+            payload['watchLater'] = watch_later
+            menu_caches.append('watchlater-*.json')
+
+            # First update watchLater status to a fast local cache because online watchLater status takes a longer time to take effect
+            self.update_watchlater_local(asset_id, dict(value=payload), menu_caches)
+
+            # Asynchronously update online
+            from threading import Thread
+            Thread(target=self.update_watchlater_online, name='WatchLaterUpdate', args=(asset_id, title, url, payload)).start()
+
+        else:
+
+            # Delete
+            log(3, "[watchLater] Delete watchLater status of '{asset_id}'", asset_id=asset_id)
+
+            # Do nothing if there is no watchLater status for this asset_id
+            if not self._watchlater.get(asset_id):
+                log(3, "[Resumepoints] '{asset_id}' not present, nothing to delete", asset_id=asset_id)
+                return True
+
+            # Add menu caches
+            menu_caches.append('watchlater-*.json')
+
+            # Delete local representation and cache
+            self.delete_watchlater_local(asset_id, menu_caches)
 
             # Asynchronously delete online
             from threading import Thread
-            Thread(target=self.delete_online, name='ResumePointsDelete', args=(asset_id,)).start()
+            Thread(target=self.delete_watchlater_online, name='WatchLaterDelete', args=(asset_id,)).start()
 
         return True
 
-    def update_online(self, asset_id, title, url, payload):
-        """Update resumepoint online"""
+    def update_watchlater_online(self, asset_id, title, url, payload):
+        """Update watchLater status online"""
         from json import dumps
         try:
-            get_url_json('https://video-user-data.vrt.be/resume_points/{asset_id}'.format(asset_id=asset_id),
-                         headers=self.resumepoint_headers(url), data=dumps(payload).encode())
+            get_url_json('{api}/{asset_id}'.format(api=self.WATCHLATER_URL, asset_id=asset_id),
+                         headers=self.watchlater_headers(url), data=dumps(payload).encode())
         except HTTPError as exc:
-            log_error('Failed to (un)watch episode {title} at VRT NU ({error})', title=title, error=exc)
+            log_error('Failed to update watchLater status of {title} at VRT NU ({error})', title=title, error=exc)
             notification(message=localize(30977, title=title))
             return False
         return True
 
-    def update_local(self, asset_id, resumepoint_json, menu_caches=None):
-        """Update resumepoint locally and update cache"""
-        self._data.update({asset_id: resumepoint_json})
+    def update_watchlater_local(self, asset_id, resumepoint_json, menu_caches=None):
+        """Update watchLater status locally and update cache"""
+        self._watchlater.update({asset_id: resumepoint_json})
         from json import dumps
-        update_cache('resume_points.json', dumps(self._data))
+        update_cache(self.WATCHLATER_CACHE_FILE, dumps(self._watchlater))
         if menu_caches:
             invalidate_caches(*menu_caches)
 
-    def delete_local(self, asset_id, menu_caches=None):
-        """Delete resumepoint locally and update cache"""
-        if asset_id in self._data:
-            del self._data[asset_id]
+    def delete_watchlater_local(self, asset_id, menu_caches=None):
+        """Delete watchLater status locally and update cache"""
+        if asset_id in self._watchlater:
+            del self._watchlater[asset_id]
             from json import dumps
-            update_cache('resume_points.json', dumps(self._data))
+            update_cache(self.WATCHLATER_CACHE_FILE, dumps(self._watchlater))
             if menu_caches:
                 invalidate_caches(*menu_caches)
 
-    def delete_online(self, asset_id):
-        """Delete resumepoint online"""
+    def delete_watchlater_online(self, asset_id):
+        """Delete watchLater status online"""
         try:
-            result = open_url('https://video-user-data.vrt.be/resume_points/{asset_id}'.format(asset_id=asset_id),
-                              headers=self.resumepoint_headers(), method='DELETE', raise_errors='all')
-            log(3, "[Resumepoints] '{asset_id}' online deleted: {code}", asset_id=asset_id, code=result.getcode())
+            result = open_url('{api}/{asset_id}'.format(api=self.WATCHLATER_URL, asset_id=asset_id),
+                              headers=self.watchlater_headers(), method='DELETE', raise_errors='all')
+            log(3, "[watchLater] '{asset_id}' online deleted: {code}", asset_id=asset_id, code=result.getcode())
         except HTTPError as exc:
-            log_error("Failed to remove '{asset_id}' from resumepoints: {error}", asset_id=asset_id, error=exc)
+            log_error("Failed to remove watchLater status of '{asset_id}': {error}", asset_id=asset_id, error=exc)
             return False
         return True
 
     def is_watchlater(self, asset_id):
         """Is a program set to watch later ?"""
-        return self._data.get(asset_id, {}).get('value', {}).get('watchLater') is True
+        return self._watchlater.get(asset_id, {}).get('value', {}).get('watchLater') is True
 
     def watchlater(self, asset_id, title, url):
         """Watch an episode later"""
-        succeeded = self.update(asset_id=asset_id, title=title, url=url, watch_later=True)
+        succeeded = self.update_watchlater(asset_id=asset_id, title=title, url=url, watch_later=True)
         if succeeded:
             notification(message=localize(30403, title=title))
             container_refresh()
 
     def unwatchlater(self, asset_id, title, url, move_down=False):
         """Unwatch an episode later"""
-        succeeded = self.update(asset_id=asset_id, title=title, url=url, watch_later=False)
+        succeeded = self.update_watchlater(asset_id=asset_id, title=title, url=url, watch_later=False)
         if succeeded:
             notification(message=localize(30404, title=title))
             # If the current item is selected and we need to move down before removing
@@ -207,27 +304,42 @@ class ResumePoints:
                 input_down()
             container_refresh()
 
-    def get_position(self, asset_id):
+    def get_position(self, video_id):
         """Return the stored position of a video"""
-        return self._data.get(asset_id, {}).get('value', {}).get('position', 0)
+        items = self._resumepoints.get('items')
+        if items:
+            for item in items:
+                if item.get('mediaId') == video_id:
+                    return item.get('at', 0)
+        return 0
 
-    def get_total(self, asset_id):
+    def get_total(self, video_id):
         """Return the stored total length of a video"""
-        return self._data.get(asset_id, {}).get('value', {}).get('total', 100)
+        items = self._resumepoints.get('items')
+        if items:
+            for item in items:
+                if item.get('mediaId') == video_id:
+                    return item.get('total', 100)
+        return 100
 
-    def get_url(self, asset_id, url_type='medium'):
-        """Return the stored url a video"""
+    def get_watchlater_url(self, asset_id, url_type='medium'):
+        """Return the stored url for a watchLater status asset"""
         from utils import reformat_url
-        return reformat_url(self._data.get(asset_id, {}).get('value', {}).get('url'), url_type)
+        return reformat_url(self._watchlater.get(asset_id, {}).get('value', {}).get('url'), url_type)
 
     def watchlater_urls(self):
         """Return all watchlater urls"""
-        return [self.get_url(asset_id) for asset_id in self._data if self.is_watchlater(asset_id)]
+        return [self.get_watchlater_url(asset_id) for asset_id in self._watchlater if self.is_watchlater(asset_id)]
 
-    def resumepoints_urls(self):
-        """Return all urls that have not been finished watching"""
-        return [self.get_url(asset_id) for asset_id in self._data
-                if self.still_watching(self.get_position(asset_id), self.get_total(asset_id))]
+    def resumepoints_ids(self):
+        """Return all ids that have not been finished watching"""
+        ids = []
+        items = self._resumepoints.get('items')
+        if items:
+            for item in items:
+                if self.still_watching(item.get('at'), item.get('total')):
+                    ids.append(item.get('mediaId'))
+        return ids
 
     @staticmethod
     def still_watching(position, total):

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -21,12 +21,13 @@ class StreamService:
     """Collect and prepare stream info for Kodi Player"""
 
     _VUPLAY_API_URL = 'https://api.vuplay.co.uk'
-    _VUALTO_API_URL = 'https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v1'
+    _VUALTO_API_URL = 'https://media-services-public.vrt.be/vualto-video-aggregator-web/rest/external/v2'
     _CLIENT = 'vrtvideo@PROD'
     _UPLYNK_LICENSE_URL = 'https://content.uplynk.com/wv'
     _INVALID_LOCATION = 'INVALID_LOCATION'
     _INCOMPLETE_ROAMING_CONFIG = 'INCOMPLETE_ROAMING_CONFIG'
-    _GEOBLOCK_ERROR_CODES = (_INCOMPLETE_ROAMING_CONFIG, _INVALID_LOCATION)
+    _BELGIUM_ONLY = 'CONTENT_AVAILABLE_ONLY_IN_BE'
+    _GEOBLOCK_ERROR_CODES = (_INCOMPLETE_ROAMING_CONFIG, _INVALID_LOCATION, _BELGIUM_ONLY)
 
     def __init__(self, _tokenresolver):
         """Initialize Stream Service class"""
@@ -303,6 +304,10 @@ class StreamService:
 
             if stream_json.get('code') == self._INVALID_LOCATION:
                 message = localize(30965)  # Geoblock error: Blocked on your geographical location based on your IP address
+                return self._handle_stream_api_error(message, stream_json)
+
+            if stream_json.get('code') == self._BELGIUM_ONLY:
+                message = localize(30973)  # Geoblock error: This program can only be played from EU
                 return self._handle_stream_api_error(message, stream_json)
 
             message = localize(30964)  # Geoblock error: Cannot be played, need Belgian phone number validation

--- a/plugin.video.vrt.nu/resources/lib/webscraper.py
+++ b/plugin.video.vrt.nu/resources/lib/webscraper.py
@@ -75,3 +75,9 @@ def get_asset_id(vrtnu_url):
     """Return an asset_id by scraping the VRT NU website"""
     asset_id = assetpath_to_id(get_asset_path(vrtnu_url))
     return asset_id
+
+
+def get_video_id(vrtnu_url):
+    """Return an video_id by scraping the VRT NU website"""
+    video_id = get_video_attributes(vrtnu_url).get('videoid')
+    return video_id


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.6
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu

v2.4.5 (2021-02-05)
- Fix watching livestreams with DRM enabled
- Warn user that InputStream Adaptive is needed for timeshifting

v2.4.4 (2021-01-25)
- Fix watching VRT NU abroad

v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
