### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2022.1.3+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2021.12.30+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.1.3+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />
@@ -16,8 +16,7 @@
     <summary lang="en_GB">Watch NBCSN Live Extra</summary>
     <description lang="en_GB">NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network</description>
     <news>
-        - Fix for list items not updating past November
-        - Add support for DRM streams
+        - Fix for free content not playing
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.nbcsnliveextra/nbcsn.py
+++ b/plugin.video.nbcsnliveextra/nbcsn.py
@@ -219,11 +219,14 @@ elif mode == 5:
     sign_stream(url, name, icon_image, pid, drm_type, drm_asset_id)
 
 elif mode == 6:
-    # Set quality level based on user settings
-    #stream_url = set_stream_quality(url)
-    #listitem = xbmcgui.ListItem(path=stream_url)
-    stream_url = url + "|User-Agent=" + UA_NBCSN
-    play_stream(stream_url)
+    stream_vars = {
+        'drm_asset_id': drm_asset_id,
+        'drm_type': drm_type,
+        'manifest_url': url,
+        'pid': pid
+    }
+    stream = Stream(stream_vars)
+    xbmcplugin.setResolvedUrl(ADDON_HANDLE, True, stream.create_listitem())
 
 elif mode == 999:
     logout()

--- a/plugin.video.nbcsnliveextra/resources/lib/stream.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/stream.py
@@ -25,8 +25,8 @@ class Stream:
         self.drm_type = stream_vars['drm_type']
         self.manifest_url = stream_vars['manifest_url']
         self.pid = stream_vars['pid']
-        self.resource_id = stream_vars['resource_id']
-        self.media_token = stream_vars['media_token']
+        if 'media_token' in stream_vars: self.media_token = stream_vars['media_token']
+        if 'resource_id' in stream_vars: self.resource_id = stream_vars['resource_id']
 
     def get_tokenized_url(self):
         payload = {
@@ -65,11 +65,10 @@ class Stream:
                 "resourceId": base64.b64encode(codecs.encode(self.resource_id)).decode("ascii"),
                 "token": self.media_token
             },
-            "drmInfo":
-                {
-                    "assetId": self.drm_asset_id,
-                    "deviceId": "android_c577f1f28b8d181d"
-                }
+            "drmInfo": {
+                "assetId": self.drm_asset_id,
+                "deviceId": "android_c577f1f28b8d181d"
+            }
         }
 
         r = requests.post(self.token_url, headers=self.token_headers, cookies=load_cookies(), json=payload, verify=VERIFY)
@@ -79,8 +78,7 @@ class Stream:
         return r.json()['drmToken']
 
     def create_listitem(self):
-        self.get_tokenized_url()
-
+        if self.media_token != '': self.get_tokenized_url()
         is_helper = inputstreamhelper.Helper('hls', drm='widevine')
         listitem = xbmcgui.ListItem(path=('%s|User-Agent=%s') % (self.manifest_url, UA_NBCSN))
         if is_helper.check_inputstream():


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2022.1.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix for free content not playing
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
