### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2022.1.29+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.1.3+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.1.29+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />
@@ -16,7 +16,7 @@
     <summary lang="en_GB">Watch NBCSN Live Extra</summary>
     <description lang="en_GB">NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network</description>
     <news>
-        - Fix for free content not playing
+        - Fix playback failing by always setting inputstream license headers
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.nbcsnliveextra/resources/lib/stream.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/stream.py
@@ -87,16 +87,18 @@ class Stream:
             else:
                 listitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
 
+            listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
+            listitem.setProperty('inputstream.adaptive.stream_headers', 'User-Agent=%s' % UA_NBCSN)
+            lic_headers = 'User-Agent=Dalvik%2F2.1.0+(Linux%3B+U%3B+Android+6.0.1%3B+Hub+Build%2FMHC19J)'
             if self.drm_type == 'widevine':
-                lic_headers = 'User-Agent=Dalvik%2F2.1.0+(Linux%3B+U%3B+Android+6.0.1%3B+Hub+Build%2FMHC19J)'
                 lic_headers += '&Content-Type=application/octet-stream'
                 lic_headers += '&X-ISP-TOKEN=%s' % urllib.quote(self.get_drm_token())
                 license_key = '%s|%s|R{SSM}|' % (self.lic_url, lic_headers)
-                listitem.setProperty('inputstream.adaptive.license_key', license_key)
                 listitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
+            else:
+                license_key = '|%s||' % (lic_headers)
 
-            listitem.setProperty('inputstream.adaptive.manifest_type', 'hls')
-            listitem.setProperty('inputstream.adaptive.stream_headers', 'User-Agent=%s' % UA_NBCSN)
+            listitem.setProperty('inputstream.adaptive.license_key', license_key)
         else:
             listitem.setMimeType("application/x-mpegURL")
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2022.1.29+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix playback failing by always setting inputstream license headers
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
