### PR TITLE
[plugin.video.lbry] 0.1.9+leia.1

### DIFF
--- a/plugin.video.lbry/addon.xml
+++ b/plugin.video.lbry/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.lbry" name="LBRY" version="0.1.6+leia.1" provider-name="accumulator">
+<addon id="plugin.video.lbry" name="LBRY" version="0.1.9+leia.1" provider-name="accumulator">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.routing" version="0.2.3"/>


### PR DESCRIPTION
Bumps the addon version in Leia to the same revision as the one being pushed to Matrix to avoid confusion. See https://github.com/xbmc/repo-plugins/pull/3884

@accumulator looks like the author did not push the updates to Leia, as a result this doesn't seem to be necessary. Keeping it open in case you want to bump the addon version in Leia to keep it in sync with Matrix. If you don't see a need for this let me know and the PR will be closed. 

Cheers