### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2021.12.30+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/README.md
+++ b/plugin.video.nbcsnliveextra/README.md
@@ -1,3 +1,7 @@
+[![GitHub release](https://img.shields.io/github/release/eracknaphobia/plugin.video.nbcsnliveextra.svg)](https://github.com/eracknaphobia/plugin.video.nbcsnliveextra/releases)
+![License](https://img.shields.io/badge/license-GPL%20(%3E%3D%202)-orange)
+[![Contributors](https://img.shields.io/github/contributors/eracknaphobia/plugin.video.nbcsnliveextra.svg)](https://github.com/eracknaphobia/plugin.video.nbcsnliveextra/graphs/contributors)
+
 plugin.video.nbcsnliveextra
 ======================
 

--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.12.23+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.12.30+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />
@@ -16,7 +16,8 @@
     <summary lang="en_GB">Watch NBCSN Live Extra</summary>
     <description lang="en_GB">NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network</description>
     <news>
-        - Fix for streams not playing
+        - Fix for list items not updating past November
+        - Add support for DRM streams
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.nbcsnliveextra/resources/lib/globals.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/globals.py
@@ -27,23 +27,12 @@ ROOTDIR = xbmcaddon.Addon().getAddonInfo('path')
 ICON = os.path.join(ROOTDIR,"icon.png")
 FANART = os.path.join(ROOTDIR,"fanart.jpg")
 ROOT_URL = 'http://stream.nbcsports.com/data/mobile'
-# CONFIG_URL = '%s/apps/NBCSports/configuration-firetv-v2.json' % ROOT_URL
 CONFIG_URL = 'http://stream.nbcsports.com/data/mobile/apps/NBCSports/configuration-android-v6.json'
-# CONFIG_URL = 'http://stream.nbcsports.com/data/mobile/apps/NBCSports/configuration-androidtv-v4.json'
 
 # Main settings
 settings = xbmcaddon.Addon()
 FREE_ONLY = str(settings.getSetting("free_only"))
 KODI_VERSION = float(re.findall(r'\d{2}\.\d{1}', xbmc.getInfoLabel("System.BuildVersion"))[0])
-# if sys.version_info[0] > 2:
-#     FREE_ONLY = settings.getSettingString("free_only")
-# else:
-#     # CDN = int(settings.getSetting(id="cdn"))
-#     # USERNAME = str(settings.getSetting(id="username"))
-#     # PASSWORD = str(settings.getSetting(id="password"))
-#     # PROVIDER = str(settings.getSetting(id="provider"))
-#     FREE_ONLY = str(settings.getSetting("free_only"))
-#     # PLAY_BEST = str(settings.getSetting(id="play_best"))
 
 filter_ids = [
     "show-all",
@@ -81,7 +70,6 @@ for fid in filter_ids:
 
 # User Agents
 UA_NBCSN = 'Adobe Primetime/1.4 Dalvik/2.1.0 (Linux; U; Android 6.0.1; Hub Build/MHC19J)'
-#UA_NBCSN = 'Mozilla/5.0 (Linux; U; Android 9;  CPH1923 Build/PPR1.180610.011)'
 
 # Event Colors
 FREE = 'FF43CD80'
@@ -211,11 +199,6 @@ def add_premium_link(name, link_url, icon, stream_info, fanart=None, info=None):
     u = sys.argv[0] + "?url=" + urllib.quote_plus(link_url) + "&mode=5&icon_image=" + urllib.quote_plus(icon)
     for key in stream_info:
         u += '&%s=%s' % (key, stream_info[key])
-    # "&requestor_id=" + urllib.quote_plus(stream_info['requestor_id']) + "&channel=" \
-    #     + urllib.quote_plus(stream_info['channel']) + "&pid=" + urllib.quote_plus(stream_info['pid'])
-
-    xbmc.log(u)
-
     liz = xbmcgui.ListItem(name)
     if icon is None: icon = ICON
     if fanart is None: fanart = FANART

--- a/plugin.video.nbcsnliveextra/resources/lib/stream.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/stream.py
@@ -33,7 +33,7 @@ class Stream:
             "application": "NBCSports",
             "authInfo": {
                 "authenticationType": "adobe-pass",
-                "requestorId": "nbcsports",
+                "requestorId": self.requestor_id,
                 "resourceId": base64.b64encode(codecs.encode(self.resource_id)).decode("ascii"),
                 "token": self.media_token
             },
@@ -61,7 +61,7 @@ class Stream:
             "platform": "android",
             "authInfo": {
                 "authenticationType": "adobe-pass",
-                "requestorId": "nbcsports",
+                "requestorId": self.requestor_id,
                 "resourceId": base64.b64encode(codecs.encode(self.resource_id)).decode("ascii"),
                 "token": self.media_token
             },
@@ -72,7 +72,6 @@ class Stream:
                 }
         }
 
-        xbmc.log(str(payload))
         r = requests.post(self.token_url, headers=self.token_headers, cookies=load_cookies(), json=payload, verify=VERIFY)
         save_cookies(r.cookies)
         xbmc.log(r.text)
@@ -80,11 +79,6 @@ class Stream:
         return r.json()['drmToken']
 
     def create_listitem(self):
-        xbmc.log('------------------------------------------------------------------------------------------')
-        xbmc.log(self.manifest_url)
-        xbmc.log(self.drm_token)
-        xbmc.log('------------------------------------------------------------------------------------------')
-
         self.get_tokenized_url()
 
         is_helper = inputstreamhelper.Helper('hls', drm='widevine')
@@ -95,24 +89,17 @@ class Stream:
             else:
                 listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
 
-            xbmc.log('---------------------- Drm Type --------------------')
-            xbmc.log(self.drm_type)
-            xbmc.log('------------------------------------------------------')
             if self.drm_type == 'widevine':
                 lic_headers = 'User-Agent=Dalvik%2F2.1.0+(Linux%3B+U%3B+Android+6.0.1%3B+Hub+Build%2FMHC19J)'
                 lic_headers += '&Content-Type=application/octet-stream'
-                # lic_headers += '&X-NewRelic-ID=VQ8AU1RbChABU1VQAQkAV10%3D'
                 lic_headers += '&X-ISP-TOKEN=%s' % urllib.quote(self.get_drm_token())
                 license_key = '%s|%s|R{SSM}|' % (self.lic_url, lic_headers)
                 listitem.setProperty('inputstream.adaptive.license_key', license_key)
                 listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
-                xbmc.log(license_key)
 
             listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
             listitem.setProperty('inputstream.adaptive.stream_headers', 'User-Agent=%s' % UA_NBCSN)
         else:
             listitem.setMimeType("application/x-mpegURL")
-
-        # listitem = xbmcgui.ListItem(path=stream_url)
 
         return listitem


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2021.12.30+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix for list items not updating past November
        - Add support for DRM streams
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
