### PR TITLE
[plugin.video.composite_for_plex@leia] 1.4.2

### DIFF
--- a/plugin.video.composite_for_plex/addon.xml
+++ b/plugin.video.composite_for_plex/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.composite_for_plex" name="Composite" version="1.4.1" provider-name="anxdpanic">
+<addon id="plugin.video.composite_for_plex" name="Composite" version="1.4.2" provider-name="anxdpanic">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.kodi-six" version="0.0.2"/>
@@ -37,25 +37,33 @@
         </menu>
     </extension>
     <extension point="xbmc.addon.metadata">
-        <news>
-[fix] xbmc.translatePath -&gt; xbmcvfs.translatePath |Kodi 19|
-[upd] improve resuming playback
-[upd] improve accuracy of library context menus |Kodi 19|
-[chg] group playlist sections on main menu
-[chg] always used cached servers during playback
-        </news>
         <assets>
             <icon>resources/media/icon.png</icon>
             <fanart>resources/media/fanart.png</fanart>
         </assets>
+        <news>
+[fix] use of deprecated ElementTree.getiterator
+[fixup] custom access urls
+[add] Detect Servers to main menu
+[chg] only refresh server cache on connection errors
+[upd] linting
+[lang] update translations from Weblate
+        </news>
         <platform>all</platform>
         <license>GPL-2.0-or-later</license>
         <source>https://github.com/anxdpanic/plugin.video.composite_for_plex</source>
         <forum>https://composite.panicked.xyz/forum</forum>
-        <description lang="en_GB">Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay</description>
-        <disclaimer lang="en_GB">Composite is NOT an official Plex add-on and is not supported or endorsed by Plex.</disclaimer>
-        <description lang="de_DE">Durchsuchen und Abspielen von Videos, Musik und Fotos, die vom Plex Media Server verwaltet werden.[CR][CR]Fork von Hippojay's PleXBMC</description>
-        <disclaimer lang="de_DE">Composite ist KEIN offizielles Plex Add-on und wird von Plex weder unterstützt noch gebilligt.</disclaimer>
         <reuselanguageinvoker>true</reuselanguageinvoker>
+        <description lang="de_DE">Durchsuchen und Abspielen von Videos, Musik und Fotos, die vom Plex Media Server verwaltet werden.[CR][CR]Fork von Hippojay's PleXBMC</description>
+        <description lang="en_GB">Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay</description>
+        <description lang="es_MX">Explora y reproduce multimedia tal como video, música y e imágenes administrados por Plex Media Server.[CR][CR]Fork de PleXBMC por Hippojay</description>
+        <description lang="fi_FI">Selaa ja toista video-, musiikki- ja valokuvamediatiedostoja, joita Plex Media Server hallinnoi.[CR][CR]Hippojayn haaroitus PleXBMC:stä</description>
+        <description lang="pl_PL">Przeglądaj i odtwarzaj pliki multimedialne zarządzane przez Plex Media Server.[CR] [CR] Jest to fork PleXBMC stworzonego przez Hippojay'a</description>
+        <description lang="vi_VN">Duyệt và phát các tập tin đa phương tiện video, nhạc và ảnh do Plex Media Server quản lý.[CR][CR]Fork of PleXBMC by Hippojay</description>
+        <disclaimer lang="de_DE">Composite ist KEIN offizielles Plex-Addon und wird von Plex weder unterstützt noch gebilligt.</disclaimer>
+        <disclaimer lang="en_GB">Composite is NOT an official Plex add-on and is not supported or endorsed by Plex.</disclaimer>
+        <disclaimer lang="es_MX">Composite NO es un complemento oficial de Plex y no tiene soporte o respaldo por parte de Plex.</disclaimer>
+        <disclaimer lang="pl_PL">Composite NIE jest oficjalnym dodatkiem do programu Plex, nie jest wspierany ani zatwierdzany przez firmę Plex.</disclaimer>
+        <disclaimer lang="vi_VN">Composite KHÔNG phải là một tiện ích chính thức của Plex và không được Plex hỗ trợ hoặc xác nhận.</disclaimer>
     </extension>
 </addon>

--- a/plugin.video.composite_for_plex/resources/language/resource.language.af_za/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.af_za/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: af_za\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.am_et/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.am_et/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: am_et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ar_sa/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ar_sa/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar_sa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ast_es/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ast_es/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ast_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.az_az/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.az_az/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: az_az\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.be_by/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.be_by/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: be_by\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.bg_bg/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.bg_bg/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.bs_ba/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.bs_ba/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bs_ba\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ca_es/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ca_es/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.cs_cz/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.cs_cz/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.cy_gb/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.cy_gb/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cy_gb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : (n==3) ? 3 :(n==6) ? 4 : 5;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.da_dk/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.da_dk/strings.po
@@ -1,0 +1,1580 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2021-06-28 08:29+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Danish <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/da_dk/>\n"
+"Language: da_dk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.7\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr "Plex Online"
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr "Log ud"
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr "Alle"
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr "Ikke set"
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr "Senest tilføjede"
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr "Senest tilføjede afsnit"
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr "Senest sete tv-serier"
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr "Alle"
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.de_de/strings.po
@@ -5,17 +5,25 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Composite\n"
-"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: Maven85\n"
-"Language-Team: German"
-"Language: de_DE\n"
+"PO-Revision-Date: 2021-10-07 01:53+0000\n"
+"Last-Translator: Kai Sommerfeld <kai.sommerfeld@gmx.com>\n"
+"Language-Team: German <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/de_de/>\n"
+"Language: de_de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.6\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.8\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr "Durchsuchen und Abspielen von Videos, Musik und Fotos, die vom Plex Media Server verwaltet werden.[CR][CR]Fork von Hippojay's PleXBMC"
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr "Composite ist KEIN offizielles Plex-Addon und wird von Plex weder unterstützt noch gebilligt."
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -31,11 +39,11 @@ msgstr "Plex Online"
 
 msgctxt "#30003"
 msgid "About to install"
-msgstr "Installiere"
+msgstr "Zu installieren"
 
 msgctxt "#30004"
 msgid "This plugin is already installed"
-msgstr "Das Add-on ist bereits installiert"
+msgstr "Das Addon ist bereits installiert"
 
 msgctxt "#30005"
 msgid "Switch Failed"
@@ -47,7 +55,7 @@ msgstr "Abmelden"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
-msgstr "Um sich abzumelden, musst du als Administrator angemeldet sein. Wechsel den Benutzer und versuche es erneut"
+msgstr "Zum Abmelden muss man als Administrator angemeldet sein. Bitte den Benutzer wechseln und erneut versuchen"
 
 msgctxt "#30008"
 msgid "myPlex"
@@ -55,17 +63,16 @@ msgstr "myPlex"
 
 msgctxt "#30009"
 msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
-msgstr "Du bist zurzeit bei myPlex angemeldet. Möchstest du dich wirklich abmelden?"
+msgstr "Zurzeit angemeldet by myPlex. Wirklich abmelden?"
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
-msgstr "Du bist zurzeit nicht bei myPlex angemeldet. Setze fort, um dich anzumelden, oder brich ab, um zurückzukehren"
+msgstr "Zurzeit nicht bei myPlex angemeldet. Fortfahren, um sich anzumelden, oder abbrechen, um zurückzukehren"
 
 msgctxt "#30012"
 msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
-msgstr "Um auf diese Bildschirme zugreifen zu können, musst du als Administrator angemeldet sein. Wechsel den Benutzer und versuche es erneut"
+msgstr "Um auf diese Bildschirme zugreifen zu können, muss man als Administrator angemeldet sein. Bitte den Benutzer wechseln und erneut versuchen"
 
 msgctxt "#30013"
 msgid "All"
@@ -85,7 +92,7 @@ msgstr "Kürzlich hinzugefügt"
 
 msgctxt "#30017"
 msgid "Recently Viewed Episodes"
-msgstr "Kürzlich gesehene Folgen"
+msgstr "Kürzlich gesehene Episoden"
 
 msgctxt "#30018"
 msgid "Recently Viewed Shows"
@@ -121,11 +128,11 @@ msgstr "Nach Ordner"
 
 msgctxt "#30026"
 msgid "Search Shows..."
-msgstr "Suche Serien..."
+msgstr "Serien suchen ..."
 
 msgctxt "#30027"
 msgid "Search Episodes..."
-msgstr "Suche Folgen..."
+msgstr "Episoden suchen ..."
 
 msgctxt "#30028"
 msgid "All"
@@ -157,15 +164,15 @@ msgstr "Nach Ordner"
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr "Suche Künstler..."
+msgstr "Interpreten suchen ..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr "Suche Album..."
+msgstr "Alben suchen ..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
-msgstr "Suche Titel..."
+msgstr "Titel suchen ..."
 
 msgctxt "#30038"
 msgid "All"
@@ -213,7 +220,7 @@ msgstr "Nach Regisseur"
 
 msgctxt "#30049"
 msgid "By Starring Actor"
-msgstr "Nach Schauspieler"
+msgstr "Nach Darsteller"
 
 msgctxt "#30050"
 msgid "By Country"
@@ -241,7 +248,7 @@ msgstr "Nach Ordner"
 
 msgctxt "#30056"
 msgid "Search..."
-msgstr "Suche..."
+msgstr "Suchen ..."
 
 msgctxt "#30057"
 msgid "All"
@@ -285,7 +292,7 @@ msgstr "Es können keine Medienserver angezeigt werden"
 
 msgctxt "#30067"
 msgid "Unable to contact server:"
-msgstr "Verbindung zum Server nicht möglich:"
+msgstr "Verbindung nicht möglich zum Server:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
@@ -301,19 +308,19 @@ msgstr "Fortsetzen"
 
 msgctxt "#30071"
 msgid "Select media to play"
-msgstr "Abzuspielende Medien wählen"
+msgstr "Medien für Wiedergabe auswählen"
 
 msgctxt "#30072"
 msgid "Select subtitle"
-msgstr "Untertiel wählen"
+msgstr "Untertiel auswählen"
 
 msgctxt "#30073"
 msgid "Select audio"
-msgstr "Audio wählen"
+msgstr "Audio auswählen"
 
 msgctxt "#30074"
 msgid "Select master server"
-msgstr "Hauptserver wählen"
+msgstr "Hauptserver auswählen"
 
 msgctxt "#30075"
 msgid "Known server list"
@@ -321,11 +328,11 @@ msgstr "Bekannte Server"
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr "Benutzerwechsel"
+msgstr "Benutzer wechseln"
 
 msgctxt "#30077"
 msgid "Enter PIN"
-msgstr "PIN-Eingabe"
+msgstr "PIN eingeben"
 
 msgctxt "#30078"
 msgid "Resume from"
@@ -333,7 +340,7 @@ msgstr "Fortsetzen bei"
 
 msgctxt "#30079"
 msgid "Start from beginning"
-msgstr "Von Anfang abspielen"
+msgstr "Von Anfang wiedergeben"
 
 msgctxt "#30080"
 msgid "myPlex Queue"
@@ -341,7 +348,7 @@ msgstr "myPlex-Warteschlange"
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr "Einloggen"
+msgstr "Anmelden"
 
 msgctxt "#30082"
 msgid "Display Servers"
@@ -365,7 +372,7 @@ msgstr "Transcodierte Wiedergabe"
 
 msgctxt "#30087"
 msgid "All episodes"
-msgstr "Alle Folgen"
+msgstr "Alle Episoden"
 
 msgctxt "#30088"
 msgid "Season"
@@ -373,14 +380,13 @@ msgstr "Staffel"
 
 msgctxt "#30089"
 msgid "Search for"
-msgstr "Suche nach"
+msgstr "Suchen nach"
 
 msgctxt "#30090"
 msgid "Unplayed"
-msgstr "Ungespielt"
+msgstr "Nicht wiedergegeben"
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr "Adresse des primären Servers"
@@ -395,7 +401,7 @@ msgstr "Erweiterte Metadaten vom PMS holen"
 
 msgctxt "#30503"
 msgid "Enable extra filter menus"
-msgstr "Menü mit erweiterten Filtern zeigen"
+msgstr "Zusätzliche Filtermenüs aktivieren"
 
 msgctxt "#30504"
 msgid "Server Discovery"
@@ -418,12 +424,12 @@ msgid "Transcode format "
 msgstr "Transcoding-Format "
 
 msgctxt "#30509"
-msgid "Recent & On Deck items"
-msgstr "Letzte & aktuelle Titel"
+msgid "Recent & OnDeck items"
+msgstr "Kürzliche und aktuelle Einträge"
 
 msgctxt "#30510"
 msgid "Debug log"
-msgstr "Debug-Log"
+msgstr "Debug-Protokoll"
 
 msgctxt "#30511"
 msgid "Auto"
@@ -443,7 +449,7 @@ msgstr "Debug-Level"
 
 msgctxt "#30515"
 msgid "Use transcoding proxy"
-msgstr "Verwende Transcoding-Proxy"
+msgstr "Transcoding-Proxy verwenden"
 
 msgctxt "#30516"
 msgid "Server"
@@ -487,7 +493,7 @@ msgstr "myPlex-Passwort"
 
 msgctxt "#30526"
 msgid "Select master server..."
-msgstr "Hauptserver auswählen..."
+msgstr "Hauptserver auswählen ..."
 
 msgctxt "#30527"
 msgid "Authentication required?"
@@ -527,7 +533,7 @@ msgstr "Auswahl des Untertitel-Streams"
 
 msgctxt "#30536"
 msgid "Kodi Control"
-msgstr "Kodi"
+msgstr "Kodi-Steuerung"
 
 msgctxt "#30537"
 msgid "External"
@@ -539,7 +545,7 @@ msgstr "Quelle für Audio- und Untertitel-Auswahl"
 
 msgctxt "#30539"
 msgid "Never show subtitles"
-msgstr "Keine Untertitel"
+msgstr "Niemals Untertitel anziegen"
 
 msgctxt "#30540"
 msgid "Quality"
@@ -555,7 +561,7 @@ msgstr "Ansicht der Plex-Kanäle"
 
 msgctxt "#30543"
 msgid "Flatten TV Shows"
-msgstr "Serien-Staffel reduzieren"
+msgstr "Serien reduzieren"
 
 msgctxt "#30544"
 msgid "Server MAC address"
@@ -563,7 +569,7 @@ msgstr "MAC-Adresse des Servers"
 
 msgctxt "#30545"
 msgid "Plex Style Watched flags"
-msgstr "Gesehen-Markierung im Plex-Stil anzeigen"
+msgstr "Gesehen-Markierung im Plex-Stil"
 
 msgctxt "#30546"
 msgid "Windows Media Server?"
@@ -574,14 +580,13 @@ msgid "Use WOL?"
 msgstr "Wake on LAN verwenden?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
-msgstr "Informationen über Genre/Regisseur/Author überspringen"
+msgstr "Informationen für Genre/Regisseur/Autor überspringen"
 
 msgctxt "#30550"
 msgid "Skip images (thumbs, fanart)"
-msgstr "Bilder (Vorschaubilder, Hintergrundbilder) überspringen"
+msgstr "Bilder (Vorschaubilder, Fanart) überspringen"
 
 msgctxt "#30551"
 msgid "Skip Media Flags"
@@ -589,7 +594,7 @@ msgstr "Medienmarkierungen überspringen"
 
 msgctxt "#30552"
 msgid "Skip Context Menus"
-msgstr "Kontextmenüelemente überspringen"
+msgstr "Kontextmenüs überspringen"
 
 msgctxt "#30553"
 msgid "Off"
@@ -601,7 +606,7 @@ msgstr "Bonjour"
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
-msgstr "TV-Theme abspielen"
+msgstr "TV-Theme-Musik wiedergeben"
 
 msgctxt "#30557"
 msgid "Select audio output"
@@ -645,7 +650,7 @@ msgstr "NAS-Stammordner"
 
 msgctxt "#30567"
 msgid "Plex Control"
-msgstr "PMS"
+msgstr "Plex Control"
 
 msgctxt "#30568"
 msgid "Subtitle Size"
@@ -653,7 +658,7 @@ msgstr "Untertitelgröße"
 
 msgctxt "#30569"
 msgid "Audio Boost"
-msgstr "Lautstärke erhöhen"
+msgstr "Lautstärkeerhöhung"
 
 msgctxt "#30570"
 msgid "Auto (GDM)"
@@ -677,7 +682,7 @@ msgstr "Aktuell"
 
 msgctxt "#30575"
 msgid "Force Skin Views"
-msgstr "Ansicht im Skin erzwingen"
+msgstr "Skin-Ansichten erzwingen"
 
 msgctxt "#30576"
 msgid "Skin Name"
@@ -693,7 +698,7 @@ msgstr "Ansicht für Serien"
 
 msgctxt "#30579"
 msgid "Season View"
-msgstr "Ansicht für Staffel"
+msgstr "Ansicht für Staffeln"
 
 msgctxt "#30580"
 msgid "Episode View"
@@ -705,27 +710,27 @@ msgstr "Ansicht für Musik"
 
 msgctxt "#30582"
 msgid "Enable Movie Shelf"
-msgstr "Shelf für Filme aktivieren"
+msgstr "Filmregal aktivieren"
 
 msgctxt "#30583"
 msgid "Enable TV Shelf"
-msgstr "Shelf für Serien aktivieren"
+msgstr "Serienregal aktivieren"
 
 msgctxt "#30584"
 msgid "Enable Music Shelf"
-msgstr "Shelf für Musik aktivieren"
+msgstr "Musikregal aktivieren"
 
 msgctxt "#30585"
 msgid "Enable Channel Shelf"
-msgstr "Shelf für Kanäle aktivieren"
+msgstr "Kanalregal aktivieren"
 
 msgctxt "#30586"
 msgid "Content filter"
-msgstr "Inhalte filtern"
+msgstr "Inhaltefilter"
 
 msgctxt "#30587"
 msgid "Map unknown content as:"
-msgstr "Unbekannte Bewertungen filtern für:"
+msgstr "Unbekannte Inhalte behandeln als:"
 
 msgctxt "#30588"
 msgid "RA Library filter"
@@ -761,7 +766,7 @@ msgstr "Vorschaubilder in voller Auflösung verwenden"
 
 msgctxt "#30596"
 msgid "Use full resolution fanart"
-msgstr "Hintergrundbilder in voller Auflösung verwenden"
+msgstr "Fanart in voller Auflösung verwenden"
 
 msgctxt "#30597"
 msgid "Hide watched recently added items"
@@ -769,7 +774,7 @@ msgstr "Gesehene Elemente in 'Kürzlich hinzugefügt' verstecken"
 
 msgctxt "#30598"
 msgid "Info"
-msgstr "Info"
+msgstr "Information"
 
 msgctxt "#30599"
 msgid "Debug"
@@ -789,7 +794,7 @@ msgstr "Clientname"
 
 msgctxt "#30603"
 msgid "Disable 'All Episodes'"
-msgstr "'Alle Episoden' aus Liste der Staffeln ausblenden"
+msgstr "‚Alle Episoden‘ deaktivieren"
 
 msgctxt "#30604"
 msgid "Enable Kodi view cache"
@@ -805,7 +810,7 @@ msgstr "Staffel-Artwork bevorzugen"
 
 msgctxt "#30607"
 msgid "Hide Unique Information in log"
-msgstr "Keine Benutzerinformation in das Log schreiben"
+msgstr "Keine Benutzerinformation in das Protokoll schreiben"
 
 msgctxt "#30608"
 msgid "Use Kodi client name?"
@@ -821,11 +826,11 @@ msgstr "HTTPS verwenden"
 
 msgctxt "#30611"
 msgid "Transcode > 1080p"
-msgstr "Transkodiere > 1080p"
+msgstr "> 1080p transkodieren"
 
 msgctxt "#30612"
 msgid "Transcode HEVC"
-msgstr "Transkodiere HEVC"
+msgstr "HEVC transkodieren"
 
 msgctxt "#30613"
 msgid "MAC Address"
@@ -877,7 +882,7 @@ msgstr "Anmeldung nicht möglich"
 
 msgctxt "#30625"
 msgid "From your computer, go to %s and enter the code below"
-msgstr "Rufe die Webseite %s auf und gib folgenden Code ein"
+msgstr "Webseite %s aufrufen und folgenden Code eingeben"
 
 msgctxt "#30626"
 msgid "Successfully signed in"
@@ -904,30 +909,27 @@ msgid "Exit"
 msgstr "Beenden"
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
-msgstr "Gib unten die myPlex-Daten ein"
+msgstr "Bitte myPlex-Daten eingeben"
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr "Unbekannt"
 
 msgctxt "#30637"
 msgid "myPlex Login"
-msgstr "myPlex Anmeldung"
+msgstr "myPlex-Anmeldung"
 
 msgctxt "#30638"
 msgid "Enter search term"
-msgstr "Suchbegriff"
+msgstr "Suchbegriff eingeben"
 
 msgctxt "#30639"
 msgid "Enter value"
-msgstr "Wert"
+msgstr "Wert eingeben"
 
 msgctxt "#30640"
 msgid "Transcode Profile"
@@ -975,23 +977,23 @@ msgstr "Serversuche"
 
 msgctxt "#30651"
 msgid "Please wait..."
-msgstr "Bitte warten..."
+msgstr "Bitte warten ..."
 
 msgctxt "#30652"
 msgid "myPlex discovery..."
-msgstr "myPlex-Suche"
+msgstr "myPlex-Suche ..."
 
 msgctxt "#30653"
 msgid "GDM discovery..."
-msgstr "GDM-Suche..."
+msgstr "GDM-Suche ..."
 
 msgctxt "#30654"
 msgid "User provided..."
-msgstr "Vom Benutzer bereitgestellt..."
+msgstr "Vom Benutzer bereitgestellt ..."
 
 msgctxt "#30655"
 msgid "Caching results..."
-msgstr "Caching-Ergebnisse..."
+msgstr "Ergebnisse zwischenspeichern ..."
 
 msgctxt "#30656"
 msgid "Finished"
@@ -1007,11 +1009,11 @@ msgstr "Keine Server gefunden"
 
 msgctxt "#30659"
 msgid "Transcode > 8-bit"
-msgstr "Transkodiere > 8-bit"
+msgstr "> 8-bit transcodieren"
 
 msgctxt "#30660"
 msgid "Device Name"
-msgstr "Gerätenamen"
+msgstr "Gerätename"
 
 msgctxt "#30661"
 msgid "Cache"
@@ -1059,19 +1061,19 @@ msgstr "Standard"
 
 msgctxt "#30672"
 msgid "Go to %s"
-msgstr "Gehe zu %s"
+msgstr "Zu %s gehen"
 
 msgctxt "#30673"
 msgid "Delete %s from the %s playlist?"
-msgstr "%s von der Wiedergabeliste '%s' entfernen?"
+msgstr "%s aus der Wiedergabeliste ‚%s‘ entfernen?"
 
 msgctxt "#30674"
 msgid "Confirm playlist item delete?"
-msgstr "Titel von der Wiedergabeliste entfernen?"
+msgstr "Eintrag aus der Wiedergabeliste entfernen?"
 
 msgctxt "#30675"
 msgid "Delete from playlist"
-msgstr "Von der Wiedergabeliste entfernen"
+msgstr "Aus der Wiedergabeliste entfernen"
 
 msgctxt "#30676"
 msgid "Select playlist"
@@ -1083,27 +1085,27 @@ msgstr "Zur Wiedergabeliste hinzufügen"
 
 msgctxt "#30678"
 msgid "Added %s to the %s playlist"
-msgstr "%s zur Wiedergabeliste '%s' hinzugefügt"
+msgstr "%s zur Wiedergabeliste ‚%s‘ hinzugefügt"
 
 msgctxt "#30679"
 msgid "Failed to add %s to the %s playlist"
-msgstr "Hinzufügen von %s zur Wiedergabeliste '%s' fehlgeschlagen"
+msgstr "Hinzufügen von %s zur Wiedergabeliste ‚%s‘ fehlgeschlagen"
 
 msgctxt "#30680"
 msgid "%s is already in the %s playlist"
-msgstr "%s ist bereits in der Wiedergabeliste '%s'"
+msgstr "%s ist bereits in der Wiedergabeliste ‚%s‘ vorhanden"
 
 msgctxt "#30681"
 msgid "%s has been removed the %s playlist"
-msgstr "%s von der Wiedergabeliste '%s' entfernt"
+msgstr "%s wurde aus der Wiedergabeliste ‚%s‘ entfernt"
 
 msgctxt "#30682"
 msgid "Unable to remove %s from the %s playlist"
-msgstr "Entfernen von %s von der Wiedergabeliste '%s' fehlgeschlagen"
+msgstr "Entfernen von %s aus der Wiedergabeliste ‚%s‘ fehlgeschlagen"
 
 msgctxt "#30683"
 msgid "Show the 'Delete' context menu"
-msgstr "'Löschen' im Kontextmenü anzeigen"
+msgstr "‚Löschen‘ im Kontextmenü anzeigen"
 
 msgctxt "#30684"
 msgid "Up Next"
@@ -1111,31 +1113,31 @@ msgstr "Up Next"
 
 msgctxt "#30685"
 msgid "Enable Up Next"
-msgstr "'Up Next' aktivieren"
+msgstr "‚Up Next‘ aktivieren"
 
 msgctxt "#30686"
 msgid "Open Up Next settings"
-msgstr "'Up Next'-Einstellungen"
+msgstr "‚Up Next‘-Einstellungen"
 
 msgctxt "#30687"
 msgid "Install Up Next"
-msgstr "'Up Next' installieren"
+msgstr "‚Up Next‘ installieren"
 
 msgctxt "#30688"
 msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
-msgstr "'Up Next' ist in den Einstellungen aktiviert, scheint jedoch deaktiviert zu sein. 'Up Next' jetzt aktivieren?"
+msgstr "‚Up Next‘ ist in den Einstellungen aktiviert, scheint jedoch deaktiviert zu sein. ‚Up Next‘ jetzt aktivieren?"
 
 msgctxt "#30689"
 msgid "Up Next requires Kodi 18 or higher"
-msgstr "'Up Next' benötigt Kodi 18 oder höher"
+msgstr "‚Up Next‘ benötigt Kodi 18 oder höher"
 
 msgctxt "#30690"
 msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
-msgstr "Rufe die Webseite [B]%s[/B] auf und gib folgenden Code ein: [B]%s[/B]"
+msgstr "Die Webseite [B]%s[/B] auf rufen und folgenden Code eingeben: [B]%s[/B]"
 
 msgctxt "#30691"
 msgid "Use episode thumbnails"
-msgstr "Folgen-Thumbnails verwenden"
+msgstr "Episoden-Vorschaubilder verwenden"
 
 msgctxt "#30692"
 msgid "Widgets"
@@ -1143,7 +1145,7 @@ msgstr "Widgets"
 
 msgctxt "#30693"
 msgid "Show [B]Widgets[/B] menu"
-msgstr "Menüpunkt [B]Widgets[/B] zeigen"
+msgstr "Menüpunkt [B]Widgets[/B] anzeigen"
 
 msgctxt "#30694"
 msgid "Clear Caches"
@@ -1211,7 +1213,7 @@ msgstr "Port"
 
 msgctxt "#30710"
 msgid "Kodi's Web Server Settings"
-msgstr "Kodi's Webserver-Einstellungen"
+msgstr "Kodis Webserver-Einstellungen"
 
 msgctxt "#30711"
 msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
@@ -1219,7 +1221,7 @@ msgstr "[COLOR=red]EXPERIMENTELL[/COLOR] - Dieses Feature ist experimentell[CR]�
 
 msgctxt "#30712"
 msgid "Username"
-msgstr "Benutzer"
+msgstr "Benutzername"
 
 msgctxt "#30713"
 msgid "Password"
@@ -1231,19 +1233,19 @@ msgstr "Hauptmenü"
 
 msgctxt "#30715"
 msgid "Show [B]myPlex Queue[/B] menu"
-msgstr "Menüpunkt [B]myPlex Warteschlange[/B] zeigen"
+msgstr "Menüpunkt [B]myPlex Warteschlange[/B] anzeigen"
 
 msgctxt "#30716"
 msgid "Show [B]Channels[/B] menu"
-msgstr "Menüpunkt [B]Kanäle[/B] zeigen"
+msgstr "Menüpunkt [B]Kanäle[/B] anzeigen"
 
 msgctxt "#30717"
 msgid "Show [B]Plex Online[/B] menu"
-msgstr "Menüpunkt [B]Plex Online[/B] zeigen"
+msgstr "Menüpunkt [B]Plex Online[/B] anzeigen"
 
 msgctxt "#30718"
 msgid "Show [B]Playlists[/B] menu"
-msgstr "Menüpunkt [B]Wiedergabelisten[/B] zeigen"
+msgstr "Menüpunkt [B]Wiedergabelisten[/B] anzeigen"
 
 msgctxt "#30719"
 msgid "Context Menu"
@@ -1263,7 +1265,7 @@ msgstr "Wiedergabeliste erstellen"
 
 msgctxt "#30723"
 msgid "Enter a playlist title"
-msgstr "Titel der Wiedergabeliste"
+msgstr "Titel für die Wiedergabeliste eingeben"
 
 msgctxt "#30724"
 msgid "Delete playlist"
@@ -1283,7 +1285,7 @@ msgstr "Benachrichtigungscodierung"
 
 msgctxt "#30728"
 msgid "Episode sort method"
-msgstr "Sortiermethode bei Episoden"
+msgstr "Sortiermethode für Episoden"
 
 msgctxt "#30729"
 msgid "Plex"
@@ -1299,11 +1301,11 @@ msgstr "Server verwalten"
 
 msgctxt "#30732"
 msgid "Set as Master"
-msgstr "Hauptserver einstellen"
+msgstr "Als Hauptserver einstellen"
 
 msgctxt "#30733"
 msgid "Connection Test Results"
-msgstr "Verbindungstestergebnisse"
+msgstr "Verbindungs-Testergebnisse"
 
 msgctxt "#30734"
 msgid "Default to forced subtitles"
@@ -1343,7 +1345,7 @@ msgstr "Benutzerdefiniert"
 
 msgctxt "#30743"
 msgid "All Artists"
-msgstr "Alle Künstler"
+msgstr "Alle Interpreten"
 
 msgctxt "#30744"
 msgid "All Photos"
@@ -1359,11 +1361,11 @@ msgstr "Alle Filme"
 
 msgctxt "#30747"
 msgid "Preferred lyrics format"
-msgstr "Bevorzugtes Textformat"
+msgstr "Bevorzugtes Format für Liedtexte"
 
 msgctxt "#30748"
 msgid "Lyrics"
-msgstr "Text"
+msgstr "Liedtext"
 
 msgctxt "#30749"
 msgid "lrc"
@@ -1391,7 +1393,7 @@ msgstr "Plex powered by LyricFind"
 
 msgctxt "#30755"
 msgid "Show skip intro dialog"
-msgstr "'Intro überspringen'-Dialog anzeigen"
+msgstr "‚Intro überspringen‘-Dialog anzeigen"
 
 msgctxt "#30756"
 msgid "All %s"
@@ -1568,3 +1570,15 @@ msgstr ""
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
 msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""
+
+#~ msgctxt "#30509"
+#~ msgid "Recent & On Deck items"
+#~ msgstr "Letzte & aktuelle Titel"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.el_gr/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.el_gr/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.en_au/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.en_au/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_au\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.en_gb/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -1566,4 +1574,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.en_nz/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.en_nz/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_nz\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.en_us/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.en_us/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.eo/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.eo/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.es_ar/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.es_ar/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es_ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.es_es/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.es_es/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.es_mx/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.es_mx/strings.po
@@ -5,36 +5,45 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Composite\n"
-"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: GITHUB USERNAME\n"
-"Language-Team: Spanish - Mexico\n"
-"Language: es_MX\n"
+"PO-Revision-Date: 2021-12-13 23:13+0000\n"
+"Last-Translator: Edson Armando <edsonarmando78@outlook.com>\n"
+"Language-Team: Spanish (Mexico) <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/es_mx/>\n"
+"Language: es_mx\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.9.1\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr "Explora y reproduce multimedia tal como video, música y e imágenes administrados por Plex Media Server.[CR][CR]Fork de PleXBMC por Hippojay"
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr "Composite NO es un complemento oficial de Plex y no tiene soporte o respaldo por parte de Plex."
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
-msgstr ""
+msgstr "¿Confirmar eliminación de archivo?"
 
 msgctxt "#30001"
 msgid "Delete this item? This action will delete media and associated data files."
-msgstr ""
+msgstr "¿Eliminar este elemento? Esta acción eliminará los archivos de medios y sus datos asociados."
 
 msgctxt "#30002"
 msgid "Plex Online"
-msgstr ""
+msgstr "Plex en línea"
 
 msgctxt "#30003"
 msgid "About to install"
-msgstr ""
+msgstr "A punto de instalar"
 
 msgctxt "#30004"
 msgid "This plugin is already installed"
-msgstr ""
+msgstr "Este complemento ya está instalado"
 
 msgctxt "#30005"
 msgid "Switch Failed"
@@ -42,53 +51,52 @@ msgstr ""
 
 msgctxt "#30006"
 msgid "Sign Out"
-msgstr ""
+msgstr "Cerrar sesión"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
-msgstr ""
+msgstr "Para cerrar sesión debes haber iniciado sesión como administrador. Cambia de usuario e inténtalo nuevamente"
 
 msgctxt "#30008"
 msgid "myPlex"
-msgstr ""
+msgstr "myPlex"
 
 msgctxt "#30009"
 msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
-msgstr ""
+msgstr "Has iniciado sesión en myPlex. ¿Seguro que quieres cerrar sesión?"
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
-msgstr ""
+msgstr "No has iniciado sesión en myPlex. Continúa para iniciar sesión, o cancela para regresar"
 
 msgctxt "#30012"
 msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
-msgstr ""
+msgstr "Para acceder a estos menús debes iniciar sesión como administrador. Cambia de usuario e inténtalo nuevamente"
 
 msgctxt "#30013"
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 msgctxt "#30014"
 msgid "Unwatched"
-msgstr ""
+msgstr "No visto"
 
 msgctxt "#30015"
 msgid "Recently Aired"
-msgstr ""
+msgstr "Emitido recientemente"
 
 msgctxt "#30016"
 msgid "Recently Added"
-msgstr ""
+msgstr "Agregado recientemente"
 
 msgctxt "#30017"
 msgid "Recently Viewed Episodes"
-msgstr ""
+msgstr "Episodios vistos recientemente"
 
 msgctxt "#30018"
 msgid "Recently Viewed Shows"
-msgstr ""
+msgstr "Series vistas recientemente"
 
 msgctxt "#30019"
 msgid "On Deck"
@@ -96,95 +104,95 @@ msgstr ""
 
 msgctxt "#30020"
 msgid "By Collection"
-msgstr ""
+msgstr "Por colección"
 
 msgctxt "#30021"
 msgid "By First Letter"
-msgstr ""
+msgstr "Por letra"
 
 msgctxt "#30022"
 msgid "By Genre"
-msgstr ""
+msgstr "Por género"
 
 msgctxt "#30023"
 msgid "By Year"
-msgstr ""
+msgstr "Por año"
 
 msgctxt "#30024"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Por clasificación"
 
 msgctxt "#30025"
 msgid "By Folder"
-msgstr ""
+msgstr "Por carpeta"
 
 msgctxt "#30026"
 msgid "Search Shows..."
-msgstr ""
+msgstr "Buscar series..."
 
 msgctxt "#30027"
 msgid "Search Episodes..."
-msgstr ""
+msgstr "Buscar episodios..."
 
 msgctxt "#30028"
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 msgctxt "#30029"
 msgid "By Album"
-msgstr ""
+msgstr "Por álbum"
 
 msgctxt "#30030"
 msgid "By Genre"
-msgstr ""
+msgstr "Por género"
 
 msgctxt "#30031"
 msgid "By Year"
-msgstr ""
+msgstr "Por año"
 
 msgctxt "#30032"
 msgid "By Collection"
-msgstr ""
+msgstr "Por colección"
 
 msgctxt "#30033"
 msgid "Recently Added"
-msgstr ""
+msgstr "Agregado recientemente"
 
 msgctxt "#30034"
 msgid "By Folder"
-msgstr ""
+msgstr "Por carpeta"
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr ""
+msgstr "Buscar artistas..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr ""
+msgstr "Buscar álbumes..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
-msgstr ""
+msgstr "Buscar pistas..."
 
 msgctxt "#30038"
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 msgctxt "#30039"
 msgid "Unwatched"
-msgstr ""
+msgstr "No visto"
 
 msgctxt "#30040"
 msgid "Recently Released"
-msgstr ""
+msgstr "Publicado recientemente"
 
 msgctxt "#30041"
 msgid "Recently Added"
-msgstr ""
+msgstr "Agregado recientemente"
 
 msgctxt "#30042"
 msgid "Recently Viewed"
-msgstr ""
+msgstr "Visto recientemente"
 
 msgctxt "#30043"
 msgid "On Deck"
@@ -192,229 +200,228 @@ msgstr ""
 
 msgctxt "#30044"
 msgid "By Collection"
-msgstr ""
+msgstr "Por colección"
 
 msgctxt "#30045"
 msgid "By Genre"
-msgstr ""
+msgstr "Por género"
 
 msgctxt "#30046"
 msgid "By Year"
-msgstr ""
+msgstr "Por año"
 
 msgctxt "#30047"
 msgid "By Decade"
-msgstr ""
+msgstr "Por década"
 
 msgctxt "#30048"
 msgid "By Director"
-msgstr ""
+msgstr "Por director"
 
 msgctxt "#30049"
 msgid "By Starring Actor"
-msgstr ""
+msgstr "Por actor protagonista"
 
 msgctxt "#30050"
 msgid "By Country"
-msgstr ""
+msgstr "Por país"
 
 msgctxt "#30051"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Por clasificación"
 
 msgctxt "#30052"
 msgid "By Rating"
-msgstr ""
+msgstr "Por calificación"
 
 msgctxt "#30053"
 msgid "By Resolution"
-msgstr ""
+msgstr "Por resolución"
 
 msgctxt "#30054"
 msgid "By First Letter"
-msgstr ""
+msgstr "Por letra"
 
 msgctxt "#30055"
 msgid "By Folder"
-msgstr ""
+msgstr "Por carpeta"
 
 msgctxt "#30056"
 msgid "Search..."
-msgstr ""
+msgstr "Buscar..."
 
 msgctxt "#30057"
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 msgctxt "#30058"
 msgid "By Year"
-msgstr ""
+msgstr "Por año"
 
 msgctxt "#30059"
 msgid "Recently Added"
-msgstr ""
+msgstr "Agregado recientemente"
 
 msgctxt "#30060"
 msgid "Camera Make"
-msgstr ""
+msgstr "Fabricante de cámara"
 
 msgctxt "#30061"
 msgid "Camera Model"
-msgstr ""
+msgstr "Modelo de cámara"
 
 msgctxt "#30062"
 msgid "Aperture"
-msgstr ""
+msgstr "Apertura"
 
 msgctxt "#30063"
 msgid "Shutter Speed"
-msgstr ""
+msgstr "Tiempo de exposición"
 
 msgctxt "#30064"
 msgid "ISO"
-msgstr ""
+msgstr "ISO"
 
 msgctxt "#30065"
 msgid "Lens"
-msgstr ""
+msgstr "Lentes"
 
 msgctxt "#30066"
 msgid "Unable to see any media servers"
-msgstr ""
+msgstr "No se encontró ningún servidor multimedia"
 
 msgctxt "#30067"
 msgid "Unable to contact server:"
-msgstr ""
+msgstr "No se pudo contactar al servidor:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
-msgstr ""
+msgstr "Actualización de biblioteca iniciada"
 
 msgctxt "#30069"
 msgid "myPlex not configured"
-msgstr ""
+msgstr "myPlex no configurado"
 
 msgctxt "#30070"
 msgid "Resume"
-msgstr ""
+msgstr "Resumir"
 
 msgctxt "#30071"
 msgid "Select media to play"
-msgstr ""
+msgstr "Seleccionar medio a reproducir"
 
 msgctxt "#30072"
 msgid "Select subtitle"
-msgstr ""
+msgstr "Seleccionar subtítulo"
 
 msgctxt "#30073"
 msgid "Select audio"
-msgstr ""
+msgstr "Seleccionar audio"
 
 msgctxt "#30074"
 msgid "Select master server"
-msgstr ""
+msgstr "Seleccionar servidor principal"
 
 msgctxt "#30075"
 msgid "Known server list"
-msgstr ""
+msgstr "Lista de servidores conocidos"
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr ""
+msgstr "Cambiar de usuario"
 
 msgctxt "#30077"
 msgid "Enter PIN"
-msgstr ""
+msgstr "Ingresar PIN"
 
 msgctxt "#30078"
 msgid "Resume from"
-msgstr ""
+msgstr "Continuar desde"
 
 msgctxt "#30079"
 msgid "Start from beginning"
-msgstr ""
+msgstr "Continuar desde el inicio"
 
 msgctxt "#30080"
 msgid "myPlex Queue"
-msgstr ""
+msgstr "Cola de myPlex"
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr ""
+msgstr "Iniciar sesión"
 
 msgctxt "#30082"
 msgid "Display Servers"
-msgstr ""
+msgstr "Mostrar servidores"
 
 msgctxt "#30083"
 msgid "Refresh Data"
-msgstr ""
+msgstr "Actualizar datos"
 
 msgctxt "#30084"
 msgid "Channels"
-msgstr ""
+msgstr "Canales"
 
 msgctxt "#30085"
 msgid "Playlists"
-msgstr ""
+msgstr "Listas de reproducción"
 
 msgctxt "#30086"
 msgid "Play Transcoded"
-msgstr ""
+msgstr "Reproducir transcodificación"
 
 msgctxt "#30087"
 msgid "All episodes"
-msgstr ""
+msgstr "Todos los episodios"
 
 msgctxt "#30088"
 msgid "Season"
-msgstr ""
+msgstr "Temporada"
 
 msgctxt "#30089"
 msgid "Search for"
-msgstr ""
+msgstr "Búsqueda de"
 
 msgctxt "#30090"
 msgid "Unplayed"
-msgstr ""
+msgstr "No reproducido"
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
-msgstr ""
+msgstr "Dirección del servidor primario"
 
 msgctxt "#30501"
 msgid "Stream from PMS"
-msgstr ""
+msgstr "Transmitir desde PMS"
 
 msgctxt "#30502"
 msgid "Get extended metadata from PMS"
-msgstr ""
+msgstr "Obtener metadatos extendidos de PMS"
 
 msgctxt "#30503"
 msgid "Enable extra filter menus"
-msgstr ""
+msgstr "Activar menús de filtros adicionales"
 
 msgctxt "#30504"
 msgid "Server Discovery"
-msgstr ""
+msgstr "Búsqueda de servidores"
 
 msgctxt "#30505"
 msgid "PMS Username: "
-msgstr ""
+msgstr "Nombre de usuario PMS: "
 
 msgctxt "#30506"
 msgid "PMS Password: "
-msgstr ""
+msgstr "Contraseña PMS: "
 
 msgctxt "#30507"
 msgid "Always Transcode"
-msgstr ""
+msgstr "Siempre transcodificar"
 
 msgctxt "#30508"
 msgid "Transcode format "
-msgstr ""
+msgstr "Formato de transcodificación "
 
 msgctxt "#30509"
 msgid "Recent & OnDeck items"
@@ -422,253 +429,252 @@ msgstr ""
 
 msgctxt "#30510"
 msgid "Debug log"
-msgstr ""
+msgstr "Registro de depuración"
 
 msgctxt "#30511"
 msgid "Auto"
-msgstr ""
+msgstr "Auto"
 
 msgctxt "#30512"
 msgid "http"
-msgstr ""
+msgstr "http"
 
 msgctxt "#30513"
 msgid "smb"
-msgstr ""
+msgstr "smb"
 
 msgctxt "#30514"
 msgid "Debug level"
-msgstr ""
+msgstr "Nivel de depuración"
 
 msgctxt "#30515"
 msgid "Use transcoding proxy"
-msgstr ""
+msgstr "Utilizar proxy de transcodificación"
 
 msgctxt "#30516"
 msgid "Server"
-msgstr ""
+msgstr "Servidor"
 
 msgctxt "#30517"
 msgid "Playback"
-msgstr ""
+msgstr "Reproducción"
 
 msgctxt "#30518"
 msgid "Transcoding"
-msgstr ""
+msgstr "Transcodificación"
 
 msgctxt "#30519"
 msgid "Wake On LAN"
-msgstr ""
+msgstr "Wake On LAN (activación remota)"
 
 msgctxt "#30520"
 msgid "Look and Feel"
-msgstr ""
+msgstr "Apariencia y estilo"
 
 msgctxt "#30521"
 msgid "Skin Home Shelf"
-msgstr ""
+msgstr "Widget de página principal de la máscara"
 
 msgctxt "#30522"
 msgid "Advanced"
-msgstr ""
+msgstr "Avanzado"
 
 msgctxt "#30523"
 msgid "Use Wake On LAN"
-msgstr ""
+msgstr "Utilizar Wake On LAN"
 
 msgctxt "#30524"
 msgid "myPlex user"
-msgstr ""
+msgstr "Usuario myPlex"
 
 msgctxt "#30525"
 msgid "myPlex password"
-msgstr ""
+msgstr "Contraseña myPlex"
 
 msgctxt "#30526"
 msgid "Select master server..."
-msgstr ""
+msgstr "Seleccionar servidor prinicipal..."
 
 msgctxt "#30527"
 msgid "Authentication required?"
-msgstr ""
+msgstr "¿Se requiere autenticación?"
 
 msgctxt "#30528"
 msgid "Load External Subtitles?"
-msgstr ""
+msgstr "¿Cargar subtítulos externos?"
 
 msgctxt "#30529"
 msgid "Always display subtitles?"
-msgstr ""
+msgstr "¿Siempre mostrar subtítulos?"
 
 msgctxt "#30530"
 msgid "Port Number"
-msgstr ""
+msgstr "Número de puerto"
 
 msgctxt "#30531"
 msgid "Use PMS localisation settings"
-msgstr ""
+msgstr "Utilizar ajustes de localización PMS"
 
 msgctxt "#30532"
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 msgctxt "#30533"
 msgid "Always"
-msgstr ""
+msgstr "Siempre"
 
 msgctxt "#30534"
 msgid "Audio stream selection"
-msgstr ""
+msgstr "Selección de transmisión de audio"
 
 msgctxt "#30535"
 msgid "Subtitle stream selection"
-msgstr ""
+msgstr "Selección de transmisión de subtítulo"
 
 msgctxt "#30536"
 msgid "Kodi Control"
-msgstr ""
+msgstr "Control de Kodi"
 
 msgctxt "#30537"
 msgid "External"
-msgstr ""
+msgstr "Externo"
 
 msgctxt "#30538"
 msgid "Audio and subtitle selector"
-msgstr ""
+msgstr "Selector de audio y subtítulo"
 
 msgctxt "#30539"
 msgid "Never show subtitles"
-msgstr ""
+msgstr "Nunca mostrar subtítulos"
 
 msgctxt "#30540"
 msgid "Quality"
-msgstr ""
+msgstr "Calidad"
 
 msgctxt "#30541"
 msgid "Proxy Port"
-msgstr ""
+msgstr "Puerto de proxy"
 
 msgctxt "#30542"
 msgid "Plex Channel View"
-msgstr ""
+msgstr "Vista de canal de Plex"
 
 msgctxt "#30543"
 msgid "Flatten TV Shows"
-msgstr ""
+msgstr "Simplificar series"
 
 msgctxt "#30544"
 msgid "Server MAC address"
-msgstr ""
+msgstr "Dirección MAC del servidor"
 
 msgctxt "#30545"
 msgid "Plex Style Watched flags"
-msgstr ""
+msgstr "Indicadores de visto al estilo Plex"
 
 msgctxt "#30546"
 msgid "Windows Media Server?"
-msgstr ""
+msgstr "¿Servidor de Windows Media?"
 
 msgctxt "#30547"
 msgid "Use WOL?"
-msgstr ""
+msgstr "¿Utilizar WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
-msgstr ""
+msgstr "Saltar género/director/escritor"
 
 msgctxt "#30550"
 msgid "Skip images (thumbs, fanart)"
-msgstr ""
+msgstr "Saltar imágenes (miniaturas, fanart)"
 
 msgctxt "#30551"
 msgid "Skip Media Flags"
-msgstr ""
+msgstr "Saltar indicadores de medios"
 
 msgctxt "#30552"
 msgid "Skip Context Menus"
-msgstr ""
+msgstr "Saltar menús contextuales"
 
 msgctxt "#30553"
 msgid "Off"
-msgstr ""
+msgstr "Apagado"
 
 msgctxt "#30554"
 msgid "Bonjour"
-msgstr ""
+msgstr "Bonjour"
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
-msgstr ""
+msgstr "Reproducir música de tema de TV"
 
 msgctxt "#30557"
 msgid "Select audio output"
-msgstr ""
+msgstr "Seleccionar salida de audio"
 
 msgctxt "#30558"
 msgid "If only one season"
-msgstr ""
+msgstr "Si solo hay una temporada"
 
 msgctxt "#30559"
 msgid "All seasons"
-msgstr ""
+msgstr "Todas las temporadas"
 
 msgctxt "#30560"
 msgid "Force DVD playback"
-msgstr ""
+msgstr "Forzar reproducción de DVD"
 
 msgctxt "#30561"
 msgid "Override SMB location"
-msgstr ""
+msgstr "Forzar ubicación SMB"
 
 msgctxt "#30562"
 msgid "NAS IP Address"
-msgstr ""
+msgstr "Dirección IP del NAS"
 
 msgctxt "#30563"
 msgid "AFP"
-msgstr ""
+msgstr "AFP"
 
 msgctxt "#30564"
 msgid "NAS Username"
-msgstr ""
+msgstr "Nombre de usuario NAS"
 
 msgctxt "#30565"
 msgid "NAS password"
-msgstr ""
+msgstr "Contraseña NAS"
 
 msgctxt "#30566"
 msgid "NAS Root Folder"
-msgstr ""
+msgstr "Carpeta raíz del NAS"
 
 msgctxt "#30567"
 msgid "Plex Control"
-msgstr ""
+msgstr "Control de Plex"
 
 msgctxt "#30568"
 msgid "Subtitle Size"
-msgstr ""
+msgstr "Tamaño de subtítulo"
 
 msgctxt "#30569"
 msgid "Audio Boost"
-msgstr ""
+msgstr "Mejora de audio"
 
 msgctxt "#30570"
 msgid "Auto (GDM)"
-msgstr ""
+msgstr "Auto (GDM)"
 
 msgctxt "#30571"
 msgid "Current Master Server"
-msgstr ""
+msgstr "Servidor principal actual"
 
 msgctxt "#30572"
 msgid "Current Master Server"
-msgstr ""
+msgstr "Servidor principal actual"
 
 msgctxt "#30573"
 msgid "Recently Added"
-msgstr ""
+msgstr "Agregado recientemente"
 
 msgctxt "#30574"
 msgid "On Deck"
@@ -676,485 +682,482 @@ msgstr ""
 
 msgctxt "#30575"
 msgid "Force Skin Views"
-msgstr ""
+msgstr "Forzar vistas de máscara"
 
 msgctxt "#30576"
 msgid "Skin Name"
-msgstr ""
+msgstr "Nombre de máscara"
 
 msgctxt "#30577"
 msgid "Movie View"
-msgstr ""
+msgstr "Vista de película"
 
 msgctxt "#30578"
 msgid "TV View"
-msgstr ""
+msgstr "Vista de serie"
 
 msgctxt "#30579"
 msgid "Season View"
-msgstr ""
+msgstr "Vista de temporada"
 
 msgctxt "#30580"
 msgid "Episode View"
-msgstr ""
+msgstr "Vista de episodio"
 
 msgctxt "#30581"
 msgid "Music View"
-msgstr ""
+msgstr "Vista de música"
 
 msgctxt "#30582"
 msgid "Enable Movie Shelf"
-msgstr ""
+msgstr "Activar widget de películas"
 
 msgctxt "#30583"
 msgid "Enable TV Shelf"
-msgstr ""
+msgstr "Activar widget de series"
 
 msgctxt "#30584"
 msgid "Enable Music Shelf"
-msgstr ""
+msgstr "Activar widget de música"
 
 msgctxt "#30585"
 msgid "Enable Channel Shelf"
-msgstr ""
+msgstr "Activar widget de canales"
 
 msgctxt "#30586"
 msgid "Content filter"
-msgstr ""
+msgstr "Filtro de contenido"
 
 msgctxt "#30587"
 msgid "Map unknown content as:"
-msgstr ""
+msgstr "Asignar contenido desconocido como:"
 
 msgctxt "#30588"
 msgid "RA Library filter"
-msgstr ""
+msgstr "Filtro de biblioteca RA"
 
 msgctxt "#30589"
 msgid "Kids"
-msgstr ""
+msgstr "Niños"
 
 msgctxt "#30590"
 msgid "Teens"
-msgstr ""
+msgstr "Adolescentes"
 
 msgctxt "#30591"
 msgid "Adults"
-msgstr ""
+msgstr "Adultos"
 
 msgctxt "#30592"
 msgid "Use menu for shared sections"
-msgstr ""
+msgstr "Utilizar menú para secciones compartidas"
 
 msgctxt "#30593"
 msgid "Cache Data"
-msgstr ""
+msgstr "Cachear datos"
 
 msgctxt "#30594"
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 msgctxt "#30595"
 msgid "Use full resolution thumbs"
-msgstr ""
+msgstr "Utilizar miniaturas de resolución máxima"
 
 msgctxt "#30596"
 msgid "Use full resolution fanart"
-msgstr ""
+msgstr "Utilizar fanart de resolución máxima"
 
 msgctxt "#30597"
 msgid "Hide watched recently added items"
-msgstr ""
+msgstr "Ocultar elementos vistos agregados recientemente"
 
 msgctxt "#30598"
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgctxt "#30599"
 msgid "Debug"
-msgstr ""
+msgstr "Depuración"
 
 msgctxt "#30600"
 msgid "Debug+"
-msgstr ""
+msgstr "Depuración+"
 
 msgctxt "#30601"
 msgid "Transcoder"
-msgstr ""
+msgstr "Transcodificador"
 
 msgctxt "#30602"
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 msgctxt "#30603"
 msgid "Disable 'All Episodes'"
-msgstr ""
+msgstr "Desactivar 'Todos los episodios'"
 
 msgctxt "#30604"
 msgid "Enable Kodi view cache"
-msgstr ""
+msgstr "Activar caché de vistas de Kodi"
 
 msgctxt "#30605"
 msgid "Manage myPlex"
-msgstr ""
+msgstr "Administrar myPlex"
 
 msgctxt "#30606"
 msgid "Prefer Season artwork"
-msgstr ""
+msgstr "Preferir arte de temporada"
 
 msgctxt "#30607"
 msgid "Hide Unique Information in log"
-msgstr ""
+msgstr "Ocultar información confidencial en el log"
 
 msgctxt "#30608"
 msgid "Use Kodi client name?"
-msgstr ""
+msgstr "¿Utilizar el nombre del cliente Kodi?"
 
 msgctxt "#30609"
 msgid "Switch off playback monitor"
-msgstr ""
+msgstr "Desactivar monitor de reproducción"
 
 msgctxt "#30610"
 msgid "Use HTTPS"
-msgstr ""
+msgstr "Utilizar HTTPS"
 
 msgctxt "#30611"
 msgid "Transcode > 1080p"
-msgstr ""
+msgstr "Transcodificar > 1080p"
 
 msgctxt "#30612"
 msgid "Transcode HEVC"
-msgstr ""
+msgstr "Transcodificar HEVC"
 
 msgctxt "#30613"
 msgid "MAC Address"
-msgstr ""
+msgstr "Dirección MAC"
 
 msgctxt "#30614"
 msgid "Universal"
-msgstr ""
+msgstr "Universal"
 
 msgctxt "#30615"
 msgid "Legacy"
-msgstr ""
+msgstr "Heredado"
 
 msgctxt "#30616"
 msgid "Refresh library section"
-msgstr ""
+msgstr "Actualizar sección de biblioteca"
 
 msgctxt "#30617"
 msgid "Username:"
-msgstr ""
+msgstr "Nombre de usuario:"
 
 msgctxt "#30618"
 msgid "Password:"
-msgstr ""
+msgstr "Contraseña:"
 
 msgctxt "#30619"
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 msgctxt "#30620"
 msgid "Submit"
-msgstr ""
+msgstr "Enviar"
 
 msgctxt "#30621"
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 msgctxt "#30622"
 msgid "Use PIN"
-msgstr ""
+msgstr "Utilizar PIN"
 
 msgctxt "#30623"
 msgid "Done"
-msgstr ""
+msgstr "Hecho"
 
 msgctxt "#30624"
 msgid "Unable to sign in"
-msgstr ""
+msgstr "No se pudo iniciar sesión"
 
 msgctxt "#30625"
 msgid "From your computer, go to %s and enter the code below"
-msgstr ""
+msgstr "Desde tu computadora, ingresa a %s e ingresa el código de abajo"
 
 msgctxt "#30626"
 msgid "Successfully signed in"
-msgstr ""
+msgstr "Sesión iniciada satisfactoriamente"
 
 msgctxt "#30627"
 msgid "Sign in not successful"
-msgstr ""
+msgstr "No se pudo iniciar sesión"
 
 msgctxt "#30628"
 msgid "Email:"
-msgstr ""
+msgstr "Correo:"
 
 msgctxt "#30629"
 msgid "Plex Pass:"
-msgstr ""
+msgstr "Contraseña de Plex:"
 
 msgctxt "#30630"
 msgid "Joined:"
-msgstr ""
+msgstr "Registrado:"
 
 msgctxt "#30631"
 msgid "Exit"
-msgstr ""
+msgstr "Salir"
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
-msgstr ""
+msgstr "Ingresa tus detalles de myPlex debajo"
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
-msgstr ""
+msgstr "Desconocido"
 
 msgctxt "#30637"
 msgid "myPlex Login"
-msgstr ""
+msgstr "Inicio de sesión myPlex"
 
 msgctxt "#30638"
 msgid "Enter search term"
-msgstr ""
+msgstr "Ingresar término de búsqueda"
 
 msgctxt "#30639"
 msgid "Enter value"
-msgstr ""
+msgstr "Ingresar un valor"
 
 msgctxt "#30640"
 msgid "Transcode Profile"
-msgstr ""
+msgstr "Transcodificar perfil"
 
 msgctxt "#30641"
 msgid "Transcode Profiles"
-msgstr ""
+msgstr "Transcodificar perfiles"
 
 msgctxt "#30642"
 msgid "Offline"
-msgstr ""
+msgstr "Sin conexión"
 
 msgctxt "#30643"
 msgid "Remote"
-msgstr ""
+msgstr "Remoto"
 
 msgctxt "#30644"
 msgid "Nearby"
-msgstr ""
+msgstr "Cercano"
 
 msgctxt "#30645"
 msgid "SSL"
-msgstr ""
+msgstr "SSL"
 
 msgctxt "#30646"
 msgid "Not Secure"
-msgstr ""
+msgstr "Insegurp"
 
 msgctxt "#30647"
 msgid "Certificate Verification"
-msgstr ""
+msgstr "Verificación de certificado"
 
 msgctxt "#30648"
 msgid "Message"
-msgstr ""
+msgstr "Mensaje"
 
 msgctxt "#30649"
 msgid "blank"
-msgstr ""
+msgstr "vacío"
 
 msgctxt "#30650"
 msgid "Server Discovery"
-msgstr ""
+msgstr "Búsqueda de servidores"
 
 msgctxt "#30651"
 msgid "Please wait..."
-msgstr ""
+msgstr "Por favor espera..."
 
 msgctxt "#30652"
 msgid "myPlex discovery..."
-msgstr ""
+msgstr "Búsqueda myPlex..."
 
 msgctxt "#30653"
 msgid "GDM discovery..."
-msgstr ""
+msgstr "Búsqueda GDM..."
 
 msgctxt "#30654"
 msgid "User provided..."
-msgstr ""
+msgstr "Usuario provisto..."
 
 msgctxt "#30655"
 msgid "Caching results..."
-msgstr ""
+msgstr "Almacenando resultados..."
 
 msgctxt "#30656"
 msgid "Finished"
-msgstr ""
+msgstr "Finalizado"
 
 msgctxt "#30657"
 msgid "Found servers:"
-msgstr ""
+msgstr "Encontrados servidores:"
 
 msgctxt "#30658"
 msgid "No servers found"
-msgstr ""
+msgstr "No se encontraron servidores"
 
 msgctxt "#30659"
 msgid "Transcode > 8-bit"
-msgstr ""
+msgstr "Transcodificar > 8-bit"
 
 msgctxt "#30660"
 msgid "Device Name"
-msgstr ""
+msgstr "Nombre del dispositivo"
 
 msgctxt "#30661"
 msgid "Cache"
-msgstr ""
+msgstr "Caché"
 
 msgctxt "#30662"
 msgid "Server Cache TTL (minutes)"
-msgstr ""
+msgstr "TTL de caché de servidor (minutos)"
 
 msgctxt "#30663"
 msgid "Server detection notification"
-msgstr ""
+msgstr "Notificación de detección de servidor"
 
 msgctxt "#30664"
 msgid "installed"
-msgstr ""
+msgstr "instalado"
 
 msgctxt "#30665"
 msgid "Movies"
-msgstr ""
+msgstr "Películas"
 
 msgctxt "#30666"
 msgid "Music"
-msgstr ""
+msgstr "Música"
 
 msgctxt "#30667"
 msgid "TV Shows"
-msgstr ""
+msgstr "Series"
 
 msgctxt "#30668"
 msgid "Photos"
-msgstr ""
+msgstr "Fotos"
 
 msgctxt "#30669"
 msgid "Server name prefix on the main menu"
-msgstr ""
+msgstr "Prefijo del nombre de servidor en el menú principal"
 
 msgctxt "#30670"
 msgid "Always"
-msgstr ""
+msgstr "Siempre"
 
 msgctxt "#30671"
 msgid "Default"
-msgstr ""
+msgstr "Predeterminado"
 
 msgctxt "#30672"
 msgid "Go to %s"
-msgstr ""
+msgstr "Ir a %s"
 
 msgctxt "#30673"
 msgid "Delete %s from the %s playlist?"
-msgstr ""
+msgstr "¿Eliminar %s de la lista de reproducción %s?"
 
 msgctxt "#30674"
 msgid "Confirm playlist item delete?"
-msgstr ""
+msgstr "¿Confirmar eliminación de lista de reproducción?"
 
 msgctxt "#30675"
 msgid "Delete from playlist"
-msgstr ""
+msgstr "Eliminar de lista de reproducción"
 
 msgctxt "#30676"
 msgid "Select playlist"
-msgstr ""
+msgstr "Seleccionar lista de reproducción"
 
 msgctxt "#30677"
 msgid "Add to playlist"
-msgstr ""
+msgstr "Agregar a lista de reproducción"
 
 msgctxt "#30678"
 msgid "Added %s to the %s playlist"
-msgstr ""
+msgstr "Agregado %s a la lista de reproducción %s"
 
 msgctxt "#30679"
 msgid "Failed to add %s to the %s playlist"
-msgstr ""
+msgstr "Error agregando %s a la lista de reproducción %s"
 
 msgctxt "#30680"
 msgid "%s is already in the %s playlist"
-msgstr ""
+msgstr "%s ya está en la lista de reproducción %s"
 
 msgctxt "#30681"
 msgid "%s has been removed the %s playlist"
-msgstr ""
+msgstr "%s ha sido borrado de la lista de reproducción %s"
 
 msgctxt "#30682"
 msgid "Unable to remove %s from the %s playlist"
-msgstr ""
+msgstr "No se puede eliminar %s de la lista de reproducción %s"
 
 msgctxt "#30683"
 msgid "Show the 'Delete' context menu"
-msgstr ""
+msgstr "Mostrar eliminar en menú contextual"
 
 msgctxt "#30684"
 msgid "Up Next"
-msgstr ""
+msgstr "Up Next"
 
 msgctxt "#30685"
 msgid "Enable Up Next"
-msgstr ""
+msgstr "Activar Up Next"
 
 msgctxt "#30686"
 msgid "Open Up Next settings"
-msgstr ""
+msgstr "Abrir configuración de Up Next"
 
 msgctxt "#30687"
 msgid "Install Up Next"
-msgstr ""
+msgstr "Instalar Up Next"
 
 msgctxt "#30688"
 msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
-msgstr ""
+msgstr "Up Next está activado en la configuración, aunque parece que Up Next está desactivado. ¿Quieres activar Up Next ahora?"
 
 msgctxt "#30689"
 msgid "Up Next requires Kodi 18 or higher"
-msgstr ""
+msgstr "Up Next requiere Kodi 18 o superior"
 
 msgctxt "#30690"
 msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
-msgstr ""
+msgstr "Desde tu computadora, ingresa a [B]%s[/B] e ingresa el siguiente código: [B]%s[/B]"
 
 msgctxt "#30691"
 msgid "Use episode thumbnails"
-msgstr ""
+msgstr "Utilizar miniaturas de episodios"
 
 msgctxt "#30692"
 msgid "Widgets"
-msgstr ""
+msgstr "Widgets"
 
 msgctxt "#30693"
 msgid "Show [B]Widgets[/B] menu"
-msgstr ""
+msgstr "Mostrar menú [B]Widgets[/B]"
 
 msgctxt "#30694"
 msgid "Clear Caches"
-msgstr ""
+msgstr "Limpiar cachés"
 
 msgctxt "#30695"
 msgid "Data Cache TTL (minutes)"
-msgstr ""
+msgstr "TTL de caché de datos (minutos)"
 
 msgctxt "#30696"
 msgid "Clear data cache on refresh"
-msgstr ""
+msgstr "Limpiar caché al actualizar"
 
 msgctxt "#30697"
 msgid "Movies on Deck"
@@ -1166,235 +1169,235 @@ msgstr ""
 
 msgctxt "#30699"
 msgid "Recently Released Movies"
-msgstr ""
+msgstr "Películas lanzadas recientemente"
 
 msgctxt "#30700"
 msgid "Recently Aired TV Shows"
-msgstr ""
+msgstr "Series emitidas recientemente"
 
 msgctxt "#30701"
 msgid "Recently Added Movies"
-msgstr ""
+msgstr "Películas agregadas recientemente"
 
 msgctxt "#30702"
 msgid "Recently Added TV Shows"
-msgstr ""
+msgstr "Series agregadas recientemente"
 
 msgctxt "#30703"
 msgid "Data Cache"
-msgstr ""
+msgstr "Caché de datos"
 
 msgctxt "#30704"
 msgid "Companion receiver is unable to start due to a port conflict"
-msgstr ""
+msgstr "El receptor de compañía no pudo iniciar debido a un conflicto de puertos"
 
 msgctxt "#30705"
 msgid "Companion receiver has started"
-msgstr ""
+msgstr "El receptor de compañía ha iniciado"
 
 msgctxt "#30706"
 msgid "Companion receiver has been stopped"
-msgstr ""
+msgstr "El receptor de compañía se ha detenido"
 
 msgctxt "#30707"
 msgid "Companion Receiver"
-msgstr ""
+msgstr "Receptor de compañía"
 
 msgctxt "#30708"
 msgid "Enabled"
-msgstr ""
+msgstr "Activado"
 
 msgctxt "#30709"
 msgid "Port"
-msgstr ""
+msgstr "Puerto"
 
 msgctxt "#30710"
 msgid "Kodi's Web Server Settings"
-msgstr ""
+msgstr "Configuración de servidor web de Kodi"
 
 msgctxt "#30711"
 msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
-msgstr ""
+msgstr "[COLOR=red]EXPERIMENTAL[/COLOR] - Esta característica es experimental[CR]Cualquier cambio a esta configuración requiere un reinicio para tomar efecto"
 
 msgctxt "#30712"
 msgid "Username"
-msgstr ""
+msgstr "Nombre de usuario"
 
 msgctxt "#30713"
 msgid "Password"
-msgstr ""
+msgstr "Contraseña"
 
 msgctxt "#30714"
 msgid "Main Menu"
-msgstr ""
+msgstr "Menú principal"
 
 msgctxt "#30715"
 msgid "Show [B]myPlex Queue[/B] menu"
-msgstr ""
+msgstr "Mostrar menú de [B]cola de myPlex[/B]"
 
 msgctxt "#30716"
 msgid "Show [B]Channels[/B] menu"
-msgstr ""
+msgstr "Mostrar menú de [B]canales[/B]"
 
 msgctxt "#30717"
 msgid "Show [B]Plex Online[/B] menu"
-msgstr ""
+msgstr "Mostrar menú de [B]Plex en línea[/B]"
 
 msgctxt "#30718"
 msgid "Show [B]Playlists[/B] menu"
-msgstr ""
+msgstr "Mostrar menú de [B]listas de reproducción[/B]"
 
 msgctxt "#30719"
 msgid "Context Menu"
-msgstr ""
+msgstr "Menú contextual"
 
 msgctxt "#30720"
 msgid "Metadata"
-msgstr ""
+msgstr "Metadatos"
 
 msgctxt "#30721"
 msgid "Transcoding"
-msgstr ""
+msgstr "Transcodificación"
 
 msgctxt "#30722"
 msgid "Create a playlist"
-msgstr ""
+msgstr "Crear una lista de reproducción"
 
 msgctxt "#30723"
 msgid "Enter a playlist title"
-msgstr ""
+msgstr "Ingresa un título de lista de reproducción"
 
 msgctxt "#30724"
 msgid "Delete playlist"
-msgstr ""
+msgstr "Eliminar lista de reproducción"
 
 msgctxt "#30725"
 msgid "Confirm playlist delete?"
-msgstr ""
+msgstr "¿Confirmar eliminación de lista de reproducción?"
 
 msgctxt "#30726"
 msgid "Are you sure you want to delete this playlist?"
-msgstr ""
+msgstr "¿Estás seguro que quieres eliminar esta lista de reproducción?"
 
 msgctxt "#30727"
 msgid "Notification encoding"
-msgstr ""
+msgstr "Codificación de notificación"
 
 msgctxt "#30728"
 msgid "Episode sort method"
-msgstr ""
+msgstr "Método de ordenamiento de episodios"
 
 msgctxt "#30729"
 msgid "Plex"
-msgstr ""
+msgstr "Plex"
 
 msgctxt "#30730"
 msgid "Kodi"
-msgstr ""
+msgstr "Kodi"
 
 msgctxt "#30731"
 msgid "Manage Servers"
-msgstr ""
+msgstr "Administrar servidores"
 
 msgctxt "#30732"
 msgid "Set as Master"
-msgstr ""
+msgstr "Establecer como principal"
 
 msgctxt "#30733"
 msgid "Connection Test Results"
-msgstr ""
+msgstr "Resultados de prueba de conexión"
 
 msgctxt "#30734"
 msgid "Default to forced subtitles"
-msgstr ""
+msgstr "Predeterminando a subtítulos forzados"
 
 msgctxt "#30735"
 msgid "Mixed content type"
-msgstr ""
+msgstr "Tipos de contenido mixtos"
 
 msgctxt "#30736"
 msgid "Default"
-msgstr ""
+msgstr "Predeterminado"
 
 msgctxt "#30737"
 msgid "Majority"
-msgstr ""
+msgstr "Mayoría"
 
 msgctxt "#30738"
 msgid "Add custom access url"
-msgstr ""
+msgstr "Agregar URL de acceso personalizado"
 
 msgctxt "#30739"
 msgid "Custom access urls"
-msgstr ""
+msgstr "URLs de acceso personalizado"
 
 msgctxt "#30740"
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 msgctxt "#30741"
 msgid "Edit custom access url"
-msgstr ""
+msgstr "Editar URL de acceso personalizado"
 
 msgctxt "#30742"
 msgid "Custom"
-msgstr ""
+msgstr "Personalizado"
 
 msgctxt "#30743"
 msgid "All Artists"
-msgstr ""
+msgstr "Todos los artistas"
 
 msgctxt "#30744"
 msgid "All Photos"
-msgstr ""
+msgstr "Todas las fotos"
 
 msgctxt "#30745"
 msgid "All Shows"
-msgstr ""
+msgstr "Todas las series"
 
 msgctxt "#30746"
 msgid "All Movies"
-msgstr ""
+msgstr "Todas las películas"
 
 msgctxt "#30747"
 msgid "Preferred lyrics format"
-msgstr ""
+msgstr "Formato de letras preferido"
 
 msgctxt "#30748"
 msgid "Lyrics"
-msgstr ""
+msgstr "Letras"
 
 msgctxt "#30749"
 msgid "lrc"
-msgstr ""
+msgstr "lrc"
 
 msgctxt "#30750"
 msgid "txt"
-msgstr ""
+msgstr "txt"
 
 msgctxt "#30751"
 msgid "Skip intro"
-msgstr ""
+msgstr "Saltar intro"
 
 msgctxt "#30752"
 msgid "Intro skipping"
-msgstr ""
+msgstr "Salto de intro"
 
 msgctxt "#30753"
 msgid "Plex Pass Required"
-msgstr ""
+msgstr "Contraseña de Plex requerida"
 
 msgctxt "#30754"
 msgid "Plex powered by LyricFind"
-msgstr ""
+msgstr "Plex impulsado por LyricFind"
 
 msgctxt "#30755"
 msgid "Show skip intro dialog"
-msgstr ""
+msgstr "Mostrar diálogo de saltar intro"
 
 msgctxt "#30756"
 msgid "All %s"
-msgstr ""
+msgstr "Todas las %s"
 
 msgctxt "#30757"
 msgid "All Servers: TV Shows On Deck"
@@ -1406,164 +1409,172 @@ msgstr ""
 
 msgctxt "#30759"
 msgid "Recently Added Episodes"
-msgstr ""
+msgstr "Episodios agregados recientemente"
 
 msgctxt "#30760"
 msgid "All Servers: Recently Added Episodes"
-msgstr ""
+msgstr "Todos los servidores: Episodios agregados recientemente"
 
 msgctxt "#30761"
 msgid "All Servers: Recently Added Movies"
-msgstr ""
+msgstr "Todos los servidores: Películas agregadas recientemente"
 
 msgctxt "#30762"
 msgid "Server name prefix on combined sections"
-msgstr ""
+msgstr "Prefijo de nombre de servidor en secciones combinadas"
 
 msgctxt "#30763"
 msgid "Recently Added item count (per server section)"
-msgstr ""
+msgstr "Cantidad de elementos de agregados recientemente (por sección de servidor)"
 
 msgctxt "#30764"
 msgid "Recently Added include watched"
-msgstr ""
+msgstr "Incluir vistos en agregados recientemente"
 
 msgctxt "#30765"
 msgid "Composite Playlist"
-msgstr ""
+msgstr "Lista de reproducción compuesta"
 
 msgctxt "#30766"
 msgid "Generate a playlist from the information below"
-msgstr ""
+msgstr "Generar una lista de reproducción con la información de abajo"
 
 msgctxt "#30767"
 msgid "Mixed"
-msgstr ""
+msgstr "Mezclar"
 
 msgctxt "#30768"
 msgid "Play"
-msgstr ""
+msgstr "Reproducir"
 
 msgctxt "#30769"
 msgid "Item Count"
-msgstr ""
+msgstr "Cantidad de elementos"
 
 msgctxt "#30770"
 msgid "All Servers"
-msgstr ""
+msgstr "Todos los servidores"
 
 msgctxt "#30771"
 msgid "Shuffle"
-msgstr ""
+msgstr "Mezclar"
 
 msgctxt "#30772"
 msgid "Source"
-msgstr ""
+msgstr "Origen"
 
 msgctxt "#30773"
 msgid "None"
-msgstr ""
+msgstr "Ninguno"
 
 msgctxt "#30774"
 msgid "Generating Playlist"
-msgstr ""
+msgstr "Generando lista de reproducción"
 
 msgctxt "#30775"
 msgid "This may take a while..."
-msgstr ""
+msgstr "Esto puede tomar un tiempo..."
 
 msgctxt "#30776"
 msgid "Retrieving server list..."
-msgstr ""
+msgstr "Obteniendo listado de servidores..."
 
 msgctxt "#30777"
 msgid "Retrieving server sections..."
-msgstr ""
+msgstr "Obteniendo secciones de servidor..."
 
 msgctxt "#30778"
 msgid "Retrieving content metadata..."
-msgstr ""
+msgstr "Obteniendo metadatos de contenido..."
 
 msgctxt "#30779"
 msgid "Retrieving final sample..."
-msgstr ""
+msgstr "Obteniendo muestra final..."
 
 msgctxt "#30780"
 msgid "Adding items to playlist..."
-msgstr ""
+msgstr "Agregando elementos a la lista de reproducción..."
 
 msgctxt "#30781"
 msgid "Adding %s to playlist..."
-msgstr ""
+msgstr "Agregando %s a la lista de reproducción..."
 
 msgctxt "#30782"
 msgid "Completed."
-msgstr ""
+msgstr "Completado."
 
 msgctxt "#30783"
 msgid "Checking section %s on %s..."
-msgstr ""
+msgstr "Verificando sección %s en %s..."
 
 msgctxt "#30784"
 msgid "Retrieving %s from %s for sample..."
-msgstr ""
+msgstr "Obteniendo %s de %s para muestra..."
 
 msgctxt "#30785"
 msgid "Retrieving %s episodes for sample..."
-msgstr ""
+msgstr "Obteniendo %s episodios para muestra..."
 
 msgctxt "#30786"
 msgid "Creating samples..."
-msgstr ""
+msgstr "Creando muestras..."
 
 msgctxt "#30787"
 msgid "Retrieving metadata for %s..."
-msgstr ""
+msgstr "Obteniendo metadatos para %s..."
 
 msgctxt "#30788"
 msgid "Show [B]Composite Playlist[/B] menu"
-msgstr ""
+msgstr "Mostrar menú de [B]Lista de reproducción compuesta[/B]"
 
 msgctxt "#30789"
 msgid "Server(s)"
-msgstr ""
+msgstr "Servidor(es)"
 
 msgctxt "#30790"
 msgid "Combined Sections"
-msgstr ""
+msgstr "Secciones combinadas"
 
 msgctxt "#30791"
 msgid "Search Movies..."
-msgstr ""
+msgstr "Buscar películas..."
 
 msgctxt "#30792"
 msgid "Mark as watched"
-msgstr ""
+msgstr "Marcar como visto"
 
 msgctxt "#30793"
 msgid "Mark as unwatched"
-msgstr ""
+msgstr "Marcar como no visto"
 
 msgctxt "#30794"
 msgid "Library - Movie Sections"
-msgstr ""
+msgstr "Biblioteca - Sección de películas"
 
 msgctxt "#30795"
 msgid "Library - TV Show Sections"
-msgstr ""
+msgstr "Biblioteca - Sección de series"
 
 msgctxt "#30796"
 msgid "Kodi Library"
-msgstr ""
+msgstr "Biblioteca de Kodi"
 
 msgctxt "#30797"
 msgid "Select sections to include in library scans"
-msgstr ""
+msgstr "Seleccionar secciones a incluir en escaneos de biblioteca"
 
 msgctxt "#30798"
 msgid "Reset selected sections"
-msgstr ""
+msgstr "Reiniciar secciones seleccionadas"
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
-msgstr ""
+msgstr "Las secciones de la biblioteca configuradas han sido reiniciadas"
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr "Continuar viendo"
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr "Detectar servidores"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.et_ee/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.et_ee/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: et_ee\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.eu_es/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.eu_es/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eu_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fa_af/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fa_af/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fa_af\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fa_ir/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fa_ir/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fa_ir\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fi_fi/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fi_fi/strings.po
@@ -5,28 +5,37 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Composite\n"
-"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: GITHUB USERNAME\n"
-"Language-Team: Finnish\n"
-"Language: fi_FI\n"
+"PO-Revision-Date: 2021-08-03 15:29+0000\n"
+"Last-Translator: Tommi Raulahti <traulahti@gmail.com>\n"
+"Language-Team: Finnish <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/fi_fi/>\n"
+"Language: fi_fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.7.2\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr "Selaa ja toista video-, musiikki- ja valokuvamediatiedostoja, joita Plex Media Server hallinnoi.[CR][CR]Hippojayn haaroitus PleXBMC:stä"
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
-msgstr ""
+msgstr "Vahvista tiedoston poisto?"
 
 msgctxt "#30001"
 msgid "Delete this item? This action will delete media and associated data files."
-msgstr ""
+msgstr "Poista tämä? Toiminto poistaa median ja siihen liittyvät tiedostot."
 
 msgctxt "#30002"
 msgid "Plex Online"
-msgstr ""
+msgstr "Plex Online"
 
 msgctxt "#30003"
 msgid "About to install"
@@ -34,15 +43,15 @@ msgstr ""
 
 msgctxt "#30004"
 msgid "This plugin is already installed"
-msgstr ""
+msgstr "Tämä lisäosa on jo asennettu"
 
 msgctxt "#30005"
 msgid "Switch Failed"
-msgstr ""
+msgstr "Vaihto epäonnistui"
 
 msgctxt "#30006"
 msgid "Sign Out"
-msgstr ""
+msgstr "Kirjaudu ulos"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
@@ -57,7 +66,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -68,11 +76,11 @@ msgstr ""
 
 msgctxt "#30013"
 msgid "All"
-msgstr ""
+msgstr "Kaikki"
 
 msgctxt "#30014"
 msgid "Unwatched"
-msgstr ""
+msgstr "Katsomattomat"
 
 msgctxt "#30015"
 msgid "Recently Aired"
@@ -96,27 +104,27 @@ msgstr ""
 
 msgctxt "#30020"
 msgid "By Collection"
-msgstr ""
+msgstr "Kokoelman mukaan"
 
 msgctxt "#30021"
 msgid "By First Letter"
-msgstr ""
+msgstr "Kirjaimen mukaan"
 
 msgctxt "#30022"
 msgid "By Genre"
-msgstr ""
+msgstr "Tyylilajin mukaan"
 
 msgctxt "#30023"
 msgid "By Year"
-msgstr ""
+msgstr "Vuoden mukaan"
 
 msgctxt "#30024"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Sisältöluokituksen mukaan"
 
 msgctxt "#30025"
 msgid "By Folder"
-msgstr ""
+msgstr "Hakemiston mukaan"
 
 msgctxt "#30026"
 msgid "Search Shows..."
@@ -128,11 +136,11 @@ msgstr ""
 
 msgctxt "#30028"
 msgid "All"
-msgstr ""
+msgstr "Kaikki"
 
 msgctxt "#30029"
 msgid "By Album"
-msgstr ""
+msgstr "Albumin mukaan"
 
 msgctxt "#30030"
 msgid "By Genre"
@@ -152,15 +160,15 @@ msgstr ""
 
 msgctxt "#30034"
 msgid "By Folder"
-msgstr ""
+msgstr "Hakemiston mukaan"
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr ""
+msgstr "Etsi esiintyjiä..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr ""
+msgstr "Etsi albumeja..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
@@ -168,11 +176,11 @@ msgstr ""
 
 msgctxt "#30038"
 msgid "All"
-msgstr ""
+msgstr "Kaikki"
 
 msgctxt "#30039"
 msgid "Unwatched"
-msgstr ""
+msgstr "Katsomattomat"
 
 msgctxt "#30040"
 msgid "Recently Released"
@@ -180,11 +188,11 @@ msgstr ""
 
 msgctxt "#30041"
 msgid "Recently Added"
-msgstr ""
+msgstr "Viimeksi lisätyt"
 
 msgctxt "#30042"
 msgid "Recently Viewed"
-msgstr ""
+msgstr "Viimeksi katsotut"
 
 msgctxt "#30043"
 msgid "On Deck"
@@ -208,87 +216,87 @@ msgstr ""
 
 msgctxt "#30048"
 msgid "By Director"
-msgstr ""
+msgstr "Ohjaajan mukaan"
 
 msgctxt "#30049"
 msgid "By Starring Actor"
-msgstr ""
+msgstr "Pääosa esittäjän mukaan"
 
 msgctxt "#30050"
 msgid "By Country"
-msgstr ""
+msgstr "Maan mukaan"
 
 msgctxt "#30051"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Sisältöluokituksen mukaan"
 
 msgctxt "#30052"
 msgid "By Rating"
-msgstr ""
+msgstr "Arvostelun mukaan"
 
 msgctxt "#30053"
 msgid "By Resolution"
-msgstr ""
+msgstr "Resoluution mukaan"
 
 msgctxt "#30054"
 msgid "By First Letter"
-msgstr ""
+msgstr "Ensimmäisen kirjaimen mukaan"
 
 msgctxt "#30055"
 msgid "By Folder"
-msgstr ""
+msgstr "Hakemiston mukaan"
 
 msgctxt "#30056"
 msgid "Search..."
-msgstr ""
+msgstr "Etsi..."
 
 msgctxt "#30057"
 msgid "All"
-msgstr ""
+msgstr "Kaikki"
 
 msgctxt "#30058"
 msgid "By Year"
-msgstr ""
+msgstr "Vuoden mukaan"
 
 msgctxt "#30059"
 msgid "Recently Added"
-msgstr ""
+msgstr "Viimeksi lisätyt"
 
 msgctxt "#30060"
 msgid "Camera Make"
-msgstr ""
+msgstr "Kameran valmistaja"
 
 msgctxt "#30061"
 msgid "Camera Model"
-msgstr ""
+msgstr "Kameran malli"
 
 msgctxt "#30062"
 msgid "Aperture"
-msgstr ""
+msgstr "Aukko"
 
 msgctxt "#30063"
 msgid "Shutter Speed"
-msgstr ""
+msgstr "Suljinnopeus"
 
 msgctxt "#30064"
 msgid "ISO"
-msgstr ""
+msgstr "ISO"
 
 msgctxt "#30065"
 msgid "Lens"
-msgstr ""
+msgstr "Linssit"
 
 msgctxt "#30066"
 msgid "Unable to see any media servers"
-msgstr ""
+msgstr "Mediapalvelimia ei löydy"
 
 msgctxt "#30067"
 msgid "Unable to contact server:"
-msgstr ""
+msgstr "Palvelimeen ei saada yhteyttä:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
-msgstr ""
+msgstr "Kirjaston päivitys alkoi"
 
 msgctxt "#30069"
 msgid "myPlex not configured"
@@ -296,35 +304,35 @@ msgstr ""
 
 msgctxt "#30070"
 msgid "Resume"
-msgstr ""
+msgstr "Palauta"
 
 msgctxt "#30071"
 msgid "Select media to play"
-msgstr ""
+msgstr "Valitse soitettava media"
 
 msgctxt "#30072"
 msgid "Select subtitle"
-msgstr ""
+msgstr "Valitse tekstitys"
 
 msgctxt "#30073"
 msgid "Select audio"
-msgstr ""
+msgstr "Valitse ääni"
 
 msgctxt "#30074"
 msgid "Select master server"
-msgstr ""
+msgstr "Valitse pääasiallinen palvelin"
 
 msgctxt "#30075"
 msgid "Known server list"
-msgstr ""
+msgstr "Lista tunnetuista palvelimista"
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr ""
+msgstr "Vaihda käyttäjä"
 
 msgctxt "#30077"
 msgid "Enter PIN"
-msgstr ""
+msgstr "Syötä PIN"
 
 msgctxt "#30078"
 msgid "Resume from"
@@ -332,31 +340,31 @@ msgstr ""
 
 msgctxt "#30079"
 msgid "Start from beginning"
-msgstr ""
+msgstr "Aloita alusta"
 
 msgctxt "#30080"
 msgid "myPlex Queue"
-msgstr ""
+msgstr "myPlex jono"
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr ""
+msgstr "Kirjaudu sisään"
 
 msgctxt "#30082"
 msgid "Display Servers"
-msgstr ""
+msgstr "Näytä palvelimet"
 
 msgctxt "#30083"
 msgid "Refresh Data"
-msgstr ""
+msgstr "Päivitä tiedot"
 
 msgctxt "#30084"
 msgid "Channels"
-msgstr ""
+msgstr "Kanavat"
 
 msgctxt "#30085"
 msgid "Playlists"
-msgstr ""
+msgstr "Soittolistat"
 
 msgctxt "#30086"
 msgid "Play Transcoded"
@@ -364,11 +372,11 @@ msgstr ""
 
 msgctxt "#30087"
 msgid "All episodes"
-msgstr ""
+msgstr "Kaikki jaksot"
 
 msgctxt "#30088"
 msgid "Season"
-msgstr ""
+msgstr "Kausi"
 
 msgctxt "#30089"
 msgid "Search for"
@@ -376,17 +384,16 @@ msgstr ""
 
 msgctxt "#30090"
 msgid "Unplayed"
-msgstr ""
+msgstr "Ei soitetut"
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
-msgstr ""
+msgstr "Ensisijainen palvelimen osoite"
 
 msgctxt "#30501"
 msgid "Stream from PMS"
-msgstr ""
+msgstr "Striimaa PMS:stä"
 
 msgctxt "#30502"
 msgid "Get extended metadata from PMS"
@@ -402,11 +409,11 @@ msgstr ""
 
 msgctxt "#30505"
 msgid "PMS Username: "
-msgstr ""
+msgstr "PMS käyttäjänimi: "
 
 msgctxt "#30506"
 msgid "PMS Password: "
-msgstr ""
+msgstr "PMS salasana: "
 
 msgctxt "#30507"
 msgid "Always Transcode"
@@ -426,15 +433,15 @@ msgstr ""
 
 msgctxt "#30511"
 msgid "Auto"
-msgstr ""
+msgstr "Automaattinen"
 
 msgctxt "#30512"
 msgid "http"
-msgstr ""
+msgstr "http"
 
 msgctxt "#30513"
 msgid "smb"
-msgstr ""
+msgstr "SMB"
 
 msgctxt "#30514"
 msgid "Debug level"
@@ -446,11 +453,11 @@ msgstr ""
 
 msgctxt "#30516"
 msgid "Server"
-msgstr ""
+msgstr "Palvelin"
 
 msgctxt "#30517"
 msgid "Playback"
-msgstr ""
+msgstr "Toisto"
 
 msgctxt "#30518"
 msgid "Transcoding"
@@ -478,31 +485,31 @@ msgstr ""
 
 msgctxt "#30524"
 msgid "myPlex user"
-msgstr ""
+msgstr "myPlex käyttäjä"
 
 msgctxt "#30525"
 msgid "myPlex password"
-msgstr ""
+msgstr "myPlex salasana"
 
 msgctxt "#30526"
 msgid "Select master server..."
-msgstr ""
+msgstr "Valitse pääasiallinen palvelin..."
 
 msgctxt "#30527"
 msgid "Authentication required?"
-msgstr ""
+msgstr "Tunnistus vaaditaan?"
 
 msgctxt "#30528"
 msgid "Load External Subtitles?"
-msgstr ""
+msgstr "Lataa ulkoiset tekstitykset?"
 
 msgctxt "#30529"
 msgid "Always display subtitles?"
-msgstr ""
+msgstr "Näytä aina tekstitykset?"
 
 msgctxt "#30530"
 msgid "Port Number"
-msgstr ""
+msgstr "Portin numero"
 
 msgctxt "#30531"
 msgid "Use PMS localisation settings"
@@ -510,19 +517,19 @@ msgstr ""
 
 msgctxt "#30532"
 msgid "Manual"
-msgstr ""
+msgstr "Manuaalinen"
 
 msgctxt "#30533"
 msgid "Always"
-msgstr ""
+msgstr "Aina"
 
 msgctxt "#30534"
 msgid "Audio stream selection"
-msgstr ""
+msgstr "Ääni streamin valinta"
 
 msgctxt "#30535"
 msgid "Subtitle stream selection"
-msgstr ""
+msgstr "Tekstitys streamin valinta"
 
 msgctxt "#30536"
 msgid "Kodi Control"
@@ -530,23 +537,23 @@ msgstr ""
 
 msgctxt "#30537"
 msgid "External"
-msgstr ""
+msgstr "Ulkoinen"
 
 msgctxt "#30538"
 msgid "Audio and subtitle selector"
-msgstr ""
+msgstr "Äänen ja tekstityksen valinta"
 
 msgctxt "#30539"
 msgid "Never show subtitles"
-msgstr ""
+msgstr "Älä koskaan näytä tekstityksiä"
 
 msgctxt "#30540"
 msgid "Quality"
-msgstr ""
+msgstr "Laatu"
 
 msgctxt "#30541"
 msgid "Proxy Port"
-msgstr ""
+msgstr "Välityspalvelimen portti"
 
 msgctxt "#30542"
 msgid "Plex Channel View"
@@ -558,7 +565,7 @@ msgstr ""
 
 msgctxt "#30544"
 msgid "Server MAC address"
-msgstr ""
+msgstr "Palvelimen MAC osoite"
 
 msgctxt "#30545"
 msgid "Plex Style Watched flags"
@@ -566,14 +573,13 @@ msgstr ""
 
 msgctxt "#30546"
 msgid "Windows Media Server?"
-msgstr ""
+msgstr "Windows media palvelin?"
 
 msgctxt "#30547"
 msgid "Use WOL?"
-msgstr ""
+msgstr "Käytä WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -588,11 +594,11 @@ msgstr ""
 
 msgctxt "#30552"
 msgid "Skip Context Menus"
-msgstr ""
+msgstr "Ohita sisältövalikot"
 
 msgctxt "#30553"
 msgid "Off"
-msgstr ""
+msgstr "Pois"
 
 msgctxt "#30554"
 msgid "Bonjour"
@@ -600,23 +606,23 @@ msgstr ""
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
-msgstr ""
+msgstr "Soita TV teemamusiikki"
 
 msgctxt "#30557"
 msgid "Select audio output"
-msgstr ""
+msgstr "Valitse äänen ulostulo"
 
 msgctxt "#30558"
 msgid "If only one season"
-msgstr ""
+msgstr "Vain jos yksi kausi"
 
 msgctxt "#30559"
 msgid "All seasons"
-msgstr ""
+msgstr "Kaikki kaudet"
 
 msgctxt "#30560"
 msgid "Force DVD playback"
-msgstr ""
+msgstr "Pakota DVD toisto"
 
 msgctxt "#30561"
 msgid "Override SMB location"
@@ -624,23 +630,23 @@ msgstr ""
 
 msgctxt "#30562"
 msgid "NAS IP Address"
-msgstr ""
+msgstr "NAS IP osoite"
 
 msgctxt "#30563"
 msgid "AFP"
-msgstr ""
+msgstr "AFP"
 
 msgctxt "#30564"
 msgid "NAS Username"
-msgstr ""
+msgstr "NAS käyttäjänimi"
 
 msgctxt "#30565"
 msgid "NAS password"
-msgstr ""
+msgstr "NAS salasana"
 
 msgctxt "#30566"
 msgid "NAS Root Folder"
-msgstr ""
+msgstr "NAS juurihakemisto"
 
 msgctxt "#30567"
 msgid "Plex Control"
@@ -648,15 +654,15 @@ msgstr ""
 
 msgctxt "#30568"
 msgid "Subtitle Size"
-msgstr ""
+msgstr "Tekstityksen koko"
 
 msgctxt "#30569"
 msgid "Audio Boost"
-msgstr ""
+msgstr "Äänen tehostus"
 
 msgctxt "#30570"
 msgid "Auto (GDM)"
-msgstr ""
+msgstr "Automaattinen (GDM)"
 
 msgctxt "#30571"
 msgid "Current Master Server"
@@ -668,7 +674,7 @@ msgstr ""
 
 msgctxt "#30573"
 msgid "Recently Added"
-msgstr ""
+msgstr "Viimeksi lisätyt"
 
 msgctxt "#30574"
 msgid "On Deck"
@@ -720,7 +726,7 @@ msgstr ""
 
 msgctxt "#30586"
 msgid "Content filter"
-msgstr ""
+msgstr "Sisältö suodatin"
 
 msgctxt "#30587"
 msgid "Map unknown content as:"
@@ -728,19 +734,19 @@ msgstr ""
 
 msgctxt "#30588"
 msgid "RA Library filter"
-msgstr ""
+msgstr "RA kirjasto suodatin"
 
 msgctxt "#30589"
 msgid "Kids"
-msgstr ""
+msgstr "Lapset"
 
 msgctxt "#30590"
 msgid "Teens"
-msgstr ""
+msgstr "Teinit"
 
 msgctxt "#30591"
 msgid "Adults"
-msgstr ""
+msgstr "Aikuiset"
 
 msgctxt "#30592"
 msgid "Use menu for shared sections"
@@ -752,7 +758,7 @@ msgstr ""
 
 msgctxt "#30594"
 msgid "Manual"
-msgstr ""
+msgstr "Manuaalinen"
 
 msgctxt "#30595"
 msgid "Use full resolution thumbs"
@@ -768,7 +774,7 @@ msgstr ""
 
 msgctxt "#30598"
 msgid "Info"
-msgstr ""
+msgstr "Tiedot"
 
 msgctxt "#30599"
 msgid "Debug"
@@ -784,7 +790,7 @@ msgstr ""
 
 msgctxt "#30602"
 msgid "Name"
-msgstr ""
+msgstr "Nimi"
 
 msgctxt "#30603"
 msgid "Disable 'All Episodes'"
@@ -796,7 +802,7 @@ msgstr ""
 
 msgctxt "#30605"
 msgid "Manage myPlex"
-msgstr ""
+msgstr "Hallitse myPlex"
 
 msgctxt "#30606"
 msgid "Prefer Season artwork"
@@ -816,7 +822,7 @@ msgstr ""
 
 msgctxt "#30610"
 msgid "Use HTTPS"
-msgstr ""
+msgstr "Käytä HTTPS"
 
 msgctxt "#30611"
 msgid "Transcode > 1080p"
@@ -828,15 +834,15 @@ msgstr ""
 
 msgctxt "#30613"
 msgid "MAC Address"
-msgstr ""
+msgstr "MAC osoite"
 
 msgctxt "#30614"
 msgid "Universal"
-msgstr ""
+msgstr "Yleinen"
 
 msgctxt "#30615"
 msgid "Legacy"
-msgstr ""
+msgstr "Perinteinen"
 
 msgctxt "#30616"
 msgid "Refresh library section"
@@ -844,51 +850,51 @@ msgstr ""
 
 msgctxt "#30617"
 msgid "Username:"
-msgstr ""
+msgstr "Käyttäjänimi:"
 
 msgctxt "#30618"
 msgid "Password:"
-msgstr ""
+msgstr "Salasana:"
 
 msgctxt "#30619"
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 msgctxt "#30620"
 msgid "Submit"
-msgstr ""
+msgstr "Lähetä"
 
 msgctxt "#30621"
 msgid "Manual"
-msgstr ""
+msgstr "Manuaalinen"
 
 msgctxt "#30622"
 msgid "Use PIN"
-msgstr ""
+msgstr "Käytä PIN"
 
 msgctxt "#30623"
 msgid "Done"
-msgstr ""
+msgstr "Tehty"
 
 msgctxt "#30624"
 msgid "Unable to sign in"
-msgstr ""
+msgstr "Kirjautuminen epäonnistui"
 
 msgctxt "#30625"
 msgid "From your computer, go to %s and enter the code below"
-msgstr ""
+msgstr "Tietokoneellasi, mene %s ja syötä yllä oleva koodi"
 
 msgctxt "#30626"
 msgid "Successfully signed in"
-msgstr ""
+msgstr "Onnistuneesti sisäänkirjauduttu"
 
 msgctxt "#30627"
 msgid "Sign in not successful"
-msgstr ""
+msgstr "Kirjautuminen ei onnistunut"
 
 msgctxt "#30628"
 msgid "Email:"
-msgstr ""
+msgstr "Sähköposti:"
 
 msgctxt "#30629"
 msgid "Plex Pass:"
@@ -896,29 +902,26 @@ msgstr ""
 
 msgctxt "#30630"
 msgid "Joined:"
-msgstr ""
+msgstr "Liitytty:"
 
 msgctxt "#30631"
 msgid "Exit"
-msgstr ""
+msgstr "Poistu"
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
-msgstr ""
+msgstr "Syötä myPlex tietosi alle"
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
-msgstr ""
+msgstr "Tuntematon"
 
 msgctxt "#30637"
 msgid "myPlex Login"
-msgstr ""
+msgstr "myPlex kirjautuminen"
 
 msgctxt "#30638"
 msgid "Enter search term"
@@ -926,7 +929,7 @@ msgstr ""
 
 msgctxt "#30639"
 msgid "Enter value"
-msgstr ""
+msgstr "Syötä arvo"
 
 msgctxt "#30640"
 msgid "Transcode Profile"
@@ -942,31 +945,31 @@ msgstr ""
 
 msgctxt "#30643"
 msgid "Remote"
-msgstr ""
+msgstr "Etä"
 
 msgctxt "#30644"
 msgid "Nearby"
-msgstr ""
+msgstr "Lähellä"
 
 msgctxt "#30645"
 msgid "SSL"
-msgstr ""
+msgstr "SSL"
 
 msgctxt "#30646"
 msgid "Not Secure"
-msgstr ""
+msgstr "Ei turvallinen"
 
 msgctxt "#30647"
 msgid "Certificate Verification"
-msgstr ""
+msgstr "Sertifikaatin tarkistus"
 
 msgctxt "#30648"
 msgid "Message"
-msgstr ""
+msgstr "Viesti"
 
 msgctxt "#30649"
 msgid "blank"
-msgstr ""
+msgstr "tyhjä"
 
 msgctxt "#30650"
 msgid "Server Discovery"
@@ -974,7 +977,7 @@ msgstr ""
 
 msgctxt "#30651"
 msgid "Please wait..."
-msgstr ""
+msgstr "Odota..."
 
 msgctxt "#30652"
 msgid "myPlex discovery..."
@@ -994,15 +997,15 @@ msgstr ""
 
 msgctxt "#30656"
 msgid "Finished"
-msgstr ""
+msgstr "Lopetettu"
 
 msgctxt "#30657"
 msgid "Found servers:"
-msgstr ""
+msgstr "Löytyneet palvelimet:"
 
 msgctxt "#30658"
 msgid "No servers found"
-msgstr ""
+msgstr "Palvelimia ei löytynyt"
 
 msgctxt "#30659"
 msgid "Transcode > 8-bit"
@@ -1010,7 +1013,7 @@ msgstr ""
 
 msgctxt "#30660"
 msgid "Device Name"
-msgstr ""
+msgstr "Laitteen nimi"
 
 msgctxt "#30661"
 msgid "Cache"
@@ -1026,23 +1029,23 @@ msgstr ""
 
 msgctxt "#30664"
 msgid "installed"
-msgstr ""
+msgstr "asennetut"
 
 msgctxt "#30665"
 msgid "Movies"
-msgstr ""
+msgstr "Elokuvat"
 
 msgctxt "#30666"
 msgid "Music"
-msgstr ""
+msgstr "Musiikki"
 
 msgctxt "#30667"
 msgid "TV Shows"
-msgstr ""
+msgstr "TV-sarjat"
 
 msgctxt "#30668"
 msgid "Photos"
-msgstr ""
+msgstr "Kuvat"
 
 msgctxt "#30669"
 msgid "Server name prefix on the main menu"
@@ -1050,19 +1053,19 @@ msgstr ""
 
 msgctxt "#30670"
 msgid "Always"
-msgstr ""
+msgstr "Aina"
 
 msgctxt "#30671"
 msgid "Default"
-msgstr ""
+msgstr "Oletus"
 
 msgctxt "#30672"
 msgid "Go to %s"
-msgstr ""
+msgstr "Mene %s"
 
 msgctxt "#30673"
 msgid "Delete %s from the %s playlist?"
-msgstr ""
+msgstr "Poista %s %s:n soittolistalta?"
 
 msgctxt "#30674"
 msgid "Confirm playlist item delete?"
@@ -1070,35 +1073,35 @@ msgstr ""
 
 msgctxt "#30675"
 msgid "Delete from playlist"
-msgstr ""
+msgstr "Poista soittolistalta"
 
 msgctxt "#30676"
 msgid "Select playlist"
-msgstr ""
+msgstr "Valitse soittolista"
 
 msgctxt "#30677"
 msgid "Add to playlist"
-msgstr ""
+msgstr "Lisää soittolistalle"
 
 msgctxt "#30678"
 msgid "Added %s to the %s playlist"
-msgstr ""
+msgstr "Lisätty %s %s soittolistalle"
 
 msgctxt "#30679"
 msgid "Failed to add %s to the %s playlist"
-msgstr ""
+msgstr "%s lisääminen %s soittolistalle epäonnistui"
 
 msgctxt "#30680"
 msgid "%s is already in the %s playlist"
-msgstr ""
+msgstr "%s on jo %s soittolistalla"
 
 msgctxt "#30681"
 msgid "%s has been removed the %s playlist"
-msgstr ""
+msgstr "%s poistettu %s soittolistalta"
 
 msgctxt "#30682"
 msgid "Unable to remove %s from the %s playlist"
-msgstr ""
+msgstr "%s poistaminen %s soittolistalta ei onnistu"
 
 msgctxt "#30683"
 msgid "Show the 'Delete' context menu"
@@ -1106,7 +1109,7 @@ msgstr ""
 
 msgctxt "#30684"
 msgid "Up Next"
-msgstr ""
+msgstr "Seuraava ylöspäin"
 
 msgctxt "#30685"
 msgid "Enable Up Next"
@@ -1146,7 +1149,7 @@ msgstr ""
 
 msgctxt "#30694"
 msgid "Clear Caches"
-msgstr ""
+msgstr "Tyhjennä välimuistit"
 
 msgctxt "#30695"
 msgid "Data Cache TTL (minutes)"
@@ -1166,19 +1169,19 @@ msgstr ""
 
 msgctxt "#30699"
 msgid "Recently Released Movies"
-msgstr ""
+msgstr "Lähiaikoina julkaistut elokuvat"
 
 msgctxt "#30700"
 msgid "Recently Aired TV Shows"
-msgstr ""
+msgstr "Lähiaikoinan lähetetyt TV-ohjelmat"
 
 msgctxt "#30701"
 msgid "Recently Added Movies"
-msgstr ""
+msgstr "Lähiaikoina lisätyt elokuvat"
 
 msgctxt "#30702"
 msgid "Recently Added TV Shows"
-msgstr ""
+msgstr "Lähiaikoina lisätyt TV-ohjelmat"
 
 msgctxt "#30703"
 msgid "Data Cache"
@@ -1202,15 +1205,15 @@ msgstr ""
 
 msgctxt "#30708"
 msgid "Enabled"
-msgstr ""
+msgstr "Päällä"
 
 msgctxt "#30709"
 msgid "Port"
-msgstr ""
+msgstr "Portti"
 
 msgctxt "#30710"
 msgid "Kodi's Web Server Settings"
-msgstr ""
+msgstr "Kodi web palvelimen asetukset"
 
 msgctxt "#30711"
 msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
@@ -1218,15 +1221,15 @@ msgstr ""
 
 msgctxt "#30712"
 msgid "Username"
-msgstr ""
+msgstr "Käyttäjänimi"
 
 msgctxt "#30713"
 msgid "Password"
-msgstr ""
+msgstr "Salasana"
 
 msgctxt "#30714"
 msgid "Main Menu"
-msgstr ""
+msgstr "Päävalikko"
 
 msgctxt "#30715"
 msgid "Show [B]myPlex Queue[/B] menu"
@@ -1250,7 +1253,7 @@ msgstr ""
 
 msgctxt "#30720"
 msgid "Metadata"
-msgstr ""
+msgstr "Metatieto"
 
 msgctxt "#30721"
 msgid "Transcoding"
@@ -1258,23 +1261,23 @@ msgstr ""
 
 msgctxt "#30722"
 msgid "Create a playlist"
-msgstr ""
+msgstr "Luo soittolista"
 
 msgctxt "#30723"
 msgid "Enter a playlist title"
-msgstr ""
+msgstr "Syötä soittolistan otsikko"
 
 msgctxt "#30724"
 msgid "Delete playlist"
-msgstr ""
+msgstr "Poista soittolista"
 
 msgctxt "#30725"
 msgid "Confirm playlist delete?"
-msgstr ""
+msgstr "Vahvista soittolistan poisto?"
 
 msgctxt "#30726"
 msgid "Are you sure you want to delete this playlist?"
-msgstr ""
+msgstr "Oletko varma että haluat poistaa tämän soittolistan?"
 
 msgctxt "#30727"
 msgid "Notification encoding"
@@ -1282,19 +1285,19 @@ msgstr ""
 
 msgctxt "#30728"
 msgid "Episode sort method"
-msgstr ""
+msgstr "Jakson lajittelutapa"
 
 msgctxt "#30729"
 msgid "Plex"
-msgstr ""
+msgstr "Plex"
 
 msgctxt "#30730"
 msgid "Kodi"
-msgstr ""
+msgstr "Kodi"
 
 msgctxt "#30731"
 msgid "Manage Servers"
-msgstr ""
+msgstr "Hallitse palvelimia"
 
 msgctxt "#30732"
 msgid "Set as Master"
@@ -1302,11 +1305,11 @@ msgstr ""
 
 msgctxt "#30733"
 msgid "Connection Test Results"
-msgstr ""
+msgstr "Yhteyskokeilun tulokset"
 
 msgctxt "#30734"
 msgid "Default to forced subtitles"
-msgstr ""
+msgstr "Oletuksena pakotettu tekstitys"
 
 msgctxt "#30735"
 msgid "Mixed content type"
@@ -1314,11 +1317,11 @@ msgstr ""
 
 msgctxt "#30736"
 msgid "Default"
-msgstr ""
+msgstr "Oletus"
 
 msgctxt "#30737"
 msgid "Majority"
-msgstr ""
+msgstr "Yleisin"
 
 msgctxt "#30738"
 msgid "Add custom access url"
@@ -1330,7 +1333,7 @@ msgstr ""
 
 msgctxt "#30740"
 msgid "Edit"
-msgstr ""
+msgstr "Muokkaa"
 
 msgctxt "#30741"
 msgid "Edit custom access url"
@@ -1342,19 +1345,19 @@ msgstr ""
 
 msgctxt "#30743"
 msgid "All Artists"
-msgstr ""
+msgstr "Kaikki esiintyjät"
 
 msgctxt "#30744"
 msgid "All Photos"
-msgstr ""
+msgstr "Kaikki kuvat"
 
 msgctxt "#30745"
 msgid "All Shows"
-msgstr ""
+msgstr "Kaikki ohjelmat"
 
 msgctxt "#30746"
 msgid "All Movies"
-msgstr ""
+msgstr "Kaikki elokuvat"
 
 msgctxt "#30747"
 msgid "Preferred lyrics format"
@@ -1362,27 +1365,27 @@ msgstr ""
 
 msgctxt "#30748"
 msgid "Lyrics"
-msgstr ""
+msgstr "Sanoitukset"
 
 msgctxt "#30749"
 msgid "lrc"
-msgstr ""
+msgstr "Irc"
 
 msgctxt "#30750"
 msgid "txt"
-msgstr ""
+msgstr "txt"
 
 msgctxt "#30751"
 msgid "Skip intro"
-msgstr ""
+msgstr "Ohita intro"
 
 msgctxt "#30752"
 msgid "Intro skipping"
-msgstr ""
+msgstr "Intron ohitus"
 
 msgctxt "#30753"
 msgid "Plex Pass Required"
-msgstr ""
+msgstr "Plex Pass vaaditaan"
 
 msgctxt "#30754"
 msgid "Plex powered by LyricFind"
@@ -1394,7 +1397,7 @@ msgstr ""
 
 msgctxt "#30756"
 msgid "All %s"
-msgstr ""
+msgstr "Kaikki %s"
 
 msgctxt "#30757"
 msgid "All Servers: TV Shows On Deck"
@@ -1406,7 +1409,7 @@ msgstr ""
 
 msgctxt "#30759"
 msgid "Recently Added Episodes"
-msgstr ""
+msgstr "Viimeksi lisätyt jaksot"
 
 msgctxt "#30760"
 msgid "All Servers: Recently Added Episodes"
@@ -1438,39 +1441,39 @@ msgstr ""
 
 msgctxt "#30767"
 msgid "Mixed"
-msgstr ""
+msgstr "Sekoitettu"
 
 msgctxt "#30768"
 msgid "Play"
-msgstr ""
+msgstr "Soita"
 
 msgctxt "#30769"
 msgid "Item Count"
-msgstr ""
+msgstr "Lukumäärä"
 
 msgctxt "#30770"
 msgid "All Servers"
-msgstr ""
+msgstr "Kaikki palvelimet"
 
 msgctxt "#30771"
 msgid "Shuffle"
-msgstr ""
+msgstr "Sekoita"
 
 msgctxt "#30772"
 msgid "Source"
-msgstr ""
+msgstr "Lähde"
 
 msgctxt "#30773"
 msgid "None"
-msgstr ""
+msgstr "Ei mitään"
 
 msgctxt "#30774"
 msgid "Generating Playlist"
-msgstr ""
+msgstr "Luodaan soittolistaa"
 
 msgctxt "#30775"
 msgid "This may take a while..."
-msgstr ""
+msgstr "Tämä voi viedä hetken..."
 
 msgctxt "#30776"
 msgid "Retrieving server list..."
@@ -1494,11 +1497,11 @@ msgstr ""
 
 msgctxt "#30781"
 msgid "Adding %s to playlist..."
-msgstr ""
+msgstr "Lisätään %s soittolistaan..."
 
 msgctxt "#30782"
 msgid "Completed."
-msgstr ""
+msgstr "Valmis."
 
 msgctxt "#30783"
 msgid "Checking section %s on %s..."
@@ -1526,7 +1529,7 @@ msgstr ""
 
 msgctxt "#30789"
 msgid "Server(s)"
-msgstr ""
+msgstr "Palvelimet"
 
 msgctxt "#30790"
 msgid "Combined Sections"
@@ -1534,15 +1537,15 @@ msgstr ""
 
 msgctxt "#30791"
 msgid "Search Movies..."
-msgstr ""
+msgstr "Etsi elokuvia..."
 
 msgctxt "#30792"
 msgid "Mark as watched"
-msgstr ""
+msgstr "Merkitse katsotuksi"
 
 msgctxt "#30793"
 msgid "Mark as unwatched"
-msgstr ""
+msgstr "Merkitse katsomattomaksi"
 
 msgctxt "#30794"
 msgid "Library - Movie Sections"
@@ -1554,7 +1557,7 @@ msgstr ""
 
 msgctxt "#30796"
 msgid "Kodi Library"
-msgstr ""
+msgstr "Kodi kirjasto"
 
 msgctxt "#30797"
 msgid "Select sections to include in library scans"
@@ -1567,3 +1570,11 @@ msgstr ""
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
 msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr "Jatka katsomista"
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr "Etsi palvelimet"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fo_fo/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fo_fo/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fo_fo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fr_ca/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fr_ca/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr_ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.fr_fr/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.gl_es/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.gl_es/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: gl_es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.he_il/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.he_il/strings.po
@@ -7,15 +7,23 @@ msgstr ""
 "Project-Id-Version: Composite\n"
 "Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: A. Dambledore\n"
-"Language-Team: Hebrew\n"
+"PO-Revision-Date: 2021-06-18 20:59+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
+"Language-Team: Hebrew (Israel) <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/he_il/>\n"
+"Language: he_il\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he_IL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.0.4\n"
+"X-Generator: Weblate 4.7\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -58,7 +66,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr "אתם כרגע מחובר אל myPlex. האם אתה בטוח שברצונך להתנתק?"
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr "אתה לא מחובר כעת לתוך myPlex. אנא המשך לרישום, או על ביטול כדי לחזור"
@@ -289,7 +296,7 @@ msgstr "אין אפשרות ליצור קשר עם השרת:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
-msgstr " עדכון הספרייה התחיל"
+msgstr "עדכון הספרייה התחיל"
 
 msgctxt "#30069"
 msgid "myPlex not configured"
@@ -573,7 +580,6 @@ msgid "Use WOL?"
 msgstr "להשתמש WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr "דלג על מידע-מטא של סגנון, במאי ותסריטאי"
@@ -903,15 +909,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1569,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.hi_in/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.hi_in/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hi_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.hr_hr/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.hr_hr/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hr_hr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.hu_hu/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.hu_hu/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.hy_am/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.hy_am/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hy_am\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.id_id/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.id_id/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: id_id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.is_is/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.is_is/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: is_is\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.it_it/strings.po
@@ -10,11 +10,19 @@ msgstr ""
 "PO-Revision-Date: 2020-01-18 21:15+0500\n"
 "Last-Translator: GITHUB USERNAME\n"
 "Language-Team: Italian\n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it_IT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr "Hai eseguito l'accesso in myPlex. Sei sicuro di voler uscire?"
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr "Non sei attualmente loggato in myPlex. Per favore continua il login, oppure annulla per tornare indietro"
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr "Indirizzo Server Primario"
@@ -504,9 +510,33 @@ msgctxt "#30530"
 msgid "Port Number"
 msgstr "Numero porta"
 
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
 msgctxt "#30536"
 msgid "Kodi Control"
 msgstr "Controllo Kodi"
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
 
 msgctxt "#30538"
 msgid "Audio and subtitle selector"
@@ -520,6 +550,10 @@ msgctxt "#30540"
 msgid "Quality"
 msgstr "Qualità"
 
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
 msgctxt "#30542"
 msgid "Plex Channel View"
 msgstr "Vista Canale Plex"
@@ -528,12 +562,23 @@ msgctxt "#30543"
 msgid "Flatten TV Shows"
 msgstr "Spiana le Serie TV"
 
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
 msgctxt "#30546"
 msgid "Windows Media Server?"
 msgstr ""
 
-# 30548
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
 
+# 30548
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr "Evita i metadata Genere/Regista/Scrittore"
@@ -553,6 +598,14 @@ msgstr "Evita i menu contestuali"
 msgctxt "#30553"
 msgid "Off"
 msgstr "Spento"
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
 
 msgctxt "#30557"
 msgid "Select audio output"
@@ -606,13 +659,17 @@ msgctxt "#30569"
 msgid "Audio Boost"
 msgstr "Aumento Livello Audio"
 
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
 msgctxt "#30571"
 msgid "Current Master Server"
 msgstr "Master Server Corrente"
 
 msgctxt "#30572"
-msgid "Shelf Items"
-msgstr "Elementi Scaffale"
+msgid "Current Master Server"
+msgstr ""
 
 msgctxt "#30573"
 msgid "Recently Added"
@@ -694,6 +751,10 @@ msgctxt "#30592"
 msgid "Use menu for shared sections"
 msgstr "Utilizza il menù per le sezioni condivise"
 
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
 msgctxt "#30594"
 msgid "Manual"
 msgstr "Manuale"
@@ -709,6 +770,18 @@ msgstr "Utilizza le fanart a piena risoluzione"
 msgctxt "#30597"
 msgid "Hide watched recently added items"
 msgstr "Nascondi gli elementi visti e aggiunti di recente"
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
 
 msgctxt "#30601"
 msgid "Transcoder"
@@ -835,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1499,3 +1569,15 @@ msgstr ""
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
 msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""
+
+#~ msgctxt "#30572"
+#~ msgid "Shelf Items"
+#~ msgstr "Elementi Scaffale"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ja_jp/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ja_jp/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja_jp\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.kn_in/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.kn_in/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: kn_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ko_kr/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ko_kr/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.lt_lt/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.lt_lt/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt_lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && (n % 100 < 11 || n % 100 > 19)) ? 0 : ((n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19)) ? 1 : 2);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.lv_lv/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.lv_lv/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lv_lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.mi/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.mi/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.mk_mk/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.mk_mk/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mk_mk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n==1 || n%10==1 ? 0 : 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ml_in/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ml_in/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ml_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.mn_mn/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.mn_mn/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mn_mn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ms_my/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ms_my/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ms_my\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.mt_mt/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.mt_mt/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mt_mt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.my_mm/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.my_mm/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: my_mm\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.nb_no/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.nb_no/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.nl_nl/strings.po
@@ -10,11 +10,19 @@ msgstr ""
 "PO-Revision-Date: 2020-01-18 21:15+0500\n"
 "Last-Translator: GITHUB USERNAME\n"
 "Language-Team: Dutch\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr "Adres van primaire server"
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr "Gebruik WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr "Genre/regisseur/schrijver-metadata overslaan"
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.os_os/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.os_os/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: os_os\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.pl_pl/strings.po
@@ -5,464 +5,471 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Composite\n"
-"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: GITHUB USERNAME\n"
-"Language-Team: Polish\n"
-"Language: pl_PL\n"
+"PO-Revision-Date: 2021-08-25 05:29+0000\n"
+"Last-Translator: eryk918 <erwinek1998@gmail.com>\n"
+"Language-Team: Polish <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/pl_pl/>\n"
+"Language: pl_pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.8\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr "Przeglądaj i odtwarzaj pliki multimedialne zarządzane przez Plex Media Server.[CR] [CR] Jest to fork PleXBMC stworzonego przez Hippojay'a"
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr "Composite NIE jest oficjalnym dodatkiem do programu Plex, nie jest wspierany ani zatwierdzany przez firmę Plex."
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
-msgstr ""
+msgstr "Potwierdzić usunięcie pliku?"
 
 msgctxt "#30001"
 msgid "Delete this item? This action will delete media and associated data files."
-msgstr ""
+msgstr "Usunąć ten element? Ta czynność spowoduje usunięcie multimediów i powiązanych z nim danych."
 
 msgctxt "#30002"
 msgid "Plex Online"
-msgstr ""
+msgstr "Plex Online"
 
 msgctxt "#30003"
 msgid "About to install"
-msgstr ""
+msgstr "Instalacja"
 
 msgctxt "#30004"
 msgid "This plugin is already installed"
-msgstr ""
+msgstr "Ta wtyczka jest już zainstalowana"
 
 msgctxt "#30005"
 msgid "Switch Failed"
-msgstr ""
+msgstr "Nie udało się przełączyć"
 
 msgctxt "#30006"
 msgid "Sign Out"
-msgstr ""
+msgstr "Wyloguj się"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
-msgstr ""
+msgstr "Aby się wylogować musisz być zalogowany jako administrator. Zmień użytkownika i spróbuj ponownie"
 
 msgctxt "#30008"
 msgid "myPlex"
-msgstr ""
+msgstr "myPlex"
 
 msgctxt "#30009"
 msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
-msgstr ""
+msgstr "Jesteś obecnie zalogowany do myPlex. Czy na pewno chcesz się wylogować?"
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
-msgstr ""
+msgstr "Nie jesteś obecnie zalogowany w serwisie myPlex. Kontynuuj, aby się zalogować, lub anuluj, aby powrócić"
 
 msgctxt "#30012"
 msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
-msgstr ""
+msgstr "Aby uzyskać dostęp do tych ekranów, musisz być zalogowany jako administrator. Zmień użytkownika i spróbuj ponownie"
 
 msgctxt "#30013"
 msgid "All"
-msgstr ""
+msgstr "Wszystko"
 
 msgctxt "#30014"
 msgid "Unwatched"
-msgstr ""
+msgstr "Nieobejrzane"
 
 msgctxt "#30015"
 msgid "Recently Aired"
-msgstr ""
+msgstr "Ostatnio emitowane"
 
 msgctxt "#30016"
 msgid "Recently Added"
-msgstr ""
+msgstr "Ostatnio dodane"
 
 msgctxt "#30017"
 msgid "Recently Viewed Episodes"
-msgstr ""
+msgstr "Ostatnio obejrzane odcinki"
 
 msgctxt "#30018"
 msgid "Recently Viewed Shows"
-msgstr ""
+msgstr "Ostatnio obejrzane programy"
 
 msgctxt "#30019"
 msgid "On Deck"
-msgstr ""
+msgstr "Aktualnie"
 
 msgctxt "#30020"
 msgid "By Collection"
-msgstr ""
+msgstr "Według kolekcji"
 
 msgctxt "#30021"
 msgid "By First Letter"
-msgstr ""
+msgstr "Według pierwszej litery"
 
 msgctxt "#30022"
 msgid "By Genre"
-msgstr ""
+msgstr "Według gatunku"
 
 msgctxt "#30023"
 msgid "By Year"
-msgstr ""
+msgstr "Według roku"
 
 msgctxt "#30024"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Według oceny treści"
 
 msgctxt "#30025"
 msgid "By Folder"
-msgstr ""
+msgstr "Według katalogu"
 
 msgctxt "#30026"
 msgid "Search Shows..."
-msgstr ""
+msgstr "Szukaj programów..."
 
 msgctxt "#30027"
 msgid "Search Episodes..."
-msgstr ""
+msgstr "Szukaj odcinków..."
 
 msgctxt "#30028"
 msgid "All"
-msgstr ""
+msgstr "Wszystko"
 
 msgctxt "#30029"
 msgid "By Album"
-msgstr ""
+msgstr "Według albumu"
 
 msgctxt "#30030"
 msgid "By Genre"
-msgstr ""
+msgstr "Według gatunku"
 
 msgctxt "#30031"
 msgid "By Year"
-msgstr ""
+msgstr "Według roku"
 
 msgctxt "#30032"
 msgid "By Collection"
-msgstr ""
+msgstr "Według kolekcji"
 
 msgctxt "#30033"
 msgid "Recently Added"
-msgstr ""
+msgstr "Ostatnio dodane"
 
 msgctxt "#30034"
 msgid "By Folder"
-msgstr ""
+msgstr "Według katalogu"
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr ""
+msgstr "Szukaj wykonawców..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr ""
+msgstr "Wyszukaj albumy..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
-msgstr ""
+msgstr "Szukaj utworów..."
 
 msgctxt "#30038"
 msgid "All"
-msgstr ""
+msgstr "Wszystko"
 
 msgctxt "#30039"
 msgid "Unwatched"
-msgstr ""
+msgstr "Nieobejrzane"
 
 msgctxt "#30040"
 msgid "Recently Released"
-msgstr ""
+msgstr "Ostatnio wydane"
 
 msgctxt "#30041"
 msgid "Recently Added"
-msgstr ""
+msgstr "Ostatnio dodane"
 
 msgctxt "#30042"
 msgid "Recently Viewed"
-msgstr ""
+msgstr "Ostatnio obejrzane"
 
 msgctxt "#30043"
 msgid "On Deck"
-msgstr ""
+msgstr "Aktualnie"
 
 msgctxt "#30044"
 msgid "By Collection"
-msgstr ""
+msgstr "Według kolekcji"
 
 msgctxt "#30045"
 msgid "By Genre"
-msgstr ""
+msgstr "Według gatunku"
 
 msgctxt "#30046"
 msgid "By Year"
-msgstr ""
+msgstr "Według roku"
 
 msgctxt "#30047"
 msgid "By Decade"
-msgstr ""
+msgstr "Według dekady"
 
 msgctxt "#30048"
 msgid "By Director"
-msgstr ""
+msgstr "Według reżysera"
 
 msgctxt "#30049"
 msgid "By Starring Actor"
-msgstr ""
+msgstr "Według występujących aktorów"
 
 msgctxt "#30050"
 msgid "By Country"
-msgstr ""
+msgstr "Według kraju"
 
 msgctxt "#30051"
 msgid "By Content Rating"
-msgstr ""
+msgstr "Według oceny treści"
 
 msgctxt "#30052"
 msgid "By Rating"
-msgstr ""
+msgstr "Według oceny"
 
 msgctxt "#30053"
 msgid "By Resolution"
-msgstr ""
+msgstr "Według rozdzielczości"
 
 msgctxt "#30054"
 msgid "By First Letter"
-msgstr ""
+msgstr "Według pierwszej litery"
 
 msgctxt "#30055"
 msgid "By Folder"
-msgstr ""
+msgstr "Według katalogu"
 
 msgctxt "#30056"
 msgid "Search..."
-msgstr ""
+msgstr "Szukaj..."
 
 msgctxt "#30057"
 msgid "All"
-msgstr ""
+msgstr "Wszystko"
 
 msgctxt "#30058"
 msgid "By Year"
-msgstr ""
+msgstr "Według roku"
 
 msgctxt "#30059"
 msgid "Recently Added"
-msgstr ""
+msgstr "Ostatnio dodane"
 
 msgctxt "#30060"
 msgid "Camera Make"
-msgstr ""
+msgstr "Marka aparatu"
 
 msgctxt "#30061"
 msgid "Camera Model"
-msgstr ""
+msgstr "Model aparatu"
 
 msgctxt "#30062"
 msgid "Aperture"
-msgstr ""
+msgstr "Przesłona"
 
 msgctxt "#30063"
 msgid "Shutter Speed"
-msgstr ""
+msgstr "Czas otwarcia migawki"
 
 msgctxt "#30064"
 msgid "ISO"
-msgstr ""
+msgstr "Czułość ISO"
 
 msgctxt "#30065"
 msgid "Lens"
-msgstr ""
+msgstr "Obiektyw"
 
 msgctxt "#30066"
 msgid "Unable to see any media servers"
-msgstr ""
+msgstr "Nie znaleziono żadnych serwerów multimediów"
 
 msgctxt "#30067"
 msgid "Unable to contact server:"
-msgstr ""
+msgstr "Nie można nawiązać połączenia z serwerem:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
-msgstr ""
+msgstr "Rozpoczęto odświeżanie biblioteki"
 
 msgctxt "#30069"
 msgid "myPlex not configured"
-msgstr ""
+msgstr "Nie skonfigurowano usługi myPlex"
 
 msgctxt "#30070"
 msgid "Resume"
-msgstr ""
+msgstr "Wznów"
 
 msgctxt "#30071"
 msgid "Select media to play"
-msgstr ""
+msgstr "Wybierz media do odtworzenia"
 
 msgctxt "#30072"
 msgid "Select subtitle"
-msgstr ""
+msgstr "Wybierz napisy"
 
 msgctxt "#30073"
 msgid "Select audio"
-msgstr ""
+msgstr "Wybierz audio"
 
 msgctxt "#30074"
 msgid "Select master server"
-msgstr ""
+msgstr "Wybierz serwer główny"
 
 msgctxt "#30075"
 msgid "Known server list"
-msgstr ""
+msgstr "Lista znanych serwerów"
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr ""
+msgstr "Przełącz użytkownika"
 
 msgctxt "#30077"
 msgid "Enter PIN"
-msgstr ""
+msgstr "Wprowadź PIN"
 
 msgctxt "#30078"
 msgid "Resume from"
-msgstr ""
+msgstr "Wznów od"
 
 msgctxt "#30079"
 msgid "Start from beginning"
-msgstr ""
+msgstr "Zacznij od początku"
 
 msgctxt "#30080"
 msgid "myPlex Queue"
-msgstr ""
+msgstr "Kolejka myPlex"
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr ""
+msgstr "Zaloguj się"
 
 msgctxt "#30082"
 msgid "Display Servers"
-msgstr ""
+msgstr "Pokaż serwery"
 
 msgctxt "#30083"
 msgid "Refresh Data"
-msgstr ""
+msgstr "Odśwież dane"
 
 msgctxt "#30084"
 msgid "Channels"
-msgstr ""
+msgstr "Kanały"
 
 msgctxt "#30085"
 msgid "Playlists"
-msgstr ""
+msgstr "Listy odtwarzania"
 
 msgctxt "#30086"
 msgid "Play Transcoded"
-msgstr ""
+msgstr "Odtwórz transkodowane"
 
 msgctxt "#30087"
 msgid "All episodes"
-msgstr ""
+msgstr "Wszystkie odcinki"
 
 msgctxt "#30088"
 msgid "Season"
-msgstr ""
+msgstr "Sezon"
 
 msgctxt "#30089"
 msgid "Search for"
-msgstr ""
+msgstr "Szukaj"
 
 msgctxt "#30090"
 msgid "Unplayed"
-msgstr ""
+msgstr "Nieodtworzone"
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
-msgstr ""
+msgstr "Adres serwera głównego"
 
 msgctxt "#30501"
 msgid "Stream from PMS"
-msgstr ""
+msgstr "Strumieniuj z PMS"
 
 msgctxt "#30502"
 msgid "Get extended metadata from PMS"
-msgstr ""
+msgstr "Pobierz rozszerzone metadane z PMS"
 
 msgctxt "#30503"
 msgid "Enable extra filter menus"
-msgstr ""
+msgstr "Włącz dodatkowe menu filtrów"
 
 msgctxt "#30504"
 msgid "Server Discovery"
-msgstr ""
+msgstr "Wykrywanie serwerów"
 
 msgctxt "#30505"
 msgid "PMS Username: "
-msgstr ""
+msgstr "Nazwa użytkownika PMS: "
 
 msgctxt "#30506"
 msgid "PMS Password: "
-msgstr ""
+msgstr "Hasło PMS: "
 
 msgctxt "#30507"
 msgid "Always Transcode"
-msgstr ""
+msgstr "Zawsze transkoduj"
 
 msgctxt "#30508"
 msgid "Transcode format "
-msgstr ""
+msgstr "Format transkodowania: "
 
 msgctxt "#30509"
 msgid "Recent & OnDeck items"
-msgstr ""
+msgstr "Ostatnie i obecnie odtwarzane elementy"
 
 msgctxt "#30510"
 msgid "Debug log"
-msgstr ""
+msgstr "Dziennik debugowania"
 
 msgctxt "#30511"
 msgid "Auto"
-msgstr ""
+msgstr "Auto"
 
 msgctxt "#30512"
 msgid "http"
-msgstr ""
+msgstr "http"
 
 msgctxt "#30513"
 msgid "smb"
-msgstr ""
+msgstr "smb"
 
 msgctxt "#30514"
 msgid "Debug level"
-msgstr ""
+msgstr "Poziom debugowania"
 
 msgctxt "#30515"
 msgid "Use transcoding proxy"
-msgstr ""
+msgstr "Używaj proxy podczas transkodowania"
 
 msgctxt "#30516"
 msgid "Server"
-msgstr ""
+msgstr "Serwer"
 
 msgctxt "#30517"
 msgid "Playback"
-msgstr ""
+msgstr "Odtwarzanie"
 
 msgctxt "#30518"
 msgid "Transcoding"
-msgstr ""
+msgstr "Transkodowanie"
 
 msgctxt "#30519"
 msgid "Wake On LAN"
-msgstr ""
+msgstr "Wake On LAN"
 
 msgctxt "#30520"
 msgid "Look and Feel"
-msgstr ""
+msgstr "Wygląd i wrażenia"
 
 msgctxt "#30521"
 msgid "Skin Home Shelf"
@@ -470,345 +477,344 @@ msgstr ""
 
 msgctxt "#30522"
 msgid "Advanced"
-msgstr ""
+msgstr "Zaawansowane"
 
 msgctxt "#30523"
 msgid "Use Wake On LAN"
-msgstr ""
+msgstr "Używaj Wake On LAN"
 
 msgctxt "#30524"
 msgid "myPlex user"
-msgstr ""
+msgstr "Użytkownik myPlex"
 
 msgctxt "#30525"
 msgid "myPlex password"
-msgstr ""
+msgstr "Hasło myPlex"
 
 msgctxt "#30526"
 msgid "Select master server..."
-msgstr ""
+msgstr "Wybierz serwer główny..."
 
 msgctxt "#30527"
 msgid "Authentication required?"
-msgstr ""
+msgstr "Wymagane uwierzytelnienie?"
 
 msgctxt "#30528"
 msgid "Load External Subtitles?"
-msgstr ""
+msgstr "Załadować zewnętrzne napisy?"
 
 msgctxt "#30529"
 msgid "Always display subtitles?"
-msgstr ""
+msgstr "Zawsze wyświetlać napisy?"
 
 msgctxt "#30530"
 msgid "Port Number"
-msgstr ""
+msgstr "Numer portu"
 
 msgctxt "#30531"
 msgid "Use PMS localisation settings"
-msgstr ""
+msgstr "Użyj ustawień lokalizacji PMS"
 
 msgctxt "#30532"
 msgid "Manual"
-msgstr ""
+msgstr "Manualnie"
 
 msgctxt "#30533"
 msgid "Always"
-msgstr ""
+msgstr "Zawsze"
 
 msgctxt "#30534"
 msgid "Audio stream selection"
-msgstr ""
+msgstr "Wybór strumienia audio"
 
 msgctxt "#30535"
 msgid "Subtitle stream selection"
-msgstr ""
+msgstr "Wybór strumienia napisów"
 
 msgctxt "#30536"
 msgid "Kodi Control"
-msgstr ""
+msgstr "Ustawienia Kodi"
 
 msgctxt "#30537"
 msgid "External"
-msgstr ""
+msgstr "Zewnętrzne"
 
 msgctxt "#30538"
 msgid "Audio and subtitle selector"
-msgstr ""
+msgstr "Wybór dźwięku i napisów"
 
 msgctxt "#30539"
 msgid "Never show subtitles"
-msgstr ""
+msgstr "Nigdy nie pokazuj napisów"
 
 msgctxt "#30540"
 msgid "Quality"
-msgstr ""
+msgstr "Jakość"
 
 msgctxt "#30541"
 msgid "Proxy Port"
-msgstr ""
+msgstr "Port proxy"
 
 msgctxt "#30542"
 msgid "Plex Channel View"
-msgstr ""
+msgstr "Widok kanału Plex"
 
 msgctxt "#30543"
 msgid "Flatten TV Shows"
-msgstr ""
+msgstr "Uprość widok wyboru programów telewizyjnych"
 
 msgctxt "#30544"
 msgid "Server MAC address"
-msgstr ""
+msgstr "Adres MAC serwera"
 
 msgctxt "#30545"
 msgid "Plex Style Watched flags"
-msgstr ""
+msgstr "Znacznik obejrzenia w stylu Plex"
 
 msgctxt "#30546"
 msgid "Windows Media Server?"
-msgstr ""
+msgstr "Windows Media Server?"
 
 msgctxt "#30547"
 msgid "Use WOL?"
-msgstr ""
+msgstr "Używać Wake On LAN?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
-msgstr ""
+msgstr "Pomiń gatunek / reżysera/ scenarzystę"
 
 msgctxt "#30550"
 msgid "Skip images (thumbs, fanart)"
-msgstr ""
+msgstr "Pomiń obrazy (miniatury, fanarty)"
 
 msgctxt "#30551"
 msgid "Skip Media Flags"
-msgstr ""
+msgstr "Pomiń znaczniki mediów"
 
 msgctxt "#30552"
 msgid "Skip Context Menus"
-msgstr ""
+msgstr "Pomiń menu kontekstowe"
 
 msgctxt "#30553"
 msgid "Off"
-msgstr ""
+msgstr "Wyłączone"
 
 msgctxt "#30554"
 msgid "Bonjour"
-msgstr ""
+msgstr "Bonjour"
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
-msgstr ""
+msgstr "Odtwarzaj muzykę z motywów telewizyjnych"
 
 msgctxt "#30557"
 msgid "Select audio output"
-msgstr ""
+msgstr "Wybierz wyjście audio"
 
 msgctxt "#30558"
 msgid "If only one season"
-msgstr ""
+msgstr "Jeśli tylko jeden sezon"
 
 msgctxt "#30559"
 msgid "All seasons"
-msgstr ""
+msgstr "Wszystkie sezony"
 
 msgctxt "#30560"
 msgid "Force DVD playback"
-msgstr ""
+msgstr "Wymuś odtwarzanie DVD"
 
 msgctxt "#30561"
 msgid "Override SMB location"
-msgstr ""
+msgstr "Zastąp lokalizację SMB"
 
 msgctxt "#30562"
 msgid "NAS IP Address"
-msgstr ""
+msgstr "Adres IP serwera NAS"
 
 msgctxt "#30563"
 msgid "AFP"
-msgstr ""
+msgstr "AFP"
 
 msgctxt "#30564"
 msgid "NAS Username"
-msgstr ""
+msgstr "Nazwa użytkownika NAS"
 
 msgctxt "#30565"
 msgid "NAS password"
-msgstr ""
+msgstr "Hasło do NAS"
 
 msgctxt "#30566"
 msgid "NAS Root Folder"
-msgstr ""
+msgstr "Katalog główny NAS"
 
 msgctxt "#30567"
 msgid "Plex Control"
-msgstr ""
+msgstr "PMS"
 
 msgctxt "#30568"
 msgid "Subtitle Size"
-msgstr ""
+msgstr "Rozmiar napisów"
 
 msgctxt "#30569"
 msgid "Audio Boost"
-msgstr ""
+msgstr "Wzmocnienie dźwięku"
 
 msgctxt "#30570"
 msgid "Auto (GDM)"
-msgstr ""
+msgstr "Automatycznie (GDM)"
 
 msgctxt "#30571"
 msgid "Current Master Server"
-msgstr ""
+msgstr "Aktualny serwer główny"
 
 msgctxt "#30572"
 msgid "Current Master Server"
-msgstr ""
+msgstr "Aktualny serwer główny"
 
 msgctxt "#30573"
 msgid "Recently Added"
-msgstr ""
+msgstr "Ostatnio dodane"
 
 msgctxt "#30574"
 msgid "On Deck"
-msgstr ""
+msgstr "Aktualnie"
 
 msgctxt "#30575"
 msgid "Force Skin Views"
-msgstr ""
+msgstr "Wymuś widok w skórze"
 
 msgctxt "#30576"
 msgid "Skin Name"
-msgstr ""
+msgstr "Nazwa skóry"
 
 msgctxt "#30577"
 msgid "Movie View"
-msgstr ""
+msgstr "Widok wg. filmu"
 
 msgctxt "#30578"
 msgid "TV View"
-msgstr ""
+msgstr "Widok wg. serialu"
 
 msgctxt "#30579"
 msgid "Season View"
-msgstr ""
+msgstr "Widok wg. sezonu"
 
 msgctxt "#30580"
 msgid "Episode View"
-msgstr ""
+msgstr "Widok wg. odcinka"
 
 msgctxt "#30581"
 msgid "Music View"
-msgstr ""
+msgstr "Widok wg. muzyki"
 
 msgctxt "#30582"
 msgid "Enable Movie Shelf"
-msgstr ""
+msgstr "Włącz półkę z filmami"
 
 msgctxt "#30583"
 msgid "Enable TV Shelf"
-msgstr ""
+msgstr "Włącz półkę z serialami"
 
 msgctxt "#30584"
 msgid "Enable Music Shelf"
-msgstr ""
+msgstr "Włącz półkę z muzyką"
 
 msgctxt "#30585"
 msgid "Enable Channel Shelf"
-msgstr ""
+msgstr "Włącz półkę z kanałami"
 
 msgctxt "#30586"
 msgid "Content filter"
-msgstr ""
+msgstr "Filtr zawartości"
 
 msgctxt "#30587"
 msgid "Map unknown content as:"
-msgstr ""
+msgstr "Mapuj nieznaną treść jako:"
 
 msgctxt "#30588"
 msgid "RA Library filter"
-msgstr ""
+msgstr "Filtr biblioteki RA"
 
 msgctxt "#30589"
 msgid "Kids"
-msgstr ""
+msgstr "Dzieci"
 
 msgctxt "#30590"
 msgid "Teens"
-msgstr ""
+msgstr "Młodzież"
 
 msgctxt "#30591"
 msgid "Adults"
-msgstr ""
+msgstr "Dorośli"
 
 msgctxt "#30592"
 msgid "Use menu for shared sections"
-msgstr ""
+msgstr "Użyj menu dla wspólnych sekcji"
 
 msgctxt "#30593"
 msgid "Cache Data"
-msgstr ""
+msgstr "Dane w pamięci podręcznej"
 
 msgctxt "#30594"
 msgid "Manual"
-msgstr ""
+msgstr "Manualnie"
 
 msgctxt "#30595"
 msgid "Use full resolution thumbs"
-msgstr ""
+msgstr "Używaj miniatur w pełnej rozdzielczości"
 
 msgctxt "#30596"
 msgid "Use full resolution fanart"
-msgstr ""
+msgstr "Używaj fanartów w pełnej rozdzielczości"
 
 msgctxt "#30597"
 msgid "Hide watched recently added items"
-msgstr ""
+msgstr "Ukryj wyświetlane elementy w „Ostatnio dodane”"
 
 msgctxt "#30598"
 msgid "Info"
-msgstr ""
+msgstr "Informacje"
 
 msgctxt "#30599"
 msgid "Debug"
-msgstr ""
+msgstr "Debugowanie"
 
 msgctxt "#30600"
 msgid "Debug+"
-msgstr ""
+msgstr "Debug+"
 
 msgctxt "#30601"
 msgid "Transcoder"
-msgstr ""
+msgstr "Transkoder"
 
 msgctxt "#30602"
 msgid "Name"
-msgstr ""
+msgstr "Nazwa klienta"
 
 msgctxt "#30603"
 msgid "Disable 'All Episodes'"
-msgstr ""
+msgstr "Ukryj „Wszystkie odcinki” z listy sezonów"
 
 msgctxt "#30604"
 msgid "Enable Kodi view cache"
-msgstr ""
+msgstr "Włącz buforowanie widoku w Kodi"
 
 msgctxt "#30605"
 msgid "Manage myPlex"
-msgstr ""
+msgstr "Zarządzaj myPlex"
 
 msgctxt "#30606"
 msgid "Prefer Season artwork"
-msgstr ""
+msgstr "Preferuj okładkę sezonu"
 
 msgctxt "#30607"
 msgid "Hide Unique Information in log"
-msgstr ""
+msgstr "Ukryj unikalne informacje w logu"
 
 msgctxt "#30608"
 msgid "Use Kodi client name?"
-msgstr ""
+msgstr "Używać nazwy klienta Kodi?"
 
 msgctxt "#30609"
 msgid "Switch off playback monitor"
@@ -816,23 +822,23 @@ msgstr ""
 
 msgctxt "#30610"
 msgid "Use HTTPS"
-msgstr ""
+msgstr "Używaj HTTPS"
 
 msgctxt "#30611"
 msgid "Transcode > 1080p"
-msgstr ""
+msgstr "Transkoduj > 1080p"
 
 msgctxt "#30612"
 msgid "Transcode HEVC"
-msgstr ""
+msgstr "Transkoduj HEVC"
 
 msgctxt "#30613"
 msgid "MAC Address"
-msgstr ""
+msgstr "Adres MAC"
 
 msgctxt "#30614"
 msgid "Universal"
-msgstr ""
+msgstr "Uniwersalny"
 
 msgctxt "#30615"
 msgid "Legacy"
@@ -844,35 +850,35 @@ msgstr ""
 
 msgctxt "#30617"
 msgid "Username:"
-msgstr ""
+msgstr "Nazwa użytkownika:"
 
 msgctxt "#30618"
 msgid "Password:"
-msgstr ""
+msgstr "Hasło:"
 
 msgctxt "#30619"
 msgid "Cancel"
-msgstr ""
+msgstr "Anuluj"
 
 msgctxt "#30620"
 msgid "Submit"
-msgstr ""
+msgstr "Zatwierdź"
 
 msgctxt "#30621"
 msgid "Manual"
-msgstr ""
+msgstr "Manualnie"
 
 msgctxt "#30622"
 msgid "Use PIN"
-msgstr ""
+msgstr "Użyj PIN'u"
 
 msgctxt "#30623"
 msgid "Done"
-msgstr ""
+msgstr "Zrobione"
 
 msgctxt "#30624"
 msgid "Unable to sign in"
-msgstr ""
+msgstr "Logowanie nie powiodło się"
 
 msgctxt "#30625"
 msgid "From your computer, go to %s and enter the code below"
@@ -880,7 +886,7 @@ msgstr ""
 
 msgctxt "#30626"
 msgid "Successfully signed in"
-msgstr ""
+msgstr "Pomyślnie zalogowano"
 
 msgctxt "#30627"
 msgid "Sign in not successful"
@@ -888,85 +894,82 @@ msgstr ""
 
 msgctxt "#30628"
 msgid "Email:"
-msgstr ""
+msgstr "E-mail:"
 
 msgctxt "#30629"
 msgid "Plex Pass:"
-msgstr ""
+msgstr "Plex Pass:"
 
 msgctxt "#30630"
 msgid "Joined:"
-msgstr ""
+msgstr "Dołączono:"
 
 msgctxt "#30631"
 msgid "Exit"
-msgstr ""
+msgstr "Wyjście"
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
-msgstr ""
+msgstr "Nieznany"
 
 msgctxt "#30637"
 msgid "myPlex Login"
-msgstr ""
+msgstr "Login w myPlex"
 
 msgctxt "#30638"
 msgid "Enter search term"
-msgstr ""
+msgstr "Podaj frazę do wyszukania"
 
 msgctxt "#30639"
 msgid "Enter value"
-msgstr ""
+msgstr "Podaj wartość"
 
 msgctxt "#30640"
 msgid "Transcode Profile"
-msgstr ""
+msgstr "Profil transkodowania"
 
 msgctxt "#30641"
 msgid "Transcode Profiles"
-msgstr ""
+msgstr "Profile transkodowania"
 
 msgctxt "#30642"
 msgid "Offline"
-msgstr ""
+msgstr "Offline"
 
 msgctxt "#30643"
 msgid "Remote"
-msgstr ""
+msgstr "Zdalny"
 
 msgctxt "#30644"
 msgid "Nearby"
-msgstr ""
+msgstr "Lokalny"
 
 msgctxt "#30645"
 msgid "SSL"
-msgstr ""
+msgstr "SSL"
 
 msgctxt "#30646"
 msgid "Not Secure"
-msgstr ""
+msgstr "Nie zabezpieczone"
 
 msgctxt "#30647"
 msgid "Certificate Verification"
-msgstr ""
+msgstr "Weryfikacja certyfikatu"
 
 msgctxt "#30648"
 msgid "Message"
-msgstr ""
+msgstr "Wiadomość"
 
 msgctxt "#30649"
 msgid "blank"
-msgstr ""
+msgstr "pusty"
 
 msgctxt "#30650"
 msgid "Server Discovery"
@@ -974,7 +977,7 @@ msgstr ""
 
 msgctxt "#30651"
 msgid "Please wait..."
-msgstr ""
+msgstr "Proszę czekać..."
 
 msgctxt "#30652"
 msgid "myPlex discovery..."
@@ -998,7 +1001,7 @@ msgstr ""
 
 msgctxt "#30657"
 msgid "Found servers:"
-msgstr ""
+msgstr "Znalezione serwery:"
 
 msgctxt "#30658"
 msgid "No servers found"
@@ -1006,19 +1009,19 @@ msgstr ""
 
 msgctxt "#30659"
 msgid "Transcode > 8-bit"
-msgstr ""
+msgstr "Transkoduj > 8-bit"
 
 msgctxt "#30660"
 msgid "Device Name"
-msgstr ""
+msgstr "Nazwa urządzenia"
 
 msgctxt "#30661"
 msgid "Cache"
-msgstr ""
+msgstr "Pamięć podręczna"
 
 msgctxt "#30662"
 msgid "Server Cache TTL (minutes)"
-msgstr ""
+msgstr "Pamięć podręczna serwera TTL (w minutach)"
 
 msgctxt "#30663"
 msgid "Server detection notification"
@@ -1026,23 +1029,23 @@ msgstr ""
 
 msgctxt "#30664"
 msgid "installed"
-msgstr ""
+msgstr "zainstalowano"
 
 msgctxt "#30665"
 msgid "Movies"
-msgstr ""
+msgstr "Filmy"
 
 msgctxt "#30666"
 msgid "Music"
-msgstr ""
+msgstr "Muzyka"
 
 msgctxt "#30667"
 msgid "TV Shows"
-msgstr ""
+msgstr "Programy telewizyjne"
 
 msgctxt "#30668"
 msgid "Photos"
-msgstr ""
+msgstr "Zdjecia"
 
 msgctxt "#30669"
 msgid "Server name prefix on the main menu"
@@ -1050,15 +1053,15 @@ msgstr ""
 
 msgctxt "#30670"
 msgid "Always"
-msgstr ""
+msgstr "Zawsze"
 
 msgctxt "#30671"
 msgid "Default"
-msgstr ""
+msgstr "Domyślnie"
 
 msgctxt "#30672"
 msgid "Go to %s"
-msgstr ""
+msgstr "Idź do %s"
 
 msgctxt "#30673"
 msgid "Delete %s from the %s playlist?"
@@ -1066,15 +1069,15 @@ msgstr ""
 
 msgctxt "#30674"
 msgid "Confirm playlist item delete?"
-msgstr ""
+msgstr "Czy na pewno chcesz usunąć ten element?"
 
 msgctxt "#30675"
 msgid "Delete from playlist"
-msgstr ""
+msgstr "Usuń z listy odtwarzania"
 
 msgctxt "#30676"
 msgid "Select playlist"
-msgstr ""
+msgstr "Wybierz listę odtwarzania"
 
 msgctxt "#30677"
 msgid "Add to playlist"
@@ -1118,7 +1121,7 @@ msgstr ""
 
 msgctxt "#30687"
 msgid "Install Up Next"
-msgstr ""
+msgstr "Zainstaluj 'Up Next'"
 
 msgctxt "#30688"
 msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
@@ -1126,7 +1129,7 @@ msgstr ""
 
 msgctxt "#30689"
 msgid "Up Next requires Kodi 18 or higher"
-msgstr ""
+msgstr "Dodatek 'Up Next' wymaga Kodi 18 i wyżej"
 
 msgctxt "#30690"
 msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
@@ -1134,11 +1137,11 @@ msgstr ""
 
 msgctxt "#30691"
 msgid "Use episode thumbnails"
-msgstr ""
+msgstr "Używaj miniatur odcinków"
 
 msgctxt "#30692"
 msgid "Widgets"
-msgstr ""
+msgstr "Widżety"
 
 msgctxt "#30693"
 msgid "Show [B]Widgets[/B] menu"
@@ -1170,7 +1173,7 @@ msgstr ""
 
 msgctxt "#30700"
 msgid "Recently Aired TV Shows"
-msgstr ""
+msgstr "Ostatnio emitowane programy telewizyjne"
 
 msgctxt "#30701"
 msgid "Recently Added Movies"
@@ -1566,4 +1569,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.pt_br/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.pt_br/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.pt_pt/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.pt_pt/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ro_md/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ro_md/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro_md\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 19) ? 1 : 2);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ro_ro/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1))\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ru_ru/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ru_ru/strings.po
@@ -5,16 +5,25 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Composite\n"
-"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2020-01-18 21:15+0500\n"
-"Last-Translator: Dukobpa3\n"
-"Language-Team: Russian\n"
+"PO-Revision-Date: 2021-09-01 17:29+0000\n"
+"Last-Translator: Dmitry Petrov <dimakrm361@gmail.com>\n"
+"Language-Team: Russian <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/ru_ru/>\n"
+"Language: ru_ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru_RU\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.8\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -42,7 +51,7 @@ msgstr ""
 
 msgctxt "#30006"
 msgid "Sign Out"
-msgstr ""
+msgstr "Выйти"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
@@ -57,7 +66,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -68,11 +76,11 @@ msgstr ""
 
 msgctxt "#30013"
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 msgctxt "#30014"
 msgid "Unwatched"
-msgstr ""
+msgstr "Не просмотрено"
 
 msgctxt "#30015"
 msgid "Recently Aired"
@@ -80,7 +88,7 @@ msgstr ""
 
 msgctxt "#30016"
 msgid "Recently Added"
-msgstr ""
+msgstr "Недавно добавленные"
 
 msgctxt "#30017"
 msgid "Recently Viewed Episodes"
@@ -92,7 +100,7 @@ msgstr ""
 
 msgctxt "#30019"
 msgid "On Deck"
-msgstr ""
+msgstr "На главной"
 
 msgctxt "#30020"
 msgid "By Collection"
@@ -100,7 +108,7 @@ msgstr ""
 
 msgctxt "#30021"
 msgid "By First Letter"
-msgstr ""
+msgstr "по первой букве"
 
 msgctxt "#30022"
 msgid "By Genre"
@@ -124,11 +132,11 @@ msgstr ""
 
 msgctxt "#30027"
 msgid "Search Episodes..."
-msgstr ""
+msgstr "Поиск серий..."
 
 msgctxt "#30028"
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 msgctxt "#30029"
 msgid "By Album"
@@ -148,7 +156,7 @@ msgstr ""
 
 msgctxt "#30033"
 msgid "Recently Added"
-msgstr ""
+msgstr "Недавно добавленные"
 
 msgctxt "#30034"
 msgid "By Folder"
@@ -156,11 +164,11 @@ msgstr ""
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr ""
+msgstr "Поиск исполнителей..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr ""
+msgstr "Поиск альбомов..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
@@ -168,11 +176,11 @@ msgstr ""
 
 msgctxt "#30038"
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 msgctxt "#30039"
 msgid "Unwatched"
-msgstr ""
+msgstr "Не просмотрено"
 
 msgctxt "#30040"
 msgid "Recently Released"
@@ -180,7 +188,7 @@ msgstr ""
 
 msgctxt "#30041"
 msgid "Recently Added"
-msgstr ""
+msgstr "Недавно добавленные"
 
 msgctxt "#30042"
 msgid "Recently Viewed"
@@ -188,7 +196,7 @@ msgstr ""
 
 msgctxt "#30043"
 msgid "On Deck"
-msgstr ""
+msgstr "На главной"
 
 msgctxt "#30044"
 msgid "By Collection"
@@ -232,7 +240,7 @@ msgstr ""
 
 msgctxt "#30054"
 msgid "By First Letter"
-msgstr ""
+msgstr "по первой букве"
 
 msgctxt "#30055"
 msgid "By Folder"
@@ -240,11 +248,11 @@ msgstr ""
 
 msgctxt "#30056"
 msgid "Search..."
-msgstr ""
+msgstr "Поиск…"
 
 msgctxt "#30057"
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 msgctxt "#30058"
 msgid "By Year"
@@ -252,19 +260,19 @@ msgstr ""
 
 msgctxt "#30059"
 msgid "Recently Added"
-msgstr ""
+msgstr "Недавно добавленные"
 
 msgctxt "#30060"
 msgid "Camera Make"
-msgstr ""
+msgstr "Производитель"
 
 msgctxt "#30061"
 msgid "Camera Model"
-msgstr ""
+msgstr "Модель фотоаппарата"
 
 msgctxt "#30062"
 msgid "Aperture"
-msgstr ""
+msgstr "Диафрагма"
 
 msgctxt "#30063"
 msgid "Shutter Speed"
@@ -272,7 +280,7 @@ msgstr ""
 
 msgctxt "#30064"
 msgid "ISO"
-msgstr ""
+msgstr "Чувствительность ISO"
 
 msgctxt "#30065"
 msgid "Lens"
@@ -296,7 +304,7 @@ msgstr ""
 
 msgctxt "#30070"
 msgid "Resume"
-msgstr ""
+msgstr "Продолжить"
 
 msgctxt "#30071"
 msgid "Select media to play"
@@ -312,7 +320,7 @@ msgstr ""
 
 msgctxt "#30074"
 msgid "Select master server"
-msgstr ""
+msgstr "Выбрать Мастер Сервер"
 
 msgctxt "#30075"
 msgid "Known server list"
@@ -320,7 +328,7 @@ msgstr ""
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr ""
+msgstr "Смена пользователя"
 
 msgctxt "#30077"
 msgid "Enter PIN"
@@ -340,7 +348,7 @@ msgstr ""
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr ""
+msgstr "Авторизация"
 
 msgctxt "#30082"
 msgid "Display Servers"
@@ -352,11 +360,11 @@ msgstr ""
 
 msgctxt "#30084"
 msgid "Channels"
-msgstr ""
+msgstr "Каналы"
 
 msgctxt "#30085"
 msgid "Playlists"
-msgstr ""
+msgstr "Плейлисты"
 
 msgctxt "#30086"
 msgid "Play Transcoded"
@@ -368,7 +376,7 @@ msgstr ""
 
 msgctxt "#30088"
 msgid "Season"
-msgstr ""
+msgstr "Сезон"
 
 msgctxt "#30089"
 msgid "Search for"
@@ -378,8 +386,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr "Основной адрес сервера"
@@ -427,6 +434,14 @@ msgstr "Отладочный лог"
 msgctxt "#30511"
 msgid "Auto"
 msgstr "Авто"
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
 
 msgctxt "#30514"
 msgid "Debug level"
@@ -486,7 +501,7 @@ msgstr "Необходима авторизация?"
 
 msgctxt "#30528"
 msgid "Load External Subtitles?"
-msgstr "Номер порта"
+msgstr "Загрузить внешние субтитры?"
 
 msgctxt "#30529"
 msgid "Always display subtitles?"
@@ -565,7 +580,6 @@ msgid "Use WOL?"
 msgstr "Использовать WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr "Отключить метаданные жанр/режиссер/сценарист"
@@ -585,6 +599,10 @@ msgstr "Отключить Контекстные меню"
 msgctxt "#30553"
 msgid "Off"
 msgstr "Выкл"
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
@@ -613,6 +631,10 @@ msgstr "Переопределить расположение SMB"
 msgctxt "#30562"
 msgid "NAS IP Address"
 msgstr "NAS IP Адрес"
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
 
 msgctxt "#30564"
 msgid "NAS Username"
@@ -647,8 +669,8 @@ msgid "Current Master Server"
 msgstr "Текущий Мастер Сервер"
 
 msgctxt "#30572"
-msgid "Shelf Items"
-msgstr "Элементы на полке"
+msgid "Current Master Server"
+msgstr ""
 
 msgctxt "#30573"
 msgid "Recently Added"
@@ -713,6 +735,14 @@ msgstr "Связывать неизвестное содержимое как:"
 msgctxt "#30588"
 msgid "RA Library filter"
 msgstr "RA-Фильтр библиотеки"
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
 
 msgctxt "#30591"
 msgid "Adults"
@@ -879,15 +909,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1543,3 +1570,15 @@ msgstr ""
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
 msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""
+
+#~ msgctxt "#30572"
+#~ msgid "Shelf Items"
+#~ msgstr "Элементы на полке"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.scn/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.scn/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: scn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.si_lk/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.si_lk/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: si_lk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sk_sk/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sk_sk/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sl_si/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sl_si/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sl_si\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sq_al/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sq_al/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sq_al\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sr_rs/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sr_rs/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr_rs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sr_rs@latin/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sr_Latn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.sv_se/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.sv_se/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv_se\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.szl/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.szl/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: szl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.ta_in/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.ta_in/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ta_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.te_in/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.te_in/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: te_in\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.tg_tj/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.tg_tj/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tg_tj\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.th_th/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.th_th/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: th_th\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.tr_tr/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.tr_tr/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr_tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.uk_ua/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.uk_ua/strings.po
@@ -10,11 +10,19 @@ msgstr ""
 "PO-Revision-Date: 2020-01-18 21:15+0500\n"
 "Last-Translator: Dukobpa3\n"
 "Language-Team: Ukrainian\n"
+"Language: uk_UA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: uk_UA\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr "Головна адреса сервера"
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr "Використовувати WOL?"
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr "Вимкнути Метадані жанр/режисер/сценарист"
@@ -663,8 +668,8 @@ msgid "Current Master Server"
 msgstr "Поточний Майстер Сервер"
 
 msgctxt "#30572"
-msgid "Shelf Items"
-msgstr "Елементи на полиці"
+msgid "Current Master Server"
+msgstr ""
 
 msgctxt "#30573"
 msgid "Recently Added"
@@ -729,6 +734,18 @@ msgstr "Відмічати невідомий контент як"
 msgctxt "#30588"
 msgid "RA Library filter"
 msgstr "RA-Фільтр бібліотеки"
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
 
 msgctxt "#30592"
 msgid "Use menu for shared sections"
@@ -891,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1555,3 +1569,15 @@ msgstr ""
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
 msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""
+
+#~ msgctxt "#30572"
+#~ msgid "Shelf Items"
+#~ msgstr "Елементи на полиці"

--- a/plugin.video.composite_for_plex/resources/language/resource.language.uz_uz/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.uz_uz/strings.po
@@ -1,0 +1,1579 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: https://github.com/anxdpanic/plugin.video.composite_for_plex/issues\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2020-01-18 21:15+0500\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uz_uz\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr ""
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr ""
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr ""
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.vi_vn/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.vi_vn/strings.po
@@ -1,0 +1,1580 @@
+# Kodi language file
+# Addon Name: Composite
+# Addon id: plugin.video.composite_for_plex
+# Addon Provider: anxdpanic
+msgid ""
+msgstr ""
+"Project-Id-Version: Composite\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"POT-Creation-Date: 2014-10-26 17:05+0000\n"
+"PO-Revision-Date: 2021-08-25 05:29+0000\n"
+"Last-Translator: Nguyễn Trung Hậu <trunghau1712@gmail.com>\n"
+"Language-Team: Vietnamese <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/vi_vn/>\n"
+"Language: vi_vn\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.8\n"
+
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr "Duyệt và phát các tập tin đa phương tiện video, nhạc và ảnh do Plex Media Server quản lý.[CR][CR]Fork of PleXBMC by Hippojay"
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr "Composite KHÔNG phải là một tiện ích chính thức của Plex và không được Plex hỗ trợ hoặc xác nhận."
+
+msgctxt "#30000"
+msgid "Confirm file delete?"
+msgstr "Xác nhận xóa tập tin?"
+
+msgctxt "#30001"
+msgid "Delete this item? This action will delete media and associated data files."
+msgstr "Xóa mục này? Hành động này sẽ xóa đa phương tiện và các tập tin dữ liệu được liên kết."
+
+msgctxt "#30002"
+msgid "Plex Online"
+msgstr "Plex trực tuyến"
+
+msgctxt "#30003"
+msgid "About to install"
+msgstr ""
+
+msgctxt "#30004"
+msgid "This plugin is already installed"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Switch Failed"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Sign Out"
+msgstr "Đăng xuất"
+
+msgctxt "#30007"
+msgid "To sign out you must be logged in as an admin user. Switch user and try again"
+msgstr "Để đăng xuất, bạn phải đăng nhập với tư cách là người dùng quản trị. Chuyển đổi người dùng và thử lại"
+
+msgctxt "#30008"
+msgid "myPlex"
+msgstr "myPlex"
+
+msgctxt "#30009"
+msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
+msgstr ""
+
+#  30010
+msgctxt "#30011"
+msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
+msgstr ""
+
+msgctxt "#30012"
+msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
+msgstr ""
+
+msgctxt "#30013"
+msgid "All"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Recently Aired"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Recently Viewed Episodes"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Recently Viewed Shows"
+msgstr ""
+
+msgctxt "#30019"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30020"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30021"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30022"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30023"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30024"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30025"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Search Shows..."
+msgstr ""
+
+msgctxt "#30027"
+msgid "Search Episodes..."
+msgstr ""
+
+msgctxt "#30028"
+msgid "All"
+msgstr ""
+
+msgctxt "#30029"
+msgid "By Album"
+msgstr ""
+
+msgctxt "#30030"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30031"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30032"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30034"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Search Artists..."
+msgstr ""
+
+msgctxt "#30036"
+msgid "Search Albums..."
+msgstr ""
+
+msgctxt "#30037"
+msgid "Search Tracks..."
+msgstr ""
+
+msgctxt "#30038"
+msgid "All"
+msgstr ""
+
+msgctxt "#30039"
+msgid "Unwatched"
+msgstr ""
+
+msgctxt "#30040"
+msgid "Recently Released"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Recently Viewed"
+msgstr ""
+
+msgctxt "#30043"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30044"
+msgid "By Collection"
+msgstr ""
+
+msgctxt "#30045"
+msgid "By Genre"
+msgstr ""
+
+msgctxt "#30046"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30047"
+msgid "By Decade"
+msgstr ""
+
+msgctxt "#30048"
+msgid "By Director"
+msgstr ""
+
+msgctxt "#30049"
+msgid "By Starring Actor"
+msgstr ""
+
+msgctxt "#30050"
+msgid "By Country"
+msgstr ""
+
+msgctxt "#30051"
+msgid "By Content Rating"
+msgstr ""
+
+msgctxt "#30052"
+msgid "By Rating"
+msgstr ""
+
+msgctxt "#30053"
+msgid "By Resolution"
+msgstr ""
+
+msgctxt "#30054"
+msgid "By First Letter"
+msgstr ""
+
+msgctxt "#30055"
+msgid "By Folder"
+msgstr ""
+
+msgctxt "#30056"
+msgid "Search..."
+msgstr ""
+
+msgctxt "#30057"
+msgid "All"
+msgstr ""
+
+msgctxt "#30058"
+msgid "By Year"
+msgstr ""
+
+msgctxt "#30059"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Camera Make"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Camera Model"
+msgstr ""
+
+msgctxt "#30062"
+msgid "Aperture"
+msgstr ""
+
+msgctxt "#30063"
+msgid "Shutter Speed"
+msgstr ""
+
+msgctxt "#30064"
+msgid "ISO"
+msgstr ""
+
+msgctxt "#30065"
+msgid "Lens"
+msgstr ""
+
+msgctxt "#30066"
+msgid "Unable to see any media servers"
+msgstr ""
+
+msgctxt "#30067"
+msgid "Unable to contact server:"
+msgstr ""
+
+msgctxt "#30068"
+msgid "Library refresh started"
+msgstr ""
+
+msgctxt "#30069"
+msgid "myPlex not configured"
+msgstr ""
+
+msgctxt "#30070"
+msgid "Resume"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Select media to play"
+msgstr ""
+
+msgctxt "#30072"
+msgid "Select subtitle"
+msgstr ""
+
+msgctxt "#30073"
+msgid "Select audio"
+msgstr ""
+
+msgctxt "#30074"
+msgid "Select master server"
+msgstr ""
+
+msgctxt "#30075"
+msgid "Known server list"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Switch User"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Enter PIN"
+msgstr ""
+
+msgctxt "#30078"
+msgid "Resume from"
+msgstr ""
+
+msgctxt "#30079"
+msgid "Start from beginning"
+msgstr ""
+
+msgctxt "#30080"
+msgid "myPlex Queue"
+msgstr ""
+
+msgctxt "#30081"
+msgid "Sign In"
+msgstr ""
+
+msgctxt "#30082"
+msgid "Display Servers"
+msgstr ""
+
+msgctxt "#30083"
+msgid "Refresh Data"
+msgstr ""
+
+msgctxt "#30084"
+msgid "Channels"
+msgstr ""
+
+msgctxt "#30085"
+msgid "Playlists"
+msgstr ""
+
+msgctxt "#30086"
+msgid "Play Transcoded"
+msgstr ""
+
+msgctxt "#30087"
+msgid "All episodes"
+msgstr ""
+
+msgctxt "#30088"
+msgid "Season"
+msgstr ""
+
+msgctxt "#30089"
+msgid "Search for"
+msgstr ""
+
+msgctxt "#30090"
+msgid "Unplayed"
+msgstr ""
+
+# ##### SETTINGS
+msgctxt "#30500"
+msgid "Primary Server Address"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Stream from PMS"
+msgstr ""
+
+msgctxt "#30502"
+msgid "Get extended metadata from PMS"
+msgstr ""
+
+msgctxt "#30503"
+msgid "Enable extra filter menus"
+msgstr ""
+
+msgctxt "#30504"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30505"
+msgid "PMS Username: "
+msgstr ""
+
+msgctxt "#30506"
+msgid "PMS Password: "
+msgstr ""
+
+msgctxt "#30507"
+msgid "Always Transcode"
+msgstr ""
+
+msgctxt "#30508"
+msgid "Transcode format "
+msgstr ""
+
+msgctxt "#30509"
+msgid "Recent & OnDeck items"
+msgstr ""
+
+msgctxt "#30510"
+msgid "Debug log"
+msgstr ""
+
+msgctxt "#30511"
+msgid "Auto"
+msgstr ""
+
+msgctxt "#30512"
+msgid "http"
+msgstr ""
+
+msgctxt "#30513"
+msgid "smb"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Debug level"
+msgstr ""
+
+msgctxt "#30515"
+msgid "Use transcoding proxy"
+msgstr ""
+
+msgctxt "#30516"
+msgid "Server"
+msgstr ""
+
+msgctxt "#30517"
+msgid "Playback"
+msgstr ""
+
+msgctxt "#30518"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30519"
+msgid "Wake On LAN"
+msgstr ""
+
+msgctxt "#30520"
+msgid "Look and Feel"
+msgstr ""
+
+msgctxt "#30521"
+msgid "Skin Home Shelf"
+msgstr ""
+
+msgctxt "#30522"
+msgid "Advanced"
+msgstr ""
+
+msgctxt "#30523"
+msgid "Use Wake On LAN"
+msgstr ""
+
+msgctxt "#30524"
+msgid "myPlex user"
+msgstr ""
+
+msgctxt "#30525"
+msgid "myPlex password"
+msgstr ""
+
+msgctxt "#30526"
+msgid "Select master server..."
+msgstr ""
+
+msgctxt "#30527"
+msgid "Authentication required?"
+msgstr ""
+
+msgctxt "#30528"
+msgid "Load External Subtitles?"
+msgstr ""
+
+msgctxt "#30529"
+msgid "Always display subtitles?"
+msgstr ""
+
+msgctxt "#30530"
+msgid "Port Number"
+msgstr ""
+
+msgctxt "#30531"
+msgid "Use PMS localisation settings"
+msgstr ""
+
+msgctxt "#30532"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30533"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30534"
+msgid "Audio stream selection"
+msgstr ""
+
+msgctxt "#30535"
+msgid "Subtitle stream selection"
+msgstr ""
+
+msgctxt "#30536"
+msgid "Kodi Control"
+msgstr ""
+
+msgctxt "#30537"
+msgid "External"
+msgstr ""
+
+msgctxt "#30538"
+msgid "Audio and subtitle selector"
+msgstr ""
+
+msgctxt "#30539"
+msgid "Never show subtitles"
+msgstr ""
+
+msgctxt "#30540"
+msgid "Quality"
+msgstr ""
+
+msgctxt "#30541"
+msgid "Proxy Port"
+msgstr ""
+
+msgctxt "#30542"
+msgid "Plex Channel View"
+msgstr ""
+
+msgctxt "#30543"
+msgid "Flatten TV Shows"
+msgstr ""
+
+msgctxt "#30544"
+msgid "Server MAC address"
+msgstr ""
+
+msgctxt "#30545"
+msgid "Plex Style Watched flags"
+msgstr ""
+
+msgctxt "#30546"
+msgid "Windows Media Server?"
+msgstr ""
+
+msgctxt "#30547"
+msgid "Use WOL?"
+msgstr ""
+
+# 30548
+msgctxt "#30549"
+msgid "Skip Genre/director/writer"
+msgstr ""
+
+msgctxt "#30550"
+msgid "Skip images (thumbs, fanart)"
+msgstr ""
+
+msgctxt "#30551"
+msgid "Skip Media Flags"
+msgstr ""
+
+msgctxt "#30552"
+msgid "Skip Context Menus"
+msgstr ""
+
+msgctxt "#30553"
+msgid "Off"
+msgstr ""
+
+msgctxt "#30554"
+msgid "Bonjour"
+msgstr ""
+
+msgctxt "#30556"
+msgid "Play TV Theme Music"
+msgstr ""
+
+msgctxt "#30557"
+msgid "Select audio output"
+msgstr ""
+
+msgctxt "#30558"
+msgid "If only one season"
+msgstr ""
+
+msgctxt "#30559"
+msgid "All seasons"
+msgstr ""
+
+msgctxt "#30560"
+msgid "Force DVD playback"
+msgstr ""
+
+msgctxt "#30561"
+msgid "Override SMB location"
+msgstr ""
+
+msgctxt "#30562"
+msgid "NAS IP Address"
+msgstr ""
+
+msgctxt "#30563"
+msgid "AFP"
+msgstr ""
+
+msgctxt "#30564"
+msgid "NAS Username"
+msgstr ""
+
+msgctxt "#30565"
+msgid "NAS password"
+msgstr ""
+
+msgctxt "#30566"
+msgid "NAS Root Folder"
+msgstr ""
+
+msgctxt "#30567"
+msgid "Plex Control"
+msgstr ""
+
+msgctxt "#30568"
+msgid "Subtitle Size"
+msgstr ""
+
+msgctxt "#30569"
+msgid "Audio Boost"
+msgstr ""
+
+msgctxt "#30570"
+msgid "Auto (GDM)"
+msgstr ""
+
+msgctxt "#30571"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30572"
+msgid "Current Master Server"
+msgstr ""
+
+msgctxt "#30573"
+msgid "Recently Added"
+msgstr ""
+
+msgctxt "#30574"
+msgid "On Deck"
+msgstr ""
+
+msgctxt "#30575"
+msgid "Force Skin Views"
+msgstr ""
+
+msgctxt "#30576"
+msgid "Skin Name"
+msgstr ""
+
+msgctxt "#30577"
+msgid "Movie View"
+msgstr ""
+
+msgctxt "#30578"
+msgid "TV View"
+msgstr ""
+
+msgctxt "#30579"
+msgid "Season View"
+msgstr ""
+
+msgctxt "#30580"
+msgid "Episode View"
+msgstr ""
+
+msgctxt "#30581"
+msgid "Music View"
+msgstr ""
+
+msgctxt "#30582"
+msgid "Enable Movie Shelf"
+msgstr ""
+
+msgctxt "#30583"
+msgid "Enable TV Shelf"
+msgstr ""
+
+msgctxt "#30584"
+msgid "Enable Music Shelf"
+msgstr ""
+
+msgctxt "#30585"
+msgid "Enable Channel Shelf"
+msgstr ""
+
+msgctxt "#30586"
+msgid "Content filter"
+msgstr ""
+
+msgctxt "#30587"
+msgid "Map unknown content as:"
+msgstr ""
+
+msgctxt "#30588"
+msgid "RA Library filter"
+msgstr ""
+
+msgctxt "#30589"
+msgid "Kids"
+msgstr ""
+
+msgctxt "#30590"
+msgid "Teens"
+msgstr ""
+
+msgctxt "#30591"
+msgid "Adults"
+msgstr ""
+
+msgctxt "#30592"
+msgid "Use menu for shared sections"
+msgstr ""
+
+msgctxt "#30593"
+msgid "Cache Data"
+msgstr ""
+
+msgctxt "#30594"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30595"
+msgid "Use full resolution thumbs"
+msgstr ""
+
+msgctxt "#30596"
+msgid "Use full resolution fanart"
+msgstr ""
+
+msgctxt "#30597"
+msgid "Hide watched recently added items"
+msgstr ""
+
+msgctxt "#30598"
+msgid "Info"
+msgstr ""
+
+msgctxt "#30599"
+msgid "Debug"
+msgstr ""
+
+msgctxt "#30600"
+msgid "Debug+"
+msgstr ""
+
+msgctxt "#30601"
+msgid "Transcoder"
+msgstr ""
+
+msgctxt "#30602"
+msgid "Name"
+msgstr ""
+
+msgctxt "#30603"
+msgid "Disable 'All Episodes'"
+msgstr ""
+
+msgctxt "#30604"
+msgid "Enable Kodi view cache"
+msgstr ""
+
+msgctxt "#30605"
+msgid "Manage myPlex"
+msgstr ""
+
+msgctxt "#30606"
+msgid "Prefer Season artwork"
+msgstr ""
+
+msgctxt "#30607"
+msgid "Hide Unique Information in log"
+msgstr ""
+
+msgctxt "#30608"
+msgid "Use Kodi client name?"
+msgstr ""
+
+msgctxt "#30609"
+msgid "Switch off playback monitor"
+msgstr ""
+
+msgctxt "#30610"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#30611"
+msgid "Transcode > 1080p"
+msgstr ""
+
+msgctxt "#30612"
+msgid "Transcode HEVC"
+msgstr ""
+
+msgctxt "#30613"
+msgid "MAC Address"
+msgstr ""
+
+msgctxt "#30614"
+msgid "Universal"
+msgstr ""
+
+msgctxt "#30615"
+msgid "Legacy"
+msgstr ""
+
+msgctxt "#30616"
+msgid "Refresh library section"
+msgstr ""
+
+msgctxt "#30617"
+msgid "Username:"
+msgstr ""
+
+msgctxt "#30618"
+msgid "Password:"
+msgstr ""
+
+msgctxt "#30619"
+msgid "Cancel"
+msgstr ""
+
+msgctxt "#30620"
+msgid "Submit"
+msgstr ""
+
+msgctxt "#30621"
+msgid "Manual"
+msgstr ""
+
+msgctxt "#30622"
+msgid "Use PIN"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Done"
+msgstr ""
+
+msgctxt "#30624"
+msgid "Unable to sign in"
+msgstr ""
+
+msgctxt "#30625"
+msgid "From your computer, go to %s and enter the code below"
+msgstr ""
+
+msgctxt "#30626"
+msgid "Successfully signed in"
+msgstr ""
+
+msgctxt "#30627"
+msgid "Sign in not successful"
+msgstr ""
+
+msgctxt "#30628"
+msgid "Email:"
+msgstr ""
+
+msgctxt "#30629"
+msgid "Plex Pass:"
+msgstr ""
+
+msgctxt "#30630"
+msgid "Joined:"
+msgstr ""
+
+msgctxt "#30631"
+msgid "Exit"
+msgstr ""
+
+#  30632
+#  30633
+msgctxt "#30634"
+msgid "Enter your myPlex details below"
+msgstr ""
+
+#  30635
+msgctxt "#30636"
+msgid "Unknown"
+msgstr ""
+
+msgctxt "#30637"
+msgid "myPlex Login"
+msgstr ""
+
+msgctxt "#30638"
+msgid "Enter search term"
+msgstr ""
+
+msgctxt "#30639"
+msgid "Enter value"
+msgstr ""
+
+msgctxt "#30640"
+msgid "Transcode Profile"
+msgstr ""
+
+msgctxt "#30641"
+msgid "Transcode Profiles"
+msgstr ""
+
+msgctxt "#30642"
+msgid "Offline"
+msgstr ""
+
+msgctxt "#30643"
+msgid "Remote"
+msgstr ""
+
+msgctxt "#30644"
+msgid "Nearby"
+msgstr ""
+
+msgctxt "#30645"
+msgid "SSL"
+msgstr ""
+
+msgctxt "#30646"
+msgid "Not Secure"
+msgstr ""
+
+msgctxt "#30647"
+msgid "Certificate Verification"
+msgstr ""
+
+msgctxt "#30648"
+msgid "Message"
+msgstr ""
+
+msgctxt "#30649"
+msgid "blank"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Server Discovery"
+msgstr ""
+
+msgctxt "#30651"
+msgid "Please wait..."
+msgstr ""
+
+msgctxt "#30652"
+msgid "myPlex discovery..."
+msgstr ""
+
+msgctxt "#30653"
+msgid "GDM discovery..."
+msgstr ""
+
+msgctxt "#30654"
+msgid "User provided..."
+msgstr ""
+
+msgctxt "#30655"
+msgid "Caching results..."
+msgstr ""
+
+msgctxt "#30656"
+msgid "Finished"
+msgstr ""
+
+msgctxt "#30657"
+msgid "Found servers:"
+msgstr ""
+
+msgctxt "#30658"
+msgid "No servers found"
+msgstr ""
+
+msgctxt "#30659"
+msgid "Transcode > 8-bit"
+msgstr ""
+
+msgctxt "#30660"
+msgid "Device Name"
+msgstr ""
+
+msgctxt "#30661"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30662"
+msgid "Server Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30663"
+msgid "Server detection notification"
+msgstr ""
+
+msgctxt "#30664"
+msgid "installed"
+msgstr ""
+
+msgctxt "#30665"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#30666"
+msgid "Music"
+msgstr ""
+
+msgctxt "#30667"
+msgid "TV Shows"
+msgstr ""
+
+msgctxt "#30668"
+msgid "Photos"
+msgstr ""
+
+msgctxt "#30669"
+msgid "Server name prefix on the main menu"
+msgstr ""
+
+msgctxt "#30670"
+msgid "Always"
+msgstr ""
+
+msgctxt "#30671"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30672"
+msgid "Go to %s"
+msgstr ""
+
+msgctxt "#30673"
+msgid "Delete %s from the %s playlist?"
+msgstr ""
+
+msgctxt "#30674"
+msgid "Confirm playlist item delete?"
+msgstr ""
+
+msgctxt "#30675"
+msgid "Delete from playlist"
+msgstr ""
+
+msgctxt "#30676"
+msgid "Select playlist"
+msgstr ""
+
+msgctxt "#30677"
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt "#30678"
+msgid "Added %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30679"
+msgid "Failed to add %s to the %s playlist"
+msgstr ""
+
+msgctxt "#30680"
+msgid "%s is already in the %s playlist"
+msgstr ""
+
+msgctxt "#30681"
+msgid "%s has been removed the %s playlist"
+msgstr ""
+
+msgctxt "#30682"
+msgid "Unable to remove %s from the %s playlist"
+msgstr ""
+
+msgctxt "#30683"
+msgid "Show the 'Delete' context menu"
+msgstr ""
+
+msgctxt "#30684"
+msgid "Up Next"
+msgstr ""
+
+msgctxt "#30685"
+msgid "Enable Up Next"
+msgstr ""
+
+msgctxt "#30686"
+msgid "Open Up Next settings"
+msgstr ""
+
+msgctxt "#30687"
+msgid "Install Up Next"
+msgstr ""
+
+msgctxt "#30688"
+msgid "Up Next is enabled in the settings, however Up Next appears to be disabled. Would you like to enable Up Next now?"
+msgstr ""
+
+msgctxt "#30689"
+msgid "Up Next requires Kodi 18 or higher"
+msgstr ""
+
+msgctxt "#30690"
+msgid "From your computer, go to [B]%s[/B] and enter the following code: [B]%s[/B]"
+msgstr ""
+
+msgctxt "#30691"
+msgid "Use episode thumbnails"
+msgstr ""
+
+msgctxt "#30692"
+msgid "Widgets"
+msgstr ""
+
+msgctxt "#30693"
+msgid "Show [B]Widgets[/B] menu"
+msgstr ""
+
+msgctxt "#30694"
+msgid "Clear Caches"
+msgstr ""
+
+msgctxt "#30695"
+msgid "Data Cache TTL (minutes)"
+msgstr ""
+
+msgctxt "#30696"
+msgid "Clear data cache on refresh"
+msgstr ""
+
+msgctxt "#30697"
+msgid "Movies on Deck"
+msgstr ""
+
+msgctxt "#30698"
+msgid "TV Shows on Deck"
+msgstr ""
+
+msgctxt "#30699"
+msgid "Recently Released Movies"
+msgstr ""
+
+msgctxt "#30700"
+msgid "Recently Aired TV Shows"
+msgstr ""
+
+msgctxt "#30701"
+msgid "Recently Added Movies"
+msgstr ""
+
+msgctxt "#30702"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+msgctxt "#30703"
+msgid "Data Cache"
+msgstr ""
+
+msgctxt "#30704"
+msgid "Companion receiver is unable to start due to a port conflict"
+msgstr ""
+
+msgctxt "#30705"
+msgid "Companion receiver has started"
+msgstr ""
+
+msgctxt "#30706"
+msgid "Companion receiver has been stopped"
+msgstr ""
+
+msgctxt "#30707"
+msgid "Companion Receiver"
+msgstr ""
+
+msgctxt "#30708"
+msgid "Enabled"
+msgstr ""
+
+msgctxt "#30709"
+msgid "Port"
+msgstr ""
+
+msgctxt "#30710"
+msgid "Kodi's Web Server Settings"
+msgstr ""
+
+msgctxt "#30711"
+msgid "[COLOR=red]EXPERIMENTAL[/COLOR] - This feature is experimental[CR]Any changes to these settings will require a restart to take effect"
+msgstr ""
+
+msgctxt "#30712"
+msgid "Username"
+msgstr ""
+
+msgctxt "#30713"
+msgid "Password"
+msgstr ""
+
+msgctxt "#30714"
+msgid "Main Menu"
+msgstr ""
+
+msgctxt "#30715"
+msgid "Show [B]myPlex Queue[/B] menu"
+msgstr ""
+
+msgctxt "#30716"
+msgid "Show [B]Channels[/B] menu"
+msgstr ""
+
+msgctxt "#30717"
+msgid "Show [B]Plex Online[/B] menu"
+msgstr ""
+
+msgctxt "#30718"
+msgid "Show [B]Playlists[/B] menu"
+msgstr ""
+
+msgctxt "#30719"
+msgid "Context Menu"
+msgstr ""
+
+msgctxt "#30720"
+msgid "Metadata"
+msgstr ""
+
+msgctxt "#30721"
+msgid "Transcoding"
+msgstr ""
+
+msgctxt "#30722"
+msgid "Create a playlist"
+msgstr ""
+
+msgctxt "#30723"
+msgid "Enter a playlist title"
+msgstr ""
+
+msgctxt "#30724"
+msgid "Delete playlist"
+msgstr ""
+
+msgctxt "#30725"
+msgid "Confirm playlist delete?"
+msgstr ""
+
+msgctxt "#30726"
+msgid "Are you sure you want to delete this playlist?"
+msgstr ""
+
+msgctxt "#30727"
+msgid "Notification encoding"
+msgstr ""
+
+msgctxt "#30728"
+msgid "Episode sort method"
+msgstr ""
+
+msgctxt "#30729"
+msgid "Plex"
+msgstr ""
+
+msgctxt "#30730"
+msgid "Kodi"
+msgstr ""
+
+msgctxt "#30731"
+msgid "Manage Servers"
+msgstr ""
+
+msgctxt "#30732"
+msgid "Set as Master"
+msgstr ""
+
+msgctxt "#30733"
+msgid "Connection Test Results"
+msgstr ""
+
+msgctxt "#30734"
+msgid "Default to forced subtitles"
+msgstr ""
+
+msgctxt "#30735"
+msgid "Mixed content type"
+msgstr ""
+
+msgctxt "#30736"
+msgid "Default"
+msgstr ""
+
+msgctxt "#30737"
+msgid "Majority"
+msgstr ""
+
+msgctxt "#30738"
+msgid "Add custom access url"
+msgstr ""
+
+msgctxt "#30739"
+msgid "Custom access urls"
+msgstr ""
+
+msgctxt "#30740"
+msgid "Edit"
+msgstr ""
+
+msgctxt "#30741"
+msgid "Edit custom access url"
+msgstr ""
+
+msgctxt "#30742"
+msgid "Custom"
+msgstr ""
+
+msgctxt "#30743"
+msgid "All Artists"
+msgstr ""
+
+msgctxt "#30744"
+msgid "All Photos"
+msgstr ""
+
+msgctxt "#30745"
+msgid "All Shows"
+msgstr ""
+
+msgctxt "#30746"
+msgid "All Movies"
+msgstr ""
+
+msgctxt "#30747"
+msgid "Preferred lyrics format"
+msgstr ""
+
+msgctxt "#30748"
+msgid "Lyrics"
+msgstr ""
+
+msgctxt "#30749"
+msgid "lrc"
+msgstr ""
+
+msgctxt "#30750"
+msgid "txt"
+msgstr ""
+
+msgctxt "#30751"
+msgid "Skip intro"
+msgstr ""
+
+msgctxt "#30752"
+msgid "Intro skipping"
+msgstr ""
+
+msgctxt "#30753"
+msgid "Plex Pass Required"
+msgstr ""
+
+msgctxt "#30754"
+msgid "Plex powered by LyricFind"
+msgstr ""
+
+msgctxt "#30755"
+msgid "Show skip intro dialog"
+msgstr ""
+
+msgctxt "#30756"
+msgid "All %s"
+msgstr ""
+
+msgctxt "#30757"
+msgid "All Servers: TV Shows On Deck"
+msgstr ""
+
+msgctxt "#30758"
+msgid "All Servers: Movies On Deck"
+msgstr ""
+
+msgctxt "#30759"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30760"
+msgid "All Servers: Recently Added Episodes"
+msgstr ""
+
+msgctxt "#30761"
+msgid "All Servers: Recently Added Movies"
+msgstr ""
+
+msgctxt "#30762"
+msgid "Server name prefix on combined sections"
+msgstr ""
+
+msgctxt "#30763"
+msgid "Recently Added item count (per server section)"
+msgstr ""
+
+msgctxt "#30764"
+msgid "Recently Added include watched"
+msgstr ""
+
+msgctxt "#30765"
+msgid "Composite Playlist"
+msgstr ""
+
+msgctxt "#30766"
+msgid "Generate a playlist from the information below"
+msgstr ""
+
+msgctxt "#30767"
+msgid "Mixed"
+msgstr ""
+
+msgctxt "#30768"
+msgid "Play"
+msgstr ""
+
+msgctxt "#30769"
+msgid "Item Count"
+msgstr ""
+
+msgctxt "#30770"
+msgid "All Servers"
+msgstr ""
+
+msgctxt "#30771"
+msgid "Shuffle"
+msgstr ""
+
+msgctxt "#30772"
+msgid "Source"
+msgstr ""
+
+msgctxt "#30773"
+msgid "None"
+msgstr ""
+
+msgctxt "#30774"
+msgid "Generating Playlist"
+msgstr ""
+
+msgctxt "#30775"
+msgid "This may take a while..."
+msgstr ""
+
+msgctxt "#30776"
+msgid "Retrieving server list..."
+msgstr ""
+
+msgctxt "#30777"
+msgid "Retrieving server sections..."
+msgstr ""
+
+msgctxt "#30778"
+msgid "Retrieving content metadata..."
+msgstr ""
+
+msgctxt "#30779"
+msgid "Retrieving final sample..."
+msgstr ""
+
+msgctxt "#30780"
+msgid "Adding items to playlist..."
+msgstr ""
+
+msgctxt "#30781"
+msgid "Adding %s to playlist..."
+msgstr ""
+
+msgctxt "#30782"
+msgid "Completed."
+msgstr ""
+
+msgctxt "#30783"
+msgid "Checking section %s on %s..."
+msgstr ""
+
+msgctxt "#30784"
+msgid "Retrieving %s from %s for sample..."
+msgstr ""
+
+msgctxt "#30785"
+msgid "Retrieving %s episodes for sample..."
+msgstr ""
+
+msgctxt "#30786"
+msgid "Creating samples..."
+msgstr ""
+
+msgctxt "#30787"
+msgid "Retrieving metadata for %s..."
+msgstr ""
+
+msgctxt "#30788"
+msgid "Show [B]Composite Playlist[/B] menu"
+msgstr ""
+
+msgctxt "#30789"
+msgid "Server(s)"
+msgstr ""
+
+msgctxt "#30790"
+msgid "Combined Sections"
+msgstr ""
+
+msgctxt "#30791"
+msgid "Search Movies..."
+msgstr ""
+
+msgctxt "#30792"
+msgid "Mark as watched"
+msgstr ""
+
+msgctxt "#30793"
+msgid "Mark as unwatched"
+msgstr ""
+
+msgctxt "#30794"
+msgid "Library - Movie Sections"
+msgstr ""
+
+msgctxt "#30795"
+msgid "Library - TV Show Sections"
+msgstr ""
+
+msgctxt "#30796"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30797"
+msgid "Select sections to include in library scans"
+msgstr ""
+
+msgctxt "#30798"
+msgid "Reset selected sections"
+msgstr ""
+
+msgctxt "#30799"
+msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
+msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.zh_cn/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.zh_cn/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/language/resource.language.zh_tw/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.zh_tw/strings.po
@@ -16,6 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 
+msgctxt "Addon Description"
+msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
+msgstr ""
+
+msgctxt "Addon Disclaimer"
+msgid "Composite is NOT an official Plex add-on and is not supported or endorsed by Plex."
+msgstr ""
+
 msgctxt "#30000"
 msgid "Confirm file delete?"
 msgstr ""
@@ -57,7 +65,6 @@ msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
 msgstr ""
 
 #  30010
-
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
 msgstr ""
@@ -378,8 +385,7 @@ msgctxt "#30090"
 msgid "Unplayed"
 msgstr ""
 
-###### SETTINGS
-
+# ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
 msgstr ""
@@ -573,7 +579,6 @@ msgid "Use WOL?"
 msgstr ""
 
 # 30548
-
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
 msgstr ""
@@ -903,15 +908,12 @@ msgid "Exit"
 msgstr ""
 
 #  30632
-
 #  30633
-
 msgctxt "#30634"
 msgid "Enter your myPlex details below"
 msgstr ""
 
 #  30635
-
 msgctxt "#30636"
 msgid "Unknown"
 msgstr ""
@@ -1566,4 +1568,12 @@ msgstr ""
 
 msgctxt "#30799"
 msgid "Configured library sections have been reset"
+msgstr ""
+
+msgctxt "#30800"
+msgid "Continue Watching"
+msgstr ""
+
+msgctxt "#30801"
+msgid "Detect Servers"
 msgstr ""

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/cache_control.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/cache_control.py
@@ -19,14 +19,13 @@ import os
 import shutil
 import time
 
+# don't use kodi_six xbmcvfs
+import xbmcvfs  # pylint: disable=import-error
+from kodi_six import xbmc  # pylint: disable=import-error
 from six import PY3
 from six import text_type
 # noinspection PyPep8Naming
 from six.moves import cPickle as pickle
-
-# don't use kodi_six xbmcvfs
-import xbmcvfs  # pylint: disable=import-error
-from kodi_six import xbmc  # pylint: disable=import-error
 
 from .constants import CONFIG
 from .logger import Logger

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/common.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/common.py
@@ -13,11 +13,10 @@
 import socket
 import sys
 
+from kodi_six import xbmc  # pylint: disable=import-error
 from six.moves import xrange
 from six.moves.urllib_parse import unquote
 from six.moves.urllib_parse import urlencode
-
-from kodi_six import xbmc  # pylint: disable=import-error
 
 from .constants import COMMANDS
 from .constants import CONFIG

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/constants.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/constants.py
@@ -52,6 +52,7 @@ COMMANDS = __enum(
     COMPOSITE_PLAYLIST='composite_playlist',
     SELECT_LIBRARY_SECTIONS='select_library_sections',
     RESET_LIBRARY_SECTIONS='reset_library_sections',
+    DETECTSERVERS='detect_servers',
 )
 
 MODES = __enum(

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/dialogs/composite_playlist.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/dialogs/composite_playlist.py
@@ -15,11 +15,11 @@ import random
 from itertools import chain
 from itertools import groupby
 
-from six.moves import zip_longest
-
 import pyxbmct.addonwindow as pyxbmct  # pylint: disable=import-error
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six import PY3
+from six.moves import zip_longest
 
 from ...addon.constants import CONFIG
 from ...addon.containers import Item
@@ -429,7 +429,11 @@ class PlaylistGenerator:
         return server_sections
 
     def _get_item_collection(self, server, tree):
-        branches = tree.getiterator('Video')
+        if PY3:
+            branches = tree.iter('Video')
+        else:
+            branches = tree.getiterator('Video')
+
         if branches is None:
             return []
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/json_store.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/json_store.py
@@ -48,20 +48,20 @@ class JSONStore:
                     LOG.debug('JSONStore Save |{filename}| failed to create directories.'
                               .format(filename=self.filename.encode('utf-8')))
                     return
-            with open(self.filename, 'w') as jsonfile:
+            with open(self.filename, 'w') as jsonfile:  # pylint: disable=unspecified-encoding
                 LOG.debug('JSONStore Save |{filename}|'
                           .format(filename=self.filename.encode('utf-8')))
                 json.dump(self._data, jsonfile, indent=4, sort_keys=True)
 
     def load(self):
         if xbmcvfs.exists(self.filename):
-            with open(self.filename, 'r') as jsonfile:
+            with open(self.filename, 'r') as jsonfile:  # pylint: disable=unspecified-encoding
                 data = json.load(jsonfile)
                 self._data = data
                 LOG.debug('JSONStore Load |{filename}|'
                           .format(filename=self.filename.encode('utf-8')))
         else:
-            self._data = dict()
+            self._data = {}
 
     def get_data(self):
         return deepcopy(self._data)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/logger.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/logger.py
@@ -14,10 +14,9 @@ import inspect
 import re
 import traceback
 
+from kodi_six import xbmc  # pylint: disable=import-error
 from six import PY2
 from six import string_types
-
-from kodi_six import xbmc  # pylint: disable=import-error
 
 from .constants import CONFIG
 from .settings import AddonSettings

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/playback.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/playback.py
@@ -10,13 +10,13 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
-from six.moves import xrange
-from six.moves.urllib_parse import unquote
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
 from kodi_six import xbmcvfs  # pylint: disable=import-error
+from six import PY3
+from six.moves import xrange
+from six.moves.urllib_parse import unquote
 
 from .common import get_handle
 from .common import is_resuming_video
@@ -537,7 +537,10 @@ class StreamData:
         self.data['audio_count'] = 0
         self.data['sub_count'] = 0
 
-        tags = self.tree.getiterator('Stream')
+        if PY3:
+            tags = self.tree.iter('Stream')
+        else:
+            tags = self.tree.getiterator('Stream')
 
         forced_subtitle = False
         for bits in tags:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/albums.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/albums.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -36,7 +37,11 @@ def process_albums(context, url, tree=None):
 
     items = []
     append_item = items.append
-    albums = tree.getiterator('Directory')
+    if PY3:
+        albums = tree.iter('Directory')
+    else:
+        albums = tree.getiterator('Directory')
+
     for album in albums:
         item = Item(server, url, tree, album)
         append_item(create_album_item(context, item))

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/artists.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/artists.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -40,7 +41,11 @@ def process_artists(context, url, tree=None):
 
     items = []
     append_item = items.append
-    artists = tree.getiterator('Directory')
+    if PY3:
+        artists = tree.iter('Directory')
+    else:
+        artists = tree.getiterator('Directory')
+
     for artist in artists:
         item = Item(server, url, tree, artist)
         append_item(create_artist_item(context, item))

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/directories.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/directories.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -33,7 +34,11 @@ def process_directories(context, url, tree=None):
 
     items = []
     append_item = items.append
-    directories = tree.getiterator('Directory')
+    if PY3:
+        directories = tree.iter('Directory')
+    else:
+        directories = tree.getiterator('Directory')
+
     for directory in directories:
         item = Item(server, url, tree, directory)
         append_item(create_directory_item(context, item))

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/episodes.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/episodes.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -52,7 +53,11 @@ def process_episodes(context, url, tree=None, rating_key=None, library=False):
 
     items = []
     append_item = items.append
-    episodes = tree.getiterator('Video')
+    if PY3:
+        episodes = tree.iter('Video')
+    else:
+        episodes = tree.getiterator('Video')
+
     for episode in episodes:
         item = Item(server, url, tree, episode)
         append_item(create_episode_item(context, item, library=library))

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/movies.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/movies.py
@@ -13,6 +13,7 @@
 import time
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -42,7 +43,11 @@ def process_movies(context, url, tree=None):
     start_time = time.time()
     items = []
     append_item = items.append
-    branches = tree.getiterator()
+    if PY3:
+        branches = tree.iter()
+    else:
+        branches = tree.getiterator()
+
     for branch in branches:
         item = Item(server, url, tree, branch)
         if branch.tag.lower() == 'video':

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/music.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/music.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -27,7 +28,11 @@ def process_music(context, url, tree=None):
 
     items = []
     append_item = items.append
-    branches = tree.getiterator()
+    if PY3:
+        branches = tree.iter()
+    else:
+        branches = tree.getiterator()
+
     for music in branches:
 
         if music.get('key') is None:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/photos.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/photos.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -36,7 +37,11 @@ def process_photos(context, url, tree=None):
     items = []
     append_item = items.append
 
-    branches = tree.getiterator()
+    if PY3:
+        branches = tree.iter()
+    else:
+        branches = tree.getiterator()
+
     for branch in branches:
         item = Item(server, url, tree, branch)
         tag = branch.tag.lower()

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/plex_online.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/plex_online.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -29,7 +30,11 @@ def process_plex_online(context, url):
 
     items = []
     append_item = items.append
-    plugins = tree.getiterator()
+    if PY3:
+        plugins = tree.iter()
+    else:
+        plugins = tree.getiterator()
+
     for plugin in plugins:
         item = Item(server, url, tree, plugin)
         item = create_plex_online_item(context, item)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/plex_plugins.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/plex_plugins.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -43,7 +44,11 @@ def process_plex_plugins(context, url, tree=None):
 
     items = []
     append_item = items.append
-    plugins = tree.getiterator()
+    if PY3:
+        plugins = tree.iter()
+    else:
+        plugins = tree.getiterator()
+
     for plugin in plugins:
         item = Item(server, tree, url, plugin)
         item = create_plex_plugin_item(context, item)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/seasons.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/seasons.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -49,7 +50,11 @@ def process_seasons(context, url, rating_key=None, library=False):
     items = []
     append_item = items.append
     # For all the directory tags
-    seasons = tree.getiterator('Directory')
+    if PY3:
+        seasons = tree.iter('Directory')
+    else:
+        seasons = tree.getiterator('Directory')
+
     for season in seasons:
 
         if will_flatten:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/shows.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/shows.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -38,7 +39,11 @@ def process_shows(context, url, tree=None):
     items = []
     append_item = items.append
     # For each directory tag we find
-    shows = tree.getiterator('Directory')
+    if PY3:
+        shows = tree.iter('Directory')
+    else:
+        shows = tree.getiterator('Directory')
+
     for show in shows:
         item = Item(server, url, tree, show)
         append_item(create_show_item(context, item))

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/tracks.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/processing/tracks.py
@@ -12,6 +12,7 @@
 
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..common import get_handle
 from ..containers import Item
@@ -44,7 +45,11 @@ def process_tracks(context, url, tree=None):
     }
     items = []
     append_item = items.append
-    branches = tree.getiterator()
+    if PY3:
+        branches = tree.iter()
+    else:
+        branches = tree.getiterator()
+
     for branch in branches:
         tag = branch.tag.lower()
         item = Item(server, url, tree, branch)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/settings.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/settings.py
@@ -13,12 +13,11 @@
 import json
 import uuid
 
-from six.moves import xrange
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcaddon  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
 from kodi_six import xbmcvfs  # pylint: disable=import-error
+from six.moves import xrange
 
 from .constants import CONFIG
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/strings.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/strings.py
@@ -9,9 +9,8 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
-from six import PY3
-
 from kodi_six import xbmc  # pylint: disable=import-error
+from six import PY3
 
 from .constants import CONFIG
 from .logger import Logger
@@ -219,6 +218,8 @@ STRINGS = {
     'Library - Movie Sections': 30794,
     'Library - TV Show Sections': 30795,
     'Configured library sections have been reset': 30799,
+    'Continue Watching': 30800,
+    'Detect Servers': 30801,
 }
 
 
@@ -273,6 +274,7 @@ def directory_item_translate(title, thumb):
             'By Folder': 'By Folder',
             'Search Shows...': 'Search Shows...',
             'Search Episodes...': 'Search Episodes...',
+            'Continue Watching': 'Continue Watching',
         }
 
     elif thumb.endswith('artist.png'):
@@ -311,6 +313,7 @@ def directory_item_translate(title, thumb):
             'By First Letter': 'By First Letter',
             'By Folder': 'By Folder',
             'Search...': 'Search...',
+            'Continue Watching': 'Continue Watching',
         }
         if thumb.endswith('video.png') and title.startswith('All '):
             return i18n('All_') % title.replace('All ', '')

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/utils.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/utils.py
@@ -14,12 +14,11 @@ import json
 import os
 import time
 
+from kodi_six import xbmc  # pylint: disable=import-error
+from kodi_six import xbmcgui  # pylint: disable=import-error
 from six import PY3
 from six.moves import cPickle as pickle
 from six.moves import xrange
-
-from kodi_six import xbmc  # pylint: disable=import-error
-from kodi_six import xbmcgui  # pylint: disable=import-error
 
 from ..addon.constants import CONFIG
 from ..addon.logger import Logger

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/listener.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/listener.py
@@ -14,13 +14,12 @@
 import re
 import traceback
 
+from kodi_six import xbmc  # pylint: disable=import-error
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 from six.moves.BaseHTTPServer import HTTPServer
 from six.moves.socketserver import ThreadingMixIn
 from six.moves.urllib_parse import parse_qs
 from six.moves.urllib_parse import urlparse
-
-from kodi_six import xbmc  # pylint: disable=import-error
 
 from ..addon.common import get_platform
 from ..addon.constants import CONFIG
@@ -107,8 +106,8 @@ class PlexCompanionHandler(BaseHTTPRequestHandler):
 
             param_arrays = parse_qs(url.query)
             params = {}
-            for key in param_arrays:
-                params[key] = param_arrays[key][0]
+            for key, value in param_arrays.items():
+                params[key] = value[0]
 
             LOG.debug('request path is: [%s]' % (request_path,))
             LOG.debug('params are: %s' % params)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/subscribers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/subscribers.py
@@ -12,7 +12,6 @@
 """
 
 import re
-import threading
 
 from kodi_six import xbmcgui  # pylint: disable=import-error
 
@@ -145,11 +144,11 @@ class SubscriptionManager:  # pylint: disable=too-many-instance-attributes,
         # will need the info anyway
         msg = self.msg(players)
         if self.subscribers:
-            with threading.RLock():
-                is_nav = len(players) == 0
-                subs = self.subscribers.values()
-                for sub in subs:
-                    sub.send_update(msg, is_nav)
+            is_nav = len(players) == 0
+            subs = self.subscribers.values()
+            for sub in subs:
+                sub.send_update(msg, is_nav)
+
         self.notify_server(players)
 
         return True
@@ -196,25 +195,22 @@ class SubscriptionManager:  # pylint: disable=too-many-instance-attributes,
 
     def add_subscriber(self, data):
         sub = Subscriber(data, self.request_manager, self)
-        with threading.RLock():
-            self.subscribers[sub.uuid] = sub
+        self.subscribers[sub.uuid] = sub
         return sub
 
     def remove_subscriber(self, uuid):
-        with threading.RLock():
-            subs = self.subscribers.values()
-            for sub in subs:
-                if uuid in [sub.uuid, sub.host]:
-                    sub.cleanup()
-                    del self.subscribers[sub.uuid]
+        subs = self.subscribers.values()
+        for sub in subs:
+            if uuid in [sub.uuid, sub.host]:
+                sub.cleanup()
+                del self.subscribers[sub.uuid]
 
     def cleanup(self):
-        with threading.RLock():
-            subs = self.subscribers.values()
-            for sub in subs:
-                if sub.age > 30:
-                    sub.cleanup()
-                    del self.subscribers[sub.uuid]
+        subs = self.subscribers.values()
+        for sub in subs:
+            if sub.age > 30:
+                sub.cleanup()
+                del self.subscribers[sub.uuid]
 
     def get_player_properties(self, player_id):
         info = {}

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/utils.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/utils.py
@@ -14,9 +14,8 @@
 import base64
 import json
 
-from six import PY3
-
 from kodi_six import xbmc  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_platform
 from ..addon.constants import CONFIG
@@ -131,7 +130,7 @@ def jsonrpc(action, arguments=None):
                 base64bytes = base64.encodebytes(credentials)
                 base64string = base64bytes.decode('utf-8').replace('\n', '')
             else:
-                base64string = base64.encodestring(credentials).replace('\n', '')  # pylint: disable=deprecated-method
+                base64string = base64.encodestring(credentials).replace('\n', '')  # pylint: disable=no-member
             headers = {
                 'Content-Type': 'application/json',
                 'Authorization': 'Basic ' + base64string,

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/composite.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/composite.py
@@ -93,6 +93,11 @@ def run(start_time):  # pylint: disable=too-many-locals, too-many-statements, to
         manage_servers.run(context)
         return _finished(start_time)
 
+    if command == COMMANDS.DETECTSERVERS:
+        from .routes import detect_servers
+        detect_servers.run(context)
+        return _finished(start_time)
+
     if command == COMMANDS.DELETEREFRESH:
         from .routes import delete_refresh
         delete_refresh.run(context)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_transcoded.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_transcoded.py
@@ -21,7 +21,7 @@ def strip_transcode(url):
 
 
 if __name__ == '__main__':
-    info_tag = sys.listitem.getVideoInfoTag()  # pylint: disable=no-member
+    info_tag = sys.listitem.getVideoInfoTag()
 
     try:
         plugin_url = info_tag.getFilenameAndPath()

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_unwatched.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_unwatched.py
@@ -13,9 +13,8 @@ import json
 import re
 import sys
 
-from six.moves.urllib_parse import parse_qs
-
 from kodi_six import xbmc  # pylint: disable=import-error
+from six.moves.urllib_parse import parse_qs
 
 try:
     KODI_VERSION = int(xbmc.getInfoLabel('System.BuildVersion').split()[0].split('.')[0])
@@ -90,7 +89,7 @@ def mark_tvshow_unwatched(tvshow_id):
 
 
 if __name__ == '__main__':
-    info_tag = sys.listitem.getVideoInfoTag()  # pylint: disable=no-member
+    info_tag = sys.listitem.getVideoInfoTag()
 
     try:
         plugin_url = info_tag.getFilenameAndPath()

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_watched.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/context_menu_watched.py
@@ -13,9 +13,8 @@ import json
 import re
 import sys
 
-from six.moves.urllib_parse import parse_qs
-
 from kodi_six import xbmc  # pylint: disable=import-error
+from six.moves.urllib_parse import parse_qs
 
 try:
     KODI_VERSION = int(xbmc.getInfoLabel('System.BuildVersion').split()[0].split('.')[0])
@@ -90,7 +89,7 @@ def mark_tvshow_watched(tvshow_id):
 
 
 if __name__ == '__main__':
-    info_tag = sys.listitem.getVideoInfoTag()  # pylint: disable=no-member
+    info_tag = sys.listitem.getVideoInfoTag()
 
     try:
         plugin_url = info_tag.getFilenameAndPath()

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/plex/plexgdm.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/plex/plexgdm.py
@@ -165,8 +165,9 @@ class PlexGDM:  # pylint: disable=too-many-instance-attributes
                 media_port = self.server_list[0]['port']
 
                 LOG.debug('Checking server [%s] on port [%s]' % (media_server, media_port))
-                file_handle = urlopen('http://%s:%s/clients' % (media_server, media_port))
-                client_result = file_handle.read()
+                with urlopen('http://%s:%s/clients' % (media_server, media_port)) as file_handle:
+                    client_result = file_handle.read()
+
                 if self.client_id in client_result:
                     LOG.debug('Client registration successful')
                     LOG.debug('Client data is: %s' % client_result)
@@ -310,7 +311,7 @@ class PlexGDM:  # pylint: disable=too-many-instance-attributes
             LOG.debug('Discovery starting up')
             self._discovery_is_running = True
             self.discover_t = threading.Thread(target=self.run_discovery_loop)
-            self.discover_t.setDaemon(daemon)
+            self.discover_t.daemon = daemon
             self.discover_t.start()
         else:
             LOG.debug('Discovery already running')
@@ -320,7 +321,7 @@ class PlexGDM:  # pylint: disable=too-many-instance-attributes
             LOG.debug('Registration starting up')
             self._registration_is_running = True
             self.register_t = threading.Thread(target=self.client_update)
-            self.register_t.setDaemon(daemon)
+            self.register_t.daemon = daemon
             self.register_t.start()
         else:
             LOG.debug('Registration already running')

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/add_playlist_item.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/add_playlist_item.py
@@ -12,6 +12,7 @@
 
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_argv
 from ..addon.constants import CONFIG
@@ -88,7 +89,12 @@ def playlist_user_select(server):
     get_formatted_url = server.get_formatted_url
     tree = server.get_playlists()
 
-    for playlist in tree.getiterator('Playlist'):
+    if PY3:
+        playlist_iter = tree.iter('Playlist')
+    else:
+        playlist_iter = tree.getiterator('Playlist')
+
+    for playlist in playlist_iter:
         image = ''
         if playlist.get('composite'):
             image = get_formatted_url(server.join_url(server.get_url_location(),

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/all_all_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/all_all_servers.py
@@ -10,6 +10,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.constants import MODES
@@ -127,7 +128,11 @@ def _list_content(context, server, section):
         return []
 
     iter_type = 'Video' if get_section_type(context) == 'movie' else 'Directory'
-    branches = tree.getiterator(iter_type)
+    if PY3:
+        branches = tree.iter(iter_type)
+    else:
+        branches = tree.getiterator(iter_type)
+
     if not branches:
         return []
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_search.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_search.py
@@ -10,10 +10,9 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
+from kodi_six import xbmc  # pylint: disable=import-error
 from six.moves.urllib_parse import quote
 from six.moves.urllib_parse import unquote
-
-from kodi_six import xbmc  # pylint: disable=import-error
 
 from ..addon.logger import Logger
 from ..addon.processing.plex_plugins import process_plex_plugins

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_settings.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_settings.py
@@ -10,10 +10,10 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
-from six.moves.urllib_parse import urlencode
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six import PY3
+from six.moves.urllib_parse import urlencode
 
 from ..addon.logger import Logger
 from ..addon.strings import i18n
@@ -46,7 +46,11 @@ def run(context, url, setting_id):
 
     set_url = '%s/set?' % url
     set_params = {}
-    plugins = tree.getiterator()
+    if PY3:
+        plugins = tree.iter()
+    else:
+        plugins = tree.getiterator()
+
     for plugin in plugins:
 
         if plugin.get('id') == setting_id:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_view.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/channel_view.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.constants import MODES
@@ -34,7 +35,11 @@ def run(context, url):
 
     items = []
     append_item = items.append
-    directories = tree.getiterator('Directory')
+    if PY3:
+        directories = tree.iter('Directory')
+    else:
+        directories = tree.getiterator('Directory')
+
     for channels in directories:
 
         if channels.get('local', '') == '0' or channels.get('size', '0') == '0':

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/detect_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/detect_servers.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+
+    Copyright (C) 2011-2018 PleXBMC (plugin.video.plexbmc) by hippojay (Dave Hawes-Johnson)
+    Copyright (C) 2018-2019 Composite (plugin.video.composite_for_plex)
+
+    This file is part of Composite (plugin.video.composite_for_plex)
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+    See LICENSES/GPL-2.0-or-later.txt for more information.
+"""
+
+from kodi_six import xbmc  # pylint: disable=import-error
+
+from ..plex import plex
+
+
+def run(context):
+    context.plex_network = plex.Plex(context.settings, load=False)
+    context.plex_network.delete_cache()
+    xbmc.executebuiltin('Container.Refresh')

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/display_sections.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/display_sections.py
@@ -130,7 +130,7 @@ def server_section_menus_items(context, server_list, content_filter, display_sha
         server_items = []
         for section in sections:
 
-            if ((display_shared and server.is_owned()) or
+            if (display_shared and server.is_owned() or
                     (content_filter is not None and section.content_type() != content_filter)):
                 continue
 
@@ -278,6 +278,16 @@ def action_menu_items(context):
         }
 
         item_url = 'cmd:' + COMMANDS.SIGNOUT
+        gui_item = GUIItem(item_url, details, extra_data)
+        append_item(create_gui_item(context, gui_item))
+
+        details = {
+            'title': i18n('Detect Servers')
+        }
+        extra_data = {
+            'type': 'file'
+        }
+        item_url = 'cmd:' + COMMANDS.DETECTSERVERS
         gui_item = GUIItem(item_url, details, extra_data)
         append_item(create_gui_item(context, gui_item))
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/get_content.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/get_content.py
@@ -10,11 +10,10 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
-from six.moves.urllib_parse import quote
-from six.moves.urllib_parse import unquote
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six.moves.urllib_parse import quote
+from six.moves.urllib_parse import unquote
 
 from ..addon.common import get_handle
 from ..addon.constants import MODES

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/install_plugin.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/install_plugin.py
@@ -10,10 +10,9 @@
     See LICENSES/GPL-2.0-or-later.txt for more information.
 """
 
-from six.moves.urllib_parse import unquote_plus
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six.moves.urllib_parse import unquote_plus
 
 from ..addon.logger import Logger
 from ..addon.strings import i18n

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/kodi_library.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/kodi_library.py
@@ -11,6 +11,7 @@
 
 from kodi_six import xbmcgui  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.containers import Item
@@ -100,9 +101,16 @@ def _list_content(context, server, url):
     items = []
     append_item = items.append
 
-    branches = tree.getiterator('Video')
+    if PY3:
+        branches = tree.iter('Video')
+    else:
+        branches = tree.getiterator('Video')
+
     if not branches:
-        branches = tree.getiterator('Directory')
+        if PY3:
+            branches = tree.iter('Directory')
+        else:
+            branches = tree.getiterator('Directory')
 
     for content in branches:
         item = Item(server, url, tree, content)

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/manage_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/manage_servers.py
@@ -13,10 +13,9 @@
 import json
 from copy import deepcopy
 
-from six.moves.urllib_parse import urlparse
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six.moves.urllib_parse import urlparse
 
 from ..addon.data_cache import DATA_CACHE
 from ..addon.logger import Logger
@@ -25,6 +24,7 @@ from ..addon.strings import i18n
 from ..plex import plex
 
 LOG = Logger()
+WINDOW = xbmcgui.Window(10000)
 
 
 def run(context):
@@ -194,6 +194,7 @@ class ServerManager:
         if is_url:
             self.server_configs.add_access_url(self.server.get_uuid(), url, url_index)
             self._refresh(clear_cache=True)
+            WINDOW.setProperty('plugin.video.composite-refresh.servers', 'true')
             return
 
     def _modify_custom_access_url(self, url_index):
@@ -209,6 +210,7 @@ class ServerManager:
         else:
             self.server_configs.delete_access_url(self.server.get_uuid(), url_index)
             self._refresh(clear_cache=True)
+            WINDOW.setProperty('plugin.video.composite-refresh.servers', 'true')
             return
 
     def _show_connection_test(self):

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/on_deck_all_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/on_deck_all_servers.py
@@ -10,6 +10,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.containers import Item
@@ -46,7 +47,11 @@ def _list_content(context, server, section):
     if tree is None:
         return []
 
-    branches = tree.getiterator('Video')
+    if PY3:
+        branches = tree.iter('Video')
+    else:
+        branches = tree.getiterator('Video')
+
     if not branches:
         return []
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/recently_added_all_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/recently_added_all_servers.py
@@ -10,6 +10,7 @@
 """
 
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.containers import Item
@@ -49,7 +50,11 @@ def _list_content(context, server, section):
     if tree is None:
         return []
 
-    branches = tree.getiterator('Video')
+    if PY3:
+        branches = tree.iter('Video')
+    else:
+        branches = tree.getiterator('Video')
+
     if not branches:
         return []
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/search_all.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/search_all.py
@@ -11,10 +11,9 @@
 
 import xml.etree.ElementTree as ETree
 
-from six.moves.urllib_parse import quote
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six.moves.urllib_parse import quote
 
 from ..addon.common import get_handle
 from ..addon.containers import Item

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/search_all_servers.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/search_all_servers.py
@@ -11,6 +11,7 @@
 
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_handle
 from ..addon.constants import MODES
@@ -227,7 +228,11 @@ def _list_content(context, server, section):
         10: 'Track'
     }
 
-    branches = tree.getiterator(iter_types.get(item_type, 'Directory'))
+    if PY3:
+        branches = tree.iter(iter_types.get(item_type, 'Directory'))
+    else:
+        branches = tree.getiterator(iter_types.get(item_type, 'Directory'))
+
     if not branches:
         return []
 

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/set_audio.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/set_audio.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_argv
 from ..addon.logger import Logger
@@ -40,7 +41,12 @@ def run(context):
     display_list = []
     append_label = display_list.append
     part_id = ''
-    audio_parts = tree.getiterator('Part')
+
+    if PY3:
+        audio_parts = tree.iter('Part')
+    else:
+        audio_parts = tree.getiterator('Part')
+
     for parts in audio_parts:
 
         part_id = parts.get('id')

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/set_subtitles.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/set_subtitles.py
@@ -11,6 +11,7 @@
 """
 
 from kodi_six import xbmcgui  # pylint: disable=import-error
+from six import PY3
 
 from ..addon.common import get_argv
 from ..addon.logger import Logger
@@ -41,7 +42,12 @@ def run(context):
     append_label = display_list.append
     fl_select = False
     part_id = ''
-    subtitle_parts = tree.getiterator('Part')
+
+    if PY3:
+        subtitle_parts = tree.iter('Part')
+    else:
+        subtitle_parts = tree.getiterator('Part')
+
     for parts in subtitle_parts:
 
         part_id = parts.get('id')

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/trakttokodi.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/trakttokodi.py
@@ -12,11 +12,10 @@
 import string
 import xml.etree.ElementTree as ETree
 
-from six import PY3
-from six.moves.urllib_parse import unquote
-
 from kodi_six import xbmc  # pylint: disable=import-error
 from kodi_six import xbmcplugin  # pylint: disable=import-error
+from six import PY3
+from six.moves.urllib_parse import unquote
 
 from ..addon.common import get_handle
 from ..addon.common import get_plugin_url


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Composite
  - Add-on ID: plugin.video.composite_for_plex
  - Version number: 1.4.2
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/anxdpanic/plugin.video.composite_for_plex
  
Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay

### Description of changes:


[fix] use of deprecated ElementTree.getiterator
[fixup] custom access urls
[add] Detect Servers to main menu
[chg] only refresh server cache on connection errors
[upd] linting
[lang] update translations from Weblate
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
