### PR TITLE
[plugin.video.tvvlaanderen@leia] 1.0.5

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,12 +1,35 @@
 # Changelog
 
-## [v1.0.4](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.4) (2021-06-25)
+## [v1.0.5](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.5) (2022-01-22)
 
-[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.3...v1.0.4)
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.4...v1.0.5)
+
+**Implemented enhancements:**
+
+- Add support for Focus Sat in Romania [\#42](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/42) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add support for HD Austria [\#39](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/39) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Remove hardcoded CET timezone and fix timezone in IPTV Manager data [\#45](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/45) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix adult settings for iptv-manager channel list [\#40](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/40) ([bananenfisch](https://github.com/bananenfisch))
+
+**Merged pull requests:**
+
+- HD Austria: language, readme, addon.xml, screenshots [\#48](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/48) ([bananenfisch](https://github.com/bananenfisch))
+- Adding romanian translation [\#43](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/43) ([derzis](https://github.com/derzis))
+
+## [v1.0.4](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.4) (2021-06-27)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0...v1.0.4)
 
 **Fixed bugs:**
 
 - Set a user-agent [\#34](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/34) ([michaelarnauts](https://github.com/michaelarnauts))
+
+## [v1.0](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0) (2021-06-27)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.3...v1.0)
 
 ## [v1.0.3](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.3) (2021-02-04)
 
@@ -15,11 +38,6 @@
 **Implemented enhancements:**
 
 - Add http proxy support [\#30](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/30) ([michaelarnauts](https://github.com/michaelarnauts))
-
-**Merged pull requests:**
-
-- Make use of git archive [\#32](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/32) ([dagwieers](https://github.com/dagwieers))
-- Improve tests [\#31](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/31) ([michaelarnauts](https://github.com/michaelarnauts))
 
 ## [v1.0.2](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.2) (2020-12-21)
 
@@ -51,10 +69,6 @@
 
 - Fix EPG in the channels view [\#25](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/25) ([michaelarnauts](https://github.com/michaelarnauts))
 - Depend on inputstreamhelper to make sure widevine is installed [\#20](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/20) ([mediaminister](https://github.com/mediaminister))
-
-**Merged pull requests:**
-
-- Run tests on Python 3.9 [\#22](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/22) ([michaelarnauts](https://github.com/michaelarnauts))
 
 ## [v0.0.1](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v0.0.1) (2020-11-11)
 

--- a/plugin.video.tvvlaanderen/LICENSE
+++ b/plugin.video.tvvlaanderen/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/plugin.video.tvvlaanderen/README.md
+++ b/plugin.video.tvvlaanderen/README.md
@@ -1,20 +1,20 @@
-[![GitHub release](https://img.shields.io/github/release/add-ons/plugin.video.tvvlaanderen.svg?include_prereleases)](https://github.com/add-ons/plugin.video.tvvlaanderen/releases)
-[![Build Status](https://img.shields.io/github/workflow/status/add-ons/plugin.video.tvvlaanderen/CI/master)](https://github.com/add-ons/plugin.video.tvvlaanderen/actions?query=branch%3Amaster)
-[![Codecov status](https://img.shields.io/codecov/c/github/add-ons/plugin.video.tvvlaanderen/master)](https://codecov.io/gh/add-ons/plugin.video.tvvlaanderen/branch/master)
-[![License: GPLv3](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://opensource.org/licenses/GPL-3.0)
-[![Contributors](https://img.shields.io/github/contributors/add-ons/plugin.video.tvvlaanderen.svg)](https://github.com/add-ons/plugin.video.tvvlaanderen/graphs/contributors)
-
 # TV Vlaanderen Kodi Add-on
 
-*plugin.video.tvvlaanderen* is een Kodi add-on om Live TV, Restart en Replay te bekijken met je TV Vlaanderen abonnement. 
+*plugin.video.tvvlaanderen* is een Kodi add-on om Live TV, Restart en Replay te bekijken met je TV Vlaanderen
+abonnement.
 
 > Note: Je hebt hiervoor een betaald abonnement nodig bij [TV Vlaanderen](https://www.tv-vlaanderen.be/).
 
-Meer informatie kan je vinden op de [Wiki pagina](https://github.com/add-ons/plugin.video.tvvlaanderen/wiki).
+## Installatie
+
+Je kan deze addon installeren via de Add-on functie van Kodi door te zoeken op "TV Vlaanderen". De laatste versie kan
+ook gedownload worden bij de [releases](https://github.com/add-ons/plugin.video.tvvlaanderen/releases) van deze
+repository.
 
 ## Features
 
 De volgende features worden ondersteund:
+
 * Live TV
 * Restart TV, bekijk het huidige programma vanaf het begin (niet voor alle zenders)
 * Replay TV, bekijk een programma tot 7 dagen terug (niet voor alle zenders)
@@ -33,5 +33,5 @@ De volgende features worden ondersteund:
 
 ## Disclaimer
 
-Deze add-on wordt niet ondersteund door TV Vlaanderen, en wordt aangeboden 'as is', zonder enige garantie.
-TV Vlaanderen is een merk van Canal+ Luxembourg S. à r.l.
+Deze add-on wordt niet ondersteund door TV Vlaanderen, en wordt aangeboden 'as is', zonder enige garantie. TV Vlaanderen
+is een merk van Canal+ Luxembourg S. à r.l.

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.4" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.5" provider-name="Michaël Arnauts">
     <requires>
-        <import addon="xbmc.python" version="2.26.0"/>
-        <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="script.module.inputstreamhelper" version="0.5.1"/>
-        <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.requests" version="2.22.0"/>
-        <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="script.module.pyjwt" version="1.6.4"/>
-        <import addon="inputstream.adaptive" version="2.4.3"/>
+        <import addon="xbmc.python" version="2.26.0" />
+        <import addon="script.module.dateutil" version="2.6.0" />
+        <import addon="script.module.inputstreamhelper" version="0.5.1" />
+        <import addon="script.module.pysocks" version="1.6.8" optional="true" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.routing" version="0.2.0" />
+        <import addon="script.module.pyjwt" version="1.6.4" />
+        <import addon="inputstream.adaptive" version="2.4.3" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
@@ -22,8 +22,10 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.4 (2021-06-27)
-- Fix playback of some channels.</news>
+        <news>v1.0.5 (2022-01-22)
+- Fix incorrect time in EPG view.
+- Fix hiding of adult channels in EPG view.
+- Add translations.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.de_de/strings.po
@@ -3,103 +3,103 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
+"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 ### MENUS
 msgctxt "#30007"
 msgid "Channels"
-msgstr "Kanalen"
+msgstr "Kanäle"
 
 msgctxt "#30008"
 msgid "Show channel based overview"
-msgstr "Toon een overzicht per tv-kanaal"
+msgstr "Zeige Übersicht der Kanäle"
 
 msgctxt "#30009"
 msgid "Search"
-msgstr "Zoeken"
+msgstr "Suche"
 
 msgctxt "#30010"
 msgid "Search through the catalogue"
-msgstr "Doorzoek de catalogus"
+msgstr "Durchsuche Katalog"
 
 
 ### SUBMENUS
 msgctxt "#30051"
 msgid "Watch live [B]{channel}[/B]"
-msgstr "Kijk live [B]{channel}[/B]"
+msgstr "Schaue live [B]{channel}[/B]"
 
 msgctxt "#30052"
 msgid "Restart [B]{program}[/B] from the beginning"
-msgstr "Herstart [B]{program}[/B] vanaf het begin"
+msgstr "Neustart [B]{program}[/B] von Anfang an"
 
 msgctxt "#30053"
 msgid "TV guide for [B]{channel}[/B]"
-msgstr "Tv-gids voor [B]{channel}[/B]"
+msgstr "TV-Programm für [B]{channel}[/B]"
 
 msgctxt "#30054"
 msgid "Browse the TV guide for [B]{channel}[/B]"
-msgstr "Doorblader de tv-gids voor [B]{channel}[/B]"
+msgstr "Zeige TV-Programm für [B]{channel}[/B]"
 
 msgctxt "#30055"
 msgid "Replay for [B]{channel}[/B]"
-msgstr "Replay voor [B]{channel}[/B]"
+msgstr "Replay für [B]{channel}[/B]"
 
 msgctxt "#30056"
 msgid "Browse the replay catalog for [B]{channel}[/B]"
-msgstr "Doorblader de replay catalogus voor [B]{channel}[/B]"
+msgstr "Zeige Replay Katalog für [B]{channel}[/B]"
 
 
 ### CODE
 msgctxt "#30203"
 msgid "Your credentials are not valid!"
-msgstr "De inloggegevens zijn onjuist!"
+msgstr "Die Login-Daten sind nicht korrekt!"
 
 msgctxt "#30204"
 msgid "Enter PIN"
-msgstr "Geef PIN in"
+msgstr "Gib den PIN ein"
 
 msgctxt "#30205"
 msgid "The PIN you have entered is invalid!"
-msgstr "De ingegeven PIN is ongeldig!"
+msgstr "Der eingegebene PIN ist ungültig!"
 
 msgctxt "#30208"
 msgid "[B]{days} days[/B] remaining"
-msgstr "beschikbaar voor [B]{days}[/B] dagen"
+msgstr "noch [B]{days} Tage[/B] verfügbar"
 
 msgctxt "#30209"
 msgid "[B]1 day[/B] remaining"
-msgstr "beschikbaar voor [B]1 dag[/B]"
+msgstr "noch [B]1 Tag[/B] verfügbar"
 
 msgctxt "#30210"
 msgid "[B]{hours} hours[/B] remaining"
-msgstr "beschikbaar voor [B]{hours} uren[/B]"
+msgstr "noch [B]{hours} Stunden[/B] verfügbar"
 
 msgctxt "#30211"
 msgid "[B]1 hour[/B] remaining"
-msgstr "beschikbaar voor [B]1 uur[/B]"
+msgstr "noch [B]1 Stunde[/B] verfügbar"
 
 msgctxt "#30212"
 msgid "[B]less then 1 hour[/B] remaining"
-msgstr "beschikbaar voor [B]minder dan 1 uur[/B]"
+msgstr "[B]weniger als 1 Stunde[/B] verfügbar"
 
 msgctxt "#30213"
 msgid "[B]Now:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Nu:[/B] {start} - {end}\n» {title}"
+msgstr "[B]Jetzt:[/B] {start} - {end}\n» {title}"
 
 msgctxt "#30214"
 msgid "[B]Next:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Straks:[/B] {start} - {end}\n» {title}"
+msgstr "[B]Danach:[/B] {start} - {end}\n» {title}"
 
 
 ### Dates
 msgctxt "#30301"
 msgid "Yesterday"
-msgstr "Gisteren"
+msgstr "Gestern"
 
 msgctxt "#30302"
 msgid "Today"
-msgstr "Vandaag"
+msgstr "Heute"
 
 msgctxt "#30303"
 msgid "Tomorrow"
@@ -109,37 +109,37 @@ msgstr "Morgen"
 ### MESSAGES
 msgctxt "#30701"
 msgid "To watch a video, you need to enter your credentials. Do you want to enter them now?"
-msgstr "Om een video te bekijken moet je je inloggegevens ingeven. Wil je dit nu doen?"
+msgstr "Um dieses Service zu nutzen, musst du deine Login-Daten eingeben. Möchtest du das jetzt tun?"
 
 msgctxt "#30702"
 msgid "An error occurred while authenticating: {error}."
-msgstr "Er is een fout opgetreden tijdens het aanmelden: {error}."
+msgstr "Es ist ein Fehler während der Anmeldung aufgetreten: {error}."
 
 msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
-msgstr "Deze video is niet beschikbaar en kan nu niet worden afgespeeld."
+msgstr "Das video ist gerade nicht verfügbar und kann nicht abgespielt werden."
 
 
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
-msgstr "Inloggegevens"
+msgstr "Login-Daten"
 
 msgctxt "#30801"
 msgid "Credentials"
-msgstr "Inloggegevens"
+msgstr "Login-Daten"
 
 msgctxt "#30802"
 msgid "Email address"
-msgstr "E-mailadres"
+msgstr "E-Mail Adresse"
 
 msgctxt "#30803"
 msgid "Password"
-msgstr "Wachtwoord"
+msgstr "Passwort"
 
 msgctxt "#30804"
 msgid "Provider"
-msgstr "Provider"
+msgstr "Anbieter"
 
 msgctxt "#30820"
 msgid "Interface"
@@ -147,27 +147,27 @@ msgstr "Interface"
 
 msgctxt "#30821"
 msgid "Channels"
-msgstr "Kanalen"
+msgstr "Kanäle"
 
 msgctxt "#30822"
 msgid "Parental Content"
-msgstr "Ouderlijk toezicht"
+msgstr "Erwachsenen Inhalte"
 
 msgctxt "#30823"
 msgid "Ask PIN for 18+ channels"
-msgstr "Vraag PIN voor 18+ kanalen"
+msgstr "Frage nach PIN für 18+ Kanäle"
 
 msgctxt "#30824"
 msgid "Hide 18+ channels"
-msgstr "Verberg 18+ kanalen"
+msgstr "Verberge 18+ Kanäle"
 
 msgctxt "#30825"
 msgid "Allow 18+ channels without asking PIN"
-msgstr "18+ kanalen toestaan zonder PIN te vragen"
+msgstr "Zeige 18+ Kanäle ohne PIN Abfrage"
 
 msgctxt "#30840"
 msgid "Integration"
-msgstr "Integratie"
+msgstr "Integration"
 
 msgctxt "#30841"
 msgid "IPTV Manager"
@@ -175,32 +175,32 @@ msgstr "IPTV Manager"
 
 msgctxt "#30842"
 msgid "Install IPTV Manager add-on…"
-msgstr "Installeer de IPTV Manager add-on…"
+msgstr "Installiere das IPTV Manager add-on…"
 
 msgctxt "#30843"
 msgid "Enable IPTV Manager integration"
-msgstr "Activeer IPTV Manager integratie"
+msgstr "Aktiviere IPTV Manager Integration"
 
 msgctxt "#30844"
 msgid "IPTV Manager settings…"
-msgstr "IPTV Manager instellingen…"
+msgstr "IPTV Manager Einstellungen…"
 
 msgctxt "#30880"
 msgid "Expert"
-msgstr "Expert"
+msgstr "Experte"
 
 msgctxt "#30881"
 msgid "Logging"
-msgstr "Logboek"
+msgstr "Logging"
 
 msgctxt "#30882"
 msgid "Enable debug logging"
-msgstr "Activeer debug logging"
+msgstr "Aktiviere debug logging"
 
 msgctxt "#30883"
 msgid "Install Kodi Logfile Uploader…"
-msgstr "Installeer Kodi Logfile Uploader…"
+msgstr "Installiere Kodi Logfile Uploader…"
 
 msgctxt "#30884"
 msgid "Open Kodi Logfile Uploader…"
-msgstr "Open Kodi Logfile Uploader…"
+msgstr "Öffne Kodi Logfile Uploader…"

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.en_gb/strings.po
@@ -136,6 +136,10 @@ msgctxt "#30803"
 msgid "Password"
 msgstr ""
 
+msgctxt "#30804"
+msgid "Provider"
+msgstr ""
+
 msgctxt "#30820"
 msgid "Interface"
 msgstr ""

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.ro_ro/strings.po
@@ -1,173 +1,172 @@
 msgid ""
 msgstr ""
-"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
+"Language: ro\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 ### MENUS
 msgctxt "#30007"
 msgid "Channels"
-msgstr "Kanalen"
+msgstr "Canale"
 
 msgctxt "#30008"
 msgid "Show channel based overview"
-msgstr "Toon een overzicht per tv-kanaal"
+msgstr "Afișați o prezentare generală pentru fiecare canal TV"
 
 msgctxt "#30009"
 msgid "Search"
-msgstr "Zoeken"
+msgstr "Căutare"
 
 msgctxt "#30010"
 msgid "Search through the catalogue"
-msgstr "Doorzoek de catalogus"
+msgstr "Căutare în bibliotecă"
 
 
 ### SUBMENUS
 msgctxt "#30051"
 msgid "Watch live [B]{channel}[/B]"
-msgstr "Kijk live [B]{channel}[/B]"
+msgstr "Urmărește în direct [B]{channel}[/B]"
 
 msgctxt "#30052"
 msgid "Restart [B]{program}[/B] from the beginning"
-msgstr "Herstart [B]{program}[/B] vanaf het begin"
+msgstr "Reporniți [B]{program}[/B] de la început"
 
 msgctxt "#30053"
 msgid "TV guide for [B]{channel}[/B]"
-msgstr "Tv-gids voor [B]{channel}[/B]"
+msgstr "Ghid TV pentru [B]{channel}[/B]"
 
 msgctxt "#30054"
 msgid "Browse the TV guide for [B]{channel}[/B]"
-msgstr "Doorblader de tv-gids voor [B]{channel}[/B]"
+msgstr "Răsfoiește ghidul TV pentru [B]{channel}[/B]"
 
 msgctxt "#30055"
 msgid "Replay for [B]{channel}[/B]"
-msgstr "Replay voor [B]{channel}[/B]"
+msgstr "Replay pentru [B]{channel}[/B]"
 
 msgctxt "#30056"
 msgid "Browse the replay catalog for [B]{channel}[/B]"
-msgstr "Doorblader de replay catalogus voor [B]{channel}[/B]"
+msgstr "Răsfoiește biblioteca replay pentru [B]{channel}[/B]"
 
 
 ### CODE
 msgctxt "#30203"
 msgid "Your credentials are not valid!"
-msgstr "De inloggegevens zijn onjuist!"
+msgstr "Datele dvs de logare nu sunt corecte!"
 
 msgctxt "#30204"
 msgid "Enter PIN"
-msgstr "Geef PIN in"
+msgstr "Introduceți PIN"
 
 msgctxt "#30205"
 msgid "The PIN you have entered is invalid!"
-msgstr "De ingegeven PIN is ongeldig!"
+msgstr "PIN-ul introdus este incorect!"
 
 msgctxt "#30208"
 msgid "[B]{days} days[/B] remaining"
-msgstr "beschikbaar voor [B]{days}[/B] dagen"
+msgstr "[B]{days} zile[/B] rămase"
 
 msgctxt "#30209"
 msgid "[B]1 day[/B] remaining"
-msgstr "beschikbaar voor [B]1 dag[/B]"
+msgstr "[B]1 zi[/B] rămasă"
 
 msgctxt "#30210"
 msgid "[B]{hours} hours[/B] remaining"
-msgstr "beschikbaar voor [B]{hours} uren[/B]"
+msgstr "[B]{hours} ore[/B] rămase"
 
 msgctxt "#30211"
 msgid "[B]1 hour[/B] remaining"
-msgstr "beschikbaar voor [B]1 uur[/B]"
+msgstr "[B]1 oră[/B] rămasă"
 
 msgctxt "#30212"
 msgid "[B]less then 1 hour[/B] remaining"
-msgstr "beschikbaar voor [B]minder dan 1 uur[/B]"
+msgstr "[B]mai puțin de 1 oră[/B] rămasă"
 
 msgctxt "#30213"
 msgid "[B]Now:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Nu:[/B] {start} - {end}\n» {title}"
+msgstr "[B]Acum:[/B] {start} - {end}\n» {title}"
 
 msgctxt "#30214"
 msgid "[B]Next:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Straks:[/B] {start} - {end}\n» {title}"
+msgstr "[B]Urmează:[/B] {start} - {end}\n» {title}"
 
 
 ### Dates
 msgctxt "#30301"
 msgid "Yesterday"
-msgstr "Gisteren"
+msgstr "Ieri"
 
 msgctxt "#30302"
 msgid "Today"
-msgstr "Vandaag"
+msgstr "Astăzi"
 
 msgctxt "#30303"
 msgid "Tomorrow"
-msgstr "Morgen"
+msgstr "Mâine"
 
 
 ### MESSAGES
 msgctxt "#30701"
 msgid "To watch a video, you need to enter your credentials. Do you want to enter them now?"
-msgstr "Om een video te bekijken moet je je inloggegevens ingeven. Wil je dit nu doen?"
+msgstr "Pentru a viziona conținutul, trebuie să vă autentificați. Vă autentificați acum?"
 
 msgctxt "#30702"
 msgid "An error occurred while authenticating: {error}."
-msgstr "Er is een fout opgetreden tijdens het aanmelden: {error}."
+msgstr "A apărut o eroare la autentificare: {eroare}."
 
 msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
-msgstr "Deze video is niet beschikbaar en kan nu niet worden afgespeeld."
+msgstr "Video-ul este indisponibil și nu poate fi redat momentan."
 
 
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
-msgstr "Inloggegevens"
+msgstr "Autentificare"
 
 msgctxt "#30801"
 msgid "Credentials"
-msgstr "Inloggegevens"
+msgstr "Autentificare"
 
 msgctxt "#30802"
 msgid "Email address"
-msgstr "E-mailadres"
+msgstr "adresă e-mail"
 
 msgctxt "#30803"
 msgid "Password"
-msgstr "Wachtwoord"
+msgstr "Parolă"
 
 msgctxt "#30804"
 msgid "Provider"
-msgstr "Provider"
+msgstr "Furnizor"
 
 msgctxt "#30820"
 msgid "Interface"
-msgstr "Interface"
+msgstr "Interfață"
 
 msgctxt "#30821"
 msgid "Channels"
-msgstr "Kanalen"
+msgstr "Canale"
 
 msgctxt "#30822"
 msgid "Parental Content"
-msgstr "Ouderlijk toezicht"
+msgstr "Control Parental"
 
 msgctxt "#30823"
 msgid "Ask PIN for 18+ channels"
-msgstr "Vraag PIN voor 18+ kanalen"
+msgstr "Introduceți PIN pentru canale 18+"
 
 msgctxt "#30824"
 msgid "Hide 18+ channels"
-msgstr "Verberg 18+ kanalen"
+msgstr "Ascunde canalele 18+"
 
 msgctxt "#30825"
 msgid "Allow 18+ channels without asking PIN"
-msgstr "18+ kanalen toestaan zonder PIN te vragen"
+msgstr "Permiteți canalele 18+ fără introducere PIN"
 
 msgctxt "#30840"
 msgid "Integration"
-msgstr "Integratie"
+msgstr "Integrare"
 
 msgctxt "#30841"
 msgid "IPTV Manager"
@@ -175,15 +174,15 @@ msgstr "IPTV Manager"
 
 msgctxt "#30842"
 msgid "Install IPTV Manager add-on…"
-msgstr "Installeer de IPTV Manager add-on…"
+msgstr "Instalați suplimentul IPTV Manager …"
 
 msgctxt "#30843"
 msgid "Enable IPTV Manager integration"
-msgstr "Activeer IPTV Manager integratie"
+msgstr "Activați integrarea cu IPTV Manager"
 
 msgctxt "#30844"
 msgid "IPTV Manager settings…"
-msgstr "IPTV Manager instellingen…"
+msgstr "Setări IPTV Manager"
 
 msgctxt "#30880"
 msgid "Expert"
@@ -191,16 +190,16 @@ msgstr "Expert"
 
 msgctxt "#30881"
 msgid "Logging"
-msgstr "Logboek"
+msgstr "Logging"
 
 msgctxt "#30882"
 msgid "Enable debug logging"
-msgstr "Activeer debug logging"
+msgstr "Activați debug logging"
 
 msgctxt "#30883"
 msgid "Install Kodi Logfile Uploader…"
-msgstr "Installeer Kodi Logfile Uploader…"
+msgstr "Instalați Kodi Logfile Uploader…"
 
 msgctxt "#30884"
 msgid "Open Kodi Logfile Uploader…"
-msgstr "Open Kodi Logfile Uploader…"
+msgstr "Deschideți Kodi Logfile Uploader…"

--- a/plugin.video.tvvlaanderen/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.tvvlaanderen/resources/lib/modules/iptvmanager.py
@@ -51,7 +51,7 @@ class IPTVManager:
 
         streams = []
 
-        channels = channel_api.get_channels(filter_pin=kodiutils.get_setting_bool('interface_adult') != SETTINGS_ADULT_HIDE)
+        channels = channel_api.get_channels(filter_pin=kodiutils.get_setting_int('interface_adult') == SETTINGS_ADULT_HIDE)
         for channel in channels:
             streams.append(dict(
                 name=channel.title,
@@ -72,7 +72,7 @@ class IPTVManager:
         epg = defaultdict(list)
 
         # Load EPG data
-        channels = channel_api.get_channels(filter_pin=kodiutils.get_setting_bool('interface_adult') != SETTINGS_ADULT_HIDE)
+        channels = channel_api.get_channels(filter_pin=kodiutils.get_setting_int('interface_adult') == SETTINGS_ADULT_HIDE)
         for date in ['yesterday', 'today', 'tomorrow']:
             for channel, programs in epg_api.get_guide_with_capi([channel.station_id for channel in channels], date).items():
                 for program in programs:

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/__init__.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/__init__.py
@@ -4,22 +4,6 @@ from __future__ import absolute_import, division, unicode_literals
 
 SOLOCOO_API = 'https://tvapi.solocoo.tv/v1'
 
-TENANTS = dict([
-    ('tvv', dict(
-        name='TV Vlaanderen',
-        domain='livetv.tv-vlaanderen.be',
-        env='m7be2iphone',
-        app='tvv',
-    )),
-    ('cds', dict(
-        name='Canal Digitaal',
-        domain='livetv.canaldigitaal.nl',
-        env='m7be2iphone',
-        app='cds',
-    )),
-    # and many more, ...
-])
-
 
 class Channel:
     """ Channel Object """

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/config.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/config.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+""" Solocoo API Config """
+from __future__ import absolute_import, division, unicode_literals
+
+TENANTS = dict([
+    ('tvv', dict(
+        name='TV Vlaanderen',
+        domain='livetv.tv-vlaanderen.be',
+        env='m7be2iphone',
+        app='tvv',
+    )),
+])

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
@@ -98,7 +98,7 @@ class EpgApi:
             channels = [channels]
 
         # Python 2.7 doesn't support .timestamp(), and windows doesn't do '%s', so we need to calculate it ourself
-        epoch = datetime(1970, 1, 1, tzinfo=dateutil.tz.gettz('UTC'))
+        epoch = datetime(1970, 1, 1, tzinfo=dateutil.tz.UTC)
 
         # Generate dates in UTC format
         if date_from is not None:
@@ -167,7 +167,7 @@ class EpgApi:
         else:
             date_obj = dateutil.parser.parse(date)
 
-        # Mark as midnight
-        date_obj = date_obj.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=dateutil.tz.gettz('CET'))
-        date_obj = date_obj.astimezone(dateutil.tz.gettz('UTC'))
+        # Mark as midnight in UTC
+        date_obj = date_obj.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=dateutil.tz.tzlocal())
+        date_obj = date_obj.astimezone(dateutil.tz.UTC)
         return date_obj

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
@@ -94,7 +94,7 @@ def check_deals_entitlement(deals, offers):
             best_deal = end
 
     if best_deal is not None:
-        return dateutil.parser.parse(best_deal).astimezone(dateutil.tz.gettz('CET'))
+        return dateutil.parser.parse(best_deal).astimezone(tz=dateutil.tz.tzlocal())
 
     return False
 
@@ -137,9 +137,9 @@ def parse_program(program, offers=None):
     if not program:
         return None
 
-    # Parse dates
-    start = dateutil.parser.parse(program.get('params', {}).get('start')).astimezone(dateutil.tz.gettz('CET'))
-    end = dateutil.parser.parse(program.get('params', {}).get('end')).astimezone(dateutil.tz.gettz('CET'))
+    # Parse dates and convert from UTC to local timezone
+    start = dateutil.parser.parse(program.get('params', {}).get('start')).replace(tzinfo=dateutil.tz.UTC).astimezone(tz=dateutil.tz.tzlocal())
+    end = dateutil.parser.parse(program.get('params', {}).get('end')).replace(tzinfo=dateutil.tz.UTC).astimezone(tz=dateutil.tz.tzlocal())
 
     season = program.get('params', {}).get('seriesSeason')
     episode = program.get('params', {}).get('seriesEpisode')
@@ -182,10 +182,10 @@ def parse_program_capi(program, tenant):
     if not program:
         return None
 
-    # Parse dates
-    start = datetime.fromtimestamp(program.get('start') / 1000, dateutil.tz.gettz('CET'))
-    end = datetime.fromtimestamp(program.get('end') / 1000, dateutil.tz.gettz('CET'))
-    now = datetime.now().replace(tzinfo=dateutil.tz.gettz('CET'))
+    # Parse dates and convert from UTC to local timezone
+    start = datetime.fromtimestamp(program.get('start') / 1000, tz=dateutil.tz.UTC).astimezone(tz=dateutil.tz.tzlocal())
+    end = datetime.fromtimestamp(program.get('end') / 1000, tz=dateutil.tz.UTC).astimezone(tz=dateutil.tz.tzlocal())
+    now = datetime.now(tz=dateutil.tz.tzlocal())
 
     # Parse credits
     credit_list = []
@@ -285,7 +285,7 @@ def _request(method, url, params=None, form=None, data=None, token_bearer=None, 
     """
     if form or data:
         # Make sure we don't log the password
-        debug_data = dict()
+        debug_data = {}
         debug_data.update(form or data)
         if 'Password' in debug_data:
             debug_data['Password'] = '**redacted**'


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.5
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen

Deze add-on geeft toegang tot de live TV kanalen en de video-on-demand content dat beschikbaar is via je TV Vlaanderen abonnement.

### What's new

v1.0.5 (2022-01-22)
- Fix incorrect time in EPG view.
- Fix hiding of adult channels in EPG view.
- Add translations.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
