### PR TITLE
[plugin.video.cbc-sports] 1.0.4

### DIFF
--- a/plugin.video.cbc-sports/addon.xml
+++ b/plugin.video.cbc-sports/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.2" provider-name="Jbinkley60">
+<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.4" provider-name="Jbinkley60">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.beautifulsoup4" version="4.3.2"/>

--- a/plugin.video.cbc-sports/changelog.txt
+++ b/plugin.video.cbc-sports/changelog.txt
@@ -1,3 +1,11 @@
+Version 1.0.4
+
+-  Added another check / fix for improperly formatted time on the CBC Sports website
+
+Version 1.0.3
+
+-  Increased settings limit for CBC SPorts Archives from 150 to 500 items
+
 Version 1.0.2
 
 -  Added additional stream and video validation checking to eliminate Kodi playback errors.

--- a/plugin.video.cbc-sports/resources/lib/addon.py
+++ b/plugin.video.cbc-sports/resources/lib/addon.py
@@ -265,6 +265,7 @@ def VIDEOS(url):
 	    xbmc.log('CBC Sports VIDEOS name: ' + str(url), xbmc.LOGINFO)
 	if cbclog == 2:
 	    xbmc.log('CBC Sports VIDEOS data ' + str(jdata), xbmc.LOGDEBUG)
+	    #xbmc.log('CBC Sports VIDEOS data ' + str(jdata), xbmc.LOGINFO)
 	item_dict = jdata
 	count = len(item_dict['entries'])
 	for item in jdata['entries']:

--- a/plugin.video.cbc-sports/resources/lib/common.py
+++ b/plugin.video.cbc-sports/resources/lib/common.py
@@ -3,7 +3,8 @@ import time
 import xbmcgui, xbmcaddon, xbmcplugin, xbmc
 
 
-def timeConvert(orgtime):				#  Verify CBC Sports tiem format
+def timeConvert(orgtime):				#  Verify CBC Sports time format
+
 
     if len(orgtime) == 20 and orgtime[2] == '/' and orgtime[5] == '/' and orgtime[13] == ':':
         retime = orgtime
@@ -15,6 +16,9 @@ def timeConvert(orgtime):				#  Verify CBC Sports tiem format
         retime = retime[:5] + '/' + retime[5:]
     else:
         retime = 'invalid'
+
+    if int(orgtime[11:13]) > 24:
+        retime = 'invalid'     
 
     return(retime)
 

--- a/plugin.video.cbc-sports/resources/settings.xml
+++ b/plugin.video.cbc-sports/resources/settings.xml
@@ -54,6 +54,8 @@
 							<option>50</option>
 							<option>100</option>
 							<option>150</option>
+							<option>250</option>
+							<option>500</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>


### PR DESCRIPTION
Description

v1.0.4 is a minor update to increase the CBC Sports Archive setting limit from 150 to 500 items and add another time validation check for improperly formatted times on the CBC Sports website.

Get the latest headlines, opinion, and videos from CBC Sports. Watch live events, replays, and highlights. Some content blocked outside of Canada.

Checklist:

[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
[X ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
