### PR TITLE
[plugin.video.viervijfzes@leia] 0.4.6

### DIFF
--- a/plugin.video.viervijfzes/CHANGELOG.md
+++ b/plugin.video.viervijfzes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.4.6](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.6) (2022-02-02)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.5...v0.4.6)
+
+**Fixed bugs:**
+
+- Fix playback of DRM protected content [\#101](https://github.com/add-ons/plugin.video.viervijfzes/pull/101) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.4.5](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.5) (2021-10-21)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.4...v0.4.5)
@@ -15,12 +23,7 @@
 
 **Fixed bugs:**
 
-- Fix tests [\#94](https://github.com/add-ons/plugin.video.viervijfzes/pull/94) ([mediaminister](https://github.com/mediaminister))
 - Fix menu [\#93](https://github.com/add-ons/plugin.video.viervijfzes/pull/93) ([mediaminister](https://github.com/mediaminister))
-
-**Merged pull requests:**
-
-- Prepare for v0.4.4 [\#95](https://github.com/add-ons/plugin.video.viervijfzes/pull/95) ([mediaminister](https://github.com/mediaminister))
 
 ## [v0.4.3](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.3) (2021-04-24)
 
@@ -59,11 +62,6 @@
 
 - Fix error when requesting a My List that has not been created yet. [\#73](https://github.com/add-ons/plugin.video.viervijfzes/pull/73) ([michaelarnauts](https://github.com/michaelarnauts))
 
-**Merged pull requests:**
-
-- Cleanup CI [\#72](https://github.com/add-ons/plugin.video.viervijfzes/pull/72) ([michaelarnauts](https://github.com/michaelarnauts))
-- Remove dependency on tox [\#70](https://github.com/add-ons/plugin.video.viervijfzes/pull/70) ([michaelarnauts](https://github.com/michaelarnauts))
-
 ## [v0.4.0](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.0) (2021-02-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.3.1...v0.4.0)
@@ -72,12 +70,6 @@
 
 - Rebranding to GoPlay [\#64](https://github.com/add-ons/plugin.video.viervijfzes/pull/64) ([michaelarnauts](https://github.com/michaelarnauts))
 
-**Merged pull requests:**
-
-- Make use of git archive [\#66](https://github.com/add-ons/plugin.video.viervijfzes/pull/66) ([dagwieers](https://github.com/dagwieers))
-- Run CI on Windows [\#62](https://github.com/add-ons/plugin.video.viervijfzes/pull/62) ([michaelarnauts](https://github.com/michaelarnauts))
-- Add support for Python 3.9 [\#60](https://github.com/add-ons/plugin.video.viervijfzes/pull/60) ([michaelarnauts](https://github.com/michaelarnauts))
-
 ## [v0.3.1](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.3.1) (2020-11-28)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.3.0...v0.3.1)
@@ -85,10 +77,6 @@
 **Fixed bugs:**
 
 - Fix authentication on some older Android devices [\#58](https://github.com/add-ons/plugin.video.viervijfzes/pull/58) ([michaelarnauts](https://github.com/michaelarnauts))
-
-**Merged pull requests:**
-
-- Fix CI tests [\#59](https://github.com/add-ons/plugin.video.viervijfzes/pull/59) ([michaelarnauts](https://github.com/michaelarnauts))
 
 ## [v0.3.0](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.3.0) (2020-11-17)
 
@@ -108,11 +96,6 @@
 - Fix logging for Kodi Matrix [\#48](https://github.com/add-ons/plugin.video.viervijfzes/pull/48) ([michaelarnauts](https://github.com/michaelarnauts))
 - Opening some programs without a title could throw an error [\#45](https://github.com/add-ons/plugin.video.viervijfzes/pull/45) ([dagwieers](https://github.com/dagwieers))
 - Show message when Kodi Player fails to get the stream [\#40](https://github.com/add-ons/plugin.video.viervijfzes/pull/40) ([mediaminister](https://github.com/mediaminister))
-
-**Merged pull requests:**
-
-- Various fixes [\#46](https://github.com/add-ons/plugin.video.viervijfzes/pull/46) ([michaelarnauts](https://github.com/michaelarnauts))
-- Use sake for Kodi stubs [\#36](https://github.com/add-ons/plugin.video.viervijfzes/pull/36) ([michaelarnauts](https://github.com/michaelarnauts))
 
 ## [v0.2.0](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.2.0) (2020-06-19)
 
@@ -138,11 +121,6 @@
 - Fix multi-line text in progress dialog [\#21](https://github.com/add-ons/plugin.video.viervijfzes/pull/21) ([mediaminister](https://github.com/mediaminister))
 - Fix token encoding in auth [\#19](https://github.com/add-ons/plugin.video.viervijfzes/pull/19) ([michaelarnauts](https://github.com/michaelarnauts))
 
-**Merged pull requests:**
-
-- Check for unused translations [\#24](https://github.com/add-ons/plugin.video.viervijfzes/pull/24) ([michaelarnauts](https://github.com/michaelarnauts))
-- Move test/ to tests/ [\#17](https://github.com/add-ons/plugin.video.viervijfzes/pull/17) ([dagwieers](https://github.com/dagwieers))
-
 ## [v0.1.0](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.1.0) (2020-03-27)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/89f55f70b017d0add645d1e1d88f0ce8192d11c4...v0.1.0)
@@ -158,11 +136,7 @@
 
 **Merged pull requests:**
 
-- Improve CI tests [\#14](https://github.com/add-ons/plugin.video.viervijfzes/pull/14) ([michaelarnauts](https://github.com/michaelarnauts))
 - Small translation fixes [\#12](https://github.com/add-ons/plugin.video.viervijfzes/pull/12) ([dagwieers](https://github.com/dagwieers))
-- Various check fixes [\#11](https://github.com/add-ons/plugin.video.viervijfzes/pull/11) ([dagwieers](https://github.com/dagwieers))
-- Replace Travis with GitHub Actions [\#10](https://github.com/add-ons/plugin.video.viervijfzes/pull/10) ([michaelarnauts](https://github.com/michaelarnauts))
-- Improve code coverage [\#9](https://github.com/add-ons/plugin.video.viervijfzes/pull/9) ([michaelarnauts](https://github.com/michaelarnauts))
 
 
 

--- a/plugin.video.viervijfzes/LICENSE
+++ b/plugin.video.viervijfzes/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/plugin.video.viervijfzes/addon.xml
+++ b/plugin.video.viervijfzes/addon.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.5" provider-name="Michaël Arnauts">
+<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.6" provider-name="Michaël Arnauts">
     <requires>
-        <import addon="xbmc.python" version="2.26.0"/>
-        <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="script.module.inputstreamhelper" version="0.5.1"/>
-        <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.requests" version="2.22.0"/>
-        <import addon="script.module.routing" version="0.2.0"/>
+        <import addon="xbmc.python" version="2.26.0" />
+        <import addon="script.module.dateutil" version="2.6.0" />
+        <import addon="script.module.inputstreamhelper" version="0.5.1" />
+        <import addon="script.module.pysocks" version="1.6.8" optional="true" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.routing" version="0.2.0" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
     </extension>
-    <extension point="xbmc.service" library="service_entry.py"/>
+    <extension point="xbmc.service" library="service_entry.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="nl_NL">Bekijk programma's van Play4, Play5 en Play6.</summary>
         <description lang="nl_NL">Deze add-on geeft toegang tot de programma's die aangeboden worden op de websites van Play4, Play5 en Play6.</description>
@@ -21,8 +21,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by SBS Belgium and is provided 'as is' without any warranty of any kind. The Play4, Play5 and Play6 logos are property of SBS Belgium.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	    <news>v0.4.5 (2021-10-21)
-- Various fixes due to changes on the GoPlay website.</news>
+	    <news>v0.4.6 (2022-02-02)
+- Fix playback of DRM protected content.</news>
         <source>https://github.com/add-ons/plugin.video.viervijfzes</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.viervijfzes/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.viervijfzes/resources/lib/modules/iptvmanager.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import logging
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from resources.lib import kodiutils
 from resources.lib.viervijfzes import CHANNELS

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/aws/cognito_sync.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/aws/cognito_sync.py
@@ -15,6 +15,7 @@ try:  # Python 3
     from urllib.parse import quote, urlparse
 except ImportError:  # Python 2
     from urllib import quote
+
     from urlparse import urlparse
 
 _LOGGER = logging.getLogger(__name__)

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 import requests
 
-from resources.lib.kodiutils import html_to_kodi, STREAM_DASH, STREAM_HLS
+from resources.lib.kodiutils import STREAM_DASH, STREAM_HLS, html_to_kodi
 from resources.lib.viervijfzes import ResolvedStream
 
 try:  # Python 3
@@ -366,7 +366,7 @@ class ContentApi:
             drm_key = data['drmKey']['S']
 
             _LOGGER.debug('Fetching Authentication XML with drm_key %s', drm_key)
-            response_drm = self._get_url(self.API_GOPLAY + '/restricted/decode/%s' % drm_key, authentication=True)
+            response_drm = self._get_url(self.API_GOPLAY + '/video/xml/%s' % drm_key, authentication=True)
             data_drm = json.loads(response_drm)
 
             return ResolvedStream(

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/search.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/search.py
@@ -9,7 +9,7 @@ import logging
 import requests
 
 from resources.lib import kodiutils
-from resources.lib.viervijfzes.content import Program, ContentApi, CACHE_ONLY
+from resources.lib.viervijfzes.content import CACHE_ONLY, ContentApi, Program
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: GoPlay
  - Add-on ID: plugin.video.viervijfzes
  - Version number: 0.4.6
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.viervijfzes

Deze add-on geeft toegang tot de programma's die aangeboden worden op de websites van Play4, Play5 en Play6.

### What's new

v0.4.6 (2022-02-02)
- Fix playback of DRM protected content.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
