### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2022.2.10+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.1.29+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.2.10+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />

--- a/plugin.video.nbcsnliveextra/nbcsn.py
+++ b/plugin.video.nbcsnliveextra/nbcsn.py
@@ -8,13 +8,12 @@ def categories():
     r = requests.get(CONFIG_URL, headers=headers, verify=VERIFY)
     json_source = r.json()
 
-    for item in json_source['brands']:
-        display_name = item['display-name']
+    for item in json_source['channelChanger']:
+        display_name = item['displayName']
         url = item['id']
         icon = item['channelChangerLogo']
-        if url != 'nbc-sports-gold' and url != 'sports-talk' and url != 'scores':
+        if url != 'nbc-sports-gold' and url != 'sports-talk' and url != 'scores' and url != 'rotoworld':
             add_dir(display_name, url, 2, icon, FANART)
-
 
 def get_sub_nav(id, icon):
     headers = {'User-Agent': UA_NBCSN}
@@ -22,23 +21,16 @@ def get_sub_nav(id, icon):
     r = requests.get(CONFIG_URL, headers=headers, verify=VERIFY)
     json_source = r.json()
 
-    for brand in json_source['brands']:
+    for brand in json_source['channelChanger']:
         if brand['id'] == id:
-            app_name = brand['chromecastApplicationName']
-            for sub_nav in brand['sub-nav']:
-                display_name = sub_nav['display-name']
-                status = sub_nav['id']
-                url = sub_nav['feed-url']
-                if '?application=' not in url and id != 'oly-channel':
-                    if status == 'live-upcoming': status = 'live'
-                    if status == 'replays': status = 'replay'
-                    url = 'https://api-leap.nbcsports.com/feeds/assets' \
-                          '?application=%s' \
-                          '&env=prod&format=v1' \
-                          '&platform=android&size=50&statuses=%s&sections=%s' % (app_name, status, id)
-                add_dir(display_name, url, 4, icon, FANART)
+            #app_name = brand['chromecastApplicationName']
+            for sub_nav in brand['subNav']:
+                display_name = sub_nav['displayName']
+                url = sub_nav['feedUrl']
+                url = url.replace('[PLATFORM]', 'android')
+                if '/feeds/' in url:
+                    add_dir(display_name, url, 4, icon, FANART)
             break
-
 
 def scrape_videos(url):
     headers = {

--- a/plugin.video.nbcsnliveextra/resources/lib/globals.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/globals.py
@@ -27,7 +27,7 @@ ROOTDIR = xbmcaddon.Addon().getAddonInfo('path')
 ICON = os.path.join(ROOTDIR,"icon.png")
 FANART = os.path.join(ROOTDIR,"fanart.jpg")
 ROOT_URL = 'http://stream.nbcsports.com/data/mobile'
-CONFIG_URL = 'http://stream.nbcsports.com/data/mobile/apps/NBCSports/configuration-android-v6.json'
+CONFIG_URL = 'https://stream.nbcsports.com/data/mobile/apps/NBCSports/configuration-vjs.json'
 
 # Main settings
 settings = xbmcaddon.Addon()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2022.2.10+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Fix playback failing by always setting inputstream license headers
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
