### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.7+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,10 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.7 (2022-01-31)
+- Fix watch later (@mediaminister)
+- Fix favorites (@mediaminister)
+
 ### v2.5.6 (2021-12-22)
 - Fix watching VRT NU abroad (@mediaminister)
 - Fix resumepoints (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.6+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.7+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,10 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.7 (2022-01-31)
+- Fix watch later
+- Fix favorites
+
 v2.5.6 (2021-12-22)
 - Fix watching VRT NU abroad
 - Fix resumepoints

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -286,10 +286,6 @@ msgctxt "#30121"
 msgid "12+"
 msgstr ""
 
-msgctxt "#30128"
-msgid "Kies19"
-msgstr ""
-
 msgctxt "#30129"
 msgid "Climate"
 msgstr ""

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -286,10 +286,6 @@ msgctxt "#30121"
 msgid "12+"
 msgstr "12+"
 
-msgctxt "#30128"
-msgid "Kies19"
-msgstr "Kies19"
-
 msgctxt "#30129"
 msgid "Climate"
 msgstr "Klimaat"

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -43,33 +43,35 @@ def delete_tokens():
     TokenResolver().delete_tokens()
 
 
-@plugin.route('/follow/<program>/<title>')
-def follow(program, title):
+@plugin.route('/follow/<program_name>/<title>')
+@plugin.route('/follow/<program_name>/<program_id>/<title>')
+def follow(program_name, title, program_id=None):
     """The API interface to follow a program used by the context menu"""
     from favorites import Favorites
-    Favorites().follow(program=program, title=to_unicode(unquote_plus(from_unicode(title))))
+    Favorites().follow(program_name=program_name, title=to_unicode(unquote_plus(from_unicode(title))), program_id=program_id)
 
 
-@plugin.route('/unfollow/<program>/<title>')
-def unfollow(program, title):
+@plugin.route('/unfollow/<program_name>/<title>')
+@plugin.route('/unfollow/<program_name>/<program_id>/<title>')
+def unfollow(program_name, title, program_id=None):
     """The API interface to unfollow a program used by the context menu"""
     move_down = bool(plugin.args.get('move_down'))
     from favorites import Favorites
-    Favorites().unfollow(program=program, title=to_unicode(unquote_plus(from_unicode(title))), move_down=move_down)
+    Favorites().unfollow(program_name=program_name, title=to_unicode(unquote_plus(from_unicode(title))), program_id=program_id, move_down=move_down)
 
 
-@plugin.route('/watchlater/<path:url>/<asset_id>/<title>')
-def watchlater(asset_id, title, url):
+@plugin.route('/watchlater/<episode_id>/<title>')
+def watchlater(episode_id, title):
     """The API interface to watch an episode used by the context menu"""
     from resumepoints import ResumePoints
-    ResumePoints().watchlater(asset_id=asset_id, title=to_unicode(unquote_plus(from_unicode(title))), url=url)
+    ResumePoints().watchlater(episode_id=episode_id, title=to_unicode(unquote_plus(from_unicode(title))))
 
 
-@plugin.route('/unwatchlater/<path:url>/<asset_id>/<title>')
-def unwatchlater(asset_id, title, url):
+@plugin.route('/unwatchlater/<episode_id>/<title>')
+def unwatchlater(episode_id, title):
     """The API interface to unwatch an episode used by the context menu"""
     from resumepoints import ResumePoints
-    ResumePoints().unwatchlater(asset_id=asset_id, title=to_unicode(unquote_plus(from_unicode(title))), url=url)
+    ResumePoints().unwatchlater(episode_id=episode_id, title=to_unicode(unquote_plus(from_unicode(title))))
 
 
 @plugin.route('/favorites')

--- a/plugin.video.vrt.nu/resources/lib/apihelper.py
+++ b/plugin.video.vrt.nu/resources/lib/apihelper.py
@@ -548,8 +548,8 @@ class ApiHelper:
 
             if variety == 'watchlater':
                 self._resumepoints.refresh_watchlater(ttl=ttl('direct'))
-                episode_urls = self._resumepoints.watchlater_urls()
-                params['facets[url]'] = '[%s]' % (','.join(episode_urls))
+                episode_ids = self._resumepoints.watchlater_ids()
+                params['facets[episodeId]'] = '[%s]' % (','.join(episode_ids))
 
             if variety == 'continue':
                 self._resumepoints.refresh_resumepoints(ttl=ttl('direct'))

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -113,6 +113,14 @@ CHANNELS = [
         vod=True,
     ),
     dict(
+        id='',
+        name='vrt-nu',
+        label='VRT NU',
+        studio='VRT NU',
+        logo='https://www.vrt.be/etc.clientlibs/vrtvideo/clientlibs/clientlib-site/resources/logo-vrt_NU-pos-rgb@4x.png',
+        vod=True,
+    ),
+    dict(
         id='12',
         name='sporza',
         label='Sporza',
@@ -277,12 +285,11 @@ FEATURED = [
     dict(name='Exclusief online', id='exclusief-online', msgctxt=30100),
     dict(name='Volledig seizoen', id='volledig-seizoen', msgctxt=30101),
     dict(name='Volledige reeks', id='volledige-reeks', msgctxt=30102),
-    dict(name='Laatste kans', id='laatste-kans', msgctxt=30104),
+    # dict(name='Laatste kans', id='laatste-kans', msgctxt=30104),
     # Inhoudsgerelateerd
     dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
-    dict(name='12+', id='12+', msgctxt=30121),
+    # dict(name='12+', id='12+', msgctxt=30121),
     # Thema
-    dict(name='Kies19', id='kies-19', msgctxt=30128),
     dict(name='Klimaat', id='klimaat', msgctxt=30129),
     dict(name='De warmste week', id='de-warmste-week', msgctxt=30130),
 ]

--- a/plugin.video.vrt.nu/resources/lib/favorites.py
+++ b/plugin.video.vrt.nu/resources/lib/favorites.py
@@ -6,23 +6,25 @@
 from __future__ import absolute_import, division, unicode_literals
 
 try:  # Python 3
-    from urllib.error import HTTPError
     from urllib.parse import unquote
 except ImportError:  # Python 2
     from urllib2 import unquote
 
 from kodiutils import (container_refresh, get_cache, get_setting_bool, get_url_json,
-                       has_credentials, input_down, invalidate_caches, localize, log_error,
+                       has_credentials, input_down, invalidate_caches, localize,
                        multiselect, notification, ok_dialog, update_cache)
-from utils import program_to_id
 
 
 class Favorites:
     """Track, cache and manage VRT favorites"""
 
+    GRAPHQL_URL = 'https://www.vrt.be/vrtnu-api/graphql/v1'
+    FAVORITES_REST_URL = 'https://www.vrt.be/vrtnu-api/rest/lists/vrtnu-favoritePrograms'
+    FAVORITES_CACHE_FILE = 'favorites.json'
+
     def __init__(self):
         """Initialize favorites, relies on XBMC vfs and a special VRT token"""
-        self._data = {}  # Our internal representation
+        self._favorites = {}  # Our internal representation
 
     @staticmethod
     def is_activated():
@@ -33,79 +35,137 @@ class Favorites:
         """Get a cached copy or a newer favorites from VRT, or fall back to a cached file"""
         if not self.is_activated():
             return
-        favorites_json = get_cache('favorites.json', ttl)
-        if not favorites_json:
-            from tokenresolver import TokenResolver
-            xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
-            if xvrttoken:
-                headers = {
-                    'authorization': 'Bearer ' + xvrttoken,
-                    'content-type': 'application/json',
-                    'Referer': 'https://www.vrt.be/vrtnu',
-                }
-                favorites_url = 'https://video-user-data.vrt.be/favorites'
-                favorites_json = get_url_json(url=favorites_url, cache='favorites.json', headers=headers)
-        if favorites_json is not None:
-            self._data = favorites_json
+        favorites_dict = get_cache(self.FAVORITES_CACHE_FILE, ttl)
+        if not favorites_dict:
+            favorites_dict = self._generate_favorites_dict(self.get_favorites())
+        if favorites_dict is not None:
+            from json import dumps
+            self._favorites = favorites_dict
+            update_cache(self.FAVORITES_CACHE_FILE, dumps(self._favorites))
 
-    def update(self, program, title, value=True):
+    def update(self, program_name, title, program_id, is_favorite=True):
         """Set a program as favorite, and update local copy"""
 
         # Survive any recent updates
         self.refresh(ttl=5)
 
-        if value is self.is_favorite(program):
+        if is_favorite is self.is_favorite(program_name):
             # Already followed/unfollowed, nothing to do
             return True
 
-        from tokenresolver import TokenResolver
-        xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
-        if xvrttoken is None:
-            log_error('Failed to get favorites token from VRT NU')
-            notification(message=localize(30975))
-            return False
+        # Lookup program_id
+        if program_id == 'None' or program_id is None:
+            program_id = self.get_program_id_graphql(program_name)
 
-        headers = {
-            'authorization': 'Bearer ' + xvrttoken,
-            'content-type': 'application/json',
-            'Referer': 'https://www.vrt.be/vrtnu',
-        }
+        # Update local favorites cache
+        if is_favorite is True:
+            self._favorites[program_name] = dict(
+                program_id=program_id,
+                title=title)
+        else:
+            del self._favorites[program_name]
 
+        # Update cache dict
         from json import dumps
-        from utils import program_to_url
-        payload = dict(isFavorite=value, programUrl=program_to_url(program, 'short'), title=title)
-        data = dumps(payload).encode('utf-8')
-        program_id = program_to_id(program)
-        try:
-            get_url_json('https://video-user-data.vrt.be/favorites/{program_id}'.format(program_id=program_id), headers=headers, data=data, raise_errors='all')
-        except HTTPError as exc:
-            log_error("Failed to (un)follow program '{program}' at VRT NU ({error})", program=program, error=exc)
-            notification(message=localize(30976, program=program))
-            return False
-        # NOTE: Updates to favorites take a longer time to take effect, so we keep our own cache and use it
-        self._data[program_id] = dict(value=payload)
-        update_cache('favorites.json', dumps(self._data))
+        update_cache(self.FAVORITES_CACHE_FILE, dumps(self._favorites))
         invalidate_caches('my-offline-*.json', 'my-recent-*.json')
+
+        # Update online
+        self.set_favorite_graphql(program_id, title, is_favorite)
         return True
 
-    def is_favorite(self, program):
-        """Is a program a favorite ?"""
-        value = False
-        favorite = self._data.get(program_to_id(program))
-        if favorite:
-            value = favorite.get('value', {}).get('isFavorite')
-        return value is True
+    def get_favorites(self):
+        """Get favorites using VRT NU REST API"""
+        from tokenresolver import TokenResolver
+        vrtlogin_at = TokenResolver().get_token('vrtlogin-at')
+        favorites_json = {}
+        if vrtlogin_at:
+            headers = {
+                'Authorization': 'Bearer ' + vrtlogin_at,
+                'Accept': 'application/json',
+            }
+            querystring = 'tileType=program-poster&tileContentType=program&tileOrientation=portrait&layout=slider&title=Mijn+favoriete+programma%27s'
+            favorites_json = get_url_json(url='{}?{}'.format(self.FAVORITES_REST_URL, querystring), cache=None, headers=headers, raise_errors='all')
+        return favorites_json
 
-    def follow(self, program, title):
+    def get_program_id_graphql(self, program_name):
+        """Get programId from programName using GraphQL API"""
+        from tokenresolver import TokenResolver
+        vrtlogin_at = TokenResolver().get_token('vrtlogin-at')
+        program_id = None
+        if vrtlogin_at:
+            headers = {
+                'Authorization': 'Bearer ' + vrtlogin_at,
+                'Content-Type': 'application/json',
+            }
+            graphql = """
+                query Page($id: ID!) {
+                  page(id: $id) {
+                    ... on IPage {
+                      id
+                    }
+                  }
+                }
+            """
+            payload = dict(
+                variables=dict(
+                    id='/vrtnu/a-z/{}.model.json'.format(program_name)
+                ),
+                query=graphql,
+            )
+            from json import dumps
+            data = dumps(payload).encode('utf-8')
+            page_json = get_url_json(url=self.GRAPHQL_URL, cache=None, headers=headers, data=data, raise_errors='all')
+            program_id = page_json.get('data').get('page').get('id')
+        return program_id
+
+    def set_favorite_graphql(self, program_id, title, is_favorite=True):
+        """Set favorite using GraphQL API"""
+        from tokenresolver import TokenResolver
+        vrtlogin_at = TokenResolver().get_token('vrtlogin-at')
+        result_json = {}
+        if vrtlogin_at:
+            headers = {
+                'Authorization': 'Bearer ' + vrtlogin_at,
+                'Content-Type': 'application/json',
+            }
+            graphql_query = """
+                mutation setFavorite($input: FavoriteActionInput!) {
+                  setFavorite(input: $input) {
+                    id
+                    favorite
+                  }
+                }
+            """
+            payload = dict(
+                variables=dict(
+                    input=dict(
+                        id=program_id,
+                        title=title,
+                        favorite=is_favorite,
+                    ),
+                ),
+                query=graphql_query,
+            )
+            from json import dumps
+            data = dumps(payload).encode('utf-8')
+            result_json = get_url_json(url=self.GRAPHQL_URL, cache=None, headers=headers, data=data, raise_errors='all')
+        return result_json
+
+    def is_favorite(self, program_name):
+        """Is a program a favorite ?"""
+        return program_name in self._favorites
+
+    def follow(self, program_name, title, program_id=None):
         """Follow your favorite program"""
-        succeeded = self.update(program, title, True)
+        succeeded = self.update(program_name, title, program_id, True)
         if succeeded:
             notification(message=localize(30411, title=title))
             container_refresh()
 
-    def unfollow(self, program, title, move_down=False):
+    def unfollow(self, program_name, title, program_id=None, move_down=False):
         """Unfollow your favorite program"""
-        succeeded = self.update(program, title, False)
+        succeeded = self.update(program_name, title, program_id, False)
         if succeeded:
             notification(message=localize(30412, title=title))
             # If the current item is selected and we need to move down before removing
@@ -113,35 +173,42 @@ class Favorites:
                 input_down()
             container_refresh()
 
-    def titles(self):
-        """Return all favorite titles"""
-        return [value.get('value').get('title') for value in list(self._data.values()) if value.get('value').get('isFavorite')]
-
     def programs(self):
         """Return all favorite programs"""
-        from utils import url_to_program
-        return [url_to_program(value.get('value').get('programUrl')) for value in list(self._data.values()) if value.get('value').get('isFavorite')]
+        return self._favorites.keys()
+
+    @staticmethod
+    def _generate_favorites_dict(favorites_json):
+        """Generate a simple favorites dict with programIds and programNames"""
+        favorites_dict = {}
+        for item in favorites_json.get(':items', []):
+            program_name = favorites_json.get(':items')[item].get('data').get('program').get('name')
+            program_id = favorites_json.get(':items')[item].get('data').get('program').get('id')
+            title = favorites_json.get(':items')[item].get('title')
+            favorites_dict[program_name] = dict(
+                program_id=program_id,
+                title=title)
+        return favorites_dict
 
     def manage(self):
         """Allow the user to unselect favorites to be removed from the listing"""
-        from utils import url_to_program
         self.refresh(ttl=0)
-        if not self._data:
+        if not self._favorites:
             ok_dialog(heading=localize(30418), message=localize(30419))  # No favorites found
             return
 
-        def by_title(item):
+        def by_title(tup):
             """Sort by title"""
-            return item.get('value').get('title')
+            _, value = tup
+            return value.get('title')
 
-        items = [dict(program=url_to_program(value.get('value').get('programUrl')),
-                      title=unquote(value.get('value').get('title')),
-                      enabled=value.get('value').get('isFavorite')) for value in list(sorted(list(self._data.values()), key=by_title))]
+        items = [dict(program_id=value.get('program_id'), program_name=key,
+                      title=unquote(value.get('title'))) for key, value in sorted(self._favorites.items(), key=by_title)]
         titles = [item['title'] for item in items]
-        preselect = [idx for idx in range(0, len(items) - 1) if items[idx]['enabled']]
+        preselect = list(range(0, len(items)))
         selected = multiselect(localize(30420), options=titles, preselect=preselect)  # Please select/unselect to follow/unfollow
         if selected is not None:
             for idx in set(preselect).difference(set(selected)):
-                self.unfollow(program=items[idx]['program'], title=items[idx]['title'])
+                self.unfollow(program_name=items[idx]['program_name'], title=items[idx]['title'], program_id=items[idx]['program_id'])
             for idx in set(selected).difference(set(preselect)):
-                self.follow(program=items[idx]['program'], title=items[idx]['title'])
+                self.follow(program_name=items[idx]['program_name'], title=items[idx]['title'], program_id=items[idx]['program_id'])

--- a/plugin.video.vrt.nu/resources/lib/kodiutils.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiutils.py
@@ -1218,7 +1218,7 @@ def get_cached_url_json(url, cache, headers=None, ttl=None, fail=None):  # pylin
 
 def refresh_caches(cache_file=None):
     """Invalidate the needed caches and refresh container"""
-    files = ['favorites.json', 'oneoff.json', 'resume_points.json', 'resume_points_ddt.json']
+    files = ['favorites.json', 'oneoff.json', 'resume_points.json', 'watchlater.json']
     if cache_file and cache_file not in files:
         files.append(cache_file)
     invalidate_caches(*files)

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -35,6 +35,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         self.path = None
         self.title = None
         self.ep_id = None
+        self.episode_id = None
+        self.episode_title = None
         self.video_id = None
         from random import randint
         self.thread_id = randint(1, 10001)
@@ -61,6 +63,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
         # Reset episode data
         self.video_id = None
+        self.episode_id = None
+        self.episode_title = None
         self.asset_str = None
         self.title = None
 
@@ -87,6 +91,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
         from metadata import Metadata
         self.video_id = episode.get('videoId') or None
+        self.episode_id = episode.get('episodeId') or None
+        self.episode_title = episode.get('title') or None
         self.asset_str = Metadata(None, None).get_asset_str(episode)
         self.title = episode.get('program')
 
@@ -282,5 +288,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
             title=self.title,
             position=position,
             total=total,
-            path=self.path
+            path=self.path,
+            episode_id=self.episode_id,
+            episode_title=self.episode_title
         )

--- a/plugin.video.vrt.nu/resources/lib/service.py
+++ b/plugin.video.vrt.nu/resources/lib/service.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 from xbmc import Monitor
 from apihelper import ApiHelper
 from favorites import Favorites
-from kodiutils import container_refresh, invalidate_caches, log
+from kodiutils import container_refresh, log
 from playerinfo import PlayerInfo
 from resumepoints import ResumePoints
 from tokenresolver import TokenResolver
@@ -67,8 +67,6 @@ class VrtMonitor(Monitor, object):  # pylint: disable=useless-object-inheritance
 
         log(1, 'Settings changed')
         TokenResolver().refresh_login()
-
-        invalidate_caches('continue-*.json', 'favorites.json', 'my-offline-*.json', 'my-recent-*.json', 'resume_points.json', 'watchlater-*.json')
 
         # Init watching activity again when settings change
         self.init_watching_activity()

--- a/plugin.video.vrt.nu/resources/lib/tokenresolver.py
+++ b/plugin.video.vrt.nu/resources/lib/tokenresolver.py
@@ -304,7 +304,9 @@ class TokenResolver:
         self.delete_tokens()
 
         # Delete user-related caches
-        invalidate_caches('continue-*.json', 'favorites.json', 'my-offline-*.json', 'my-recent-*.json', 'resume_points.json', 'watchlater-*.json')
+        invalidate_caches(
+            'continue-*.json', 'favorites.json', 'my-offline-*.json', 'my-recent-*.json',
+            'resume_points.json', 'watchlater.json', 'watchlater-*.json')
 
     def logged_in(self):
         """Whether there is an active login"""

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -172,9 +172,9 @@ def video_to_api_url(url):
     return url
 
 
-def program_to_id(program):
+def program_to_str(program):
     """Convert a program url component (e.g. de-campus-cup)
-        to a favorite program_id (e.g. vrtnuazdecampuscup), used for lookups in favorites dict"""
+        to a favorite program_str (e.g. vrtnuazdecampuscup), used for lookups in favorites dict"""
     return 'vrtnuaz' + program.replace('-', '')
 
 

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -180,7 +180,7 @@ class VRTPlayer:
         show_listing(favorites_items, category=30010, cache=False)  # My favorites
 
         # Show dialog when no favorites were found
-        if not self._favorites.titles():
+        if not self._favorites.programs():
             ok_dialog(heading=localize(30415), message=localize(30416))
 
     def show_favorites_docu_menu(self):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu

v2.4.5 (2021-02-05)
- Fix watching livestreams with DRM enabled
- Warn user that InputStream Adaptive is needed for timeshifting

v2.4.4 (2021-01-25)
- Fix watching VRT NU abroad

v2.4.3 (2021-01-21)
- Add new channel "Podium 19"
- Add livestream cache to speed up playback
- Use InputStream Adaptive to play HLS
- Don't log credentials in the Kodi debug log

v2.4.2 (2020-12-18)
- Fix missing seasons (for 'Thuis') in TV Show menu
- Fix missing favourite programs in 'My programs' menuu
- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
- Updated Categories menu
- Fix date parsing on Windows

v2.4.1 (2020-10-31)
- Add new category "Nostalgia"
- Add poster support
- Add product placement and "kijkwijzer" metadata
- Get categories from online JSON
- Improvements to connection error handling
- Improvements to virtual subclip support
- Extend soon offline menu to seven days
- Improve Up Next support
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
