### PR TITLE
[plugin.video.lbry] 0.1.8+matrix.1

### DIFF
--- a/plugin.video.lbry/addon.xml
+++ b/plugin.video.lbry/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.lbry" name="LBRY" version="0.1.7+matrix.1" provider-name="accumulator">
+<addon id="plugin.video.lbry" name="LBRY" version="0.1.8+matrix.1" provider-name="accumulator">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.3"/>

--- a/plugin.video.lbry/resources/lib/plugin.py
+++ b/plugin.video.lbry/resources/lib/plugin.py
@@ -89,13 +89,10 @@ def serialize_uri(item):
         return quote(item)
 
 def serialize_comment_uri(item):
-    # all uris passed via kodi's routing system must be urlquoted
-    if type(item) is dict:
+    if 'signing_channel' in item and 'name' in item['signing_channel'] and 'claim_id' in item['signing_channel']:
         signing_channel = item['signing_channel']
         return quote(signing_channel['name'] + '#' + signing_channel['claim_id'] + '#' + item['claim_id'])
-    else:
-        return quote(item)
-
+    return None
 
 def deserialize_uri(item):
     # all uris passed via kodi's routing system must be urlquoted
@@ -128,9 +125,11 @@ def to_video_listitem(item, playlist='', channel='', repost=None):
         infoLabels['duration'] = str(item['value']['video']['duration'])
 
     if playlist == '':
-        menu.append((
-            tr(30238), 'RunPlugin(%s)' % plugin.url_for(plugin_comment_show, uri=serialize_comment_uri(item))
-            ))
+        uri = serialize_comment_uri(item)
+        if uri:
+            menu.append((
+                tr(30238), 'RunPlugin(%s)' % plugin.url_for(plugin_comment_show, uri=uri)
+                ))
 
         menu.append((
             tr(30212) % tr(30211), 'RunPlugin(%s)' % plugin.url_for(plugin_playlist_add, name=quote(tr(30211)), uri=serialize_uri(item))


### PR DESCRIPTION
### Description
Fixes a thrown exception when a search result contain a channel name (introduced in v0.1.7 due a testing oversight).

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
