### PR TITLE
[plugin.video.orftvthek@leia] 0.12.4

### DIFF
--- a/plugin.video.orftvthek/addon.xml
+++ b/plugin.video.orftvthek/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.orftvthek" name="ORF TVthek" version="0.12.3" provider-name="sofaking">
+<addon id="plugin.video.orftvthek" name="ORF TVthek" version="0.12.4" provider-name="sofaking">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.future" version="0.17.1"/>
@@ -26,9 +26,8 @@
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>
         </assets>
-        <news>v0.12.3 (08/10/2021)
-            [fix] service api restart
-            [fix] service api auth change
+        <news>v0.12.4 (30/01/2022)
+            [fix] fixed drm content (license server error 500)
         </news>
     </extension>
 </addon>

--- a/plugin.video.orftvthek/changelog.txt
+++ b/plugin.video.orftvthek/changelog.txt
@@ -1,12 +1,14 @@
+* 0.12.4
+ - added header to drm license server request (fixes error 500 for drm content) 
+
+* 0.12.3-1
+ - bugfix livestream restart (kodi <19 only)
+ - removed quality setting
+ - livestream active bugfix
+
 * 0.12.3
  - service api fixes (auth & restart)
  - minor logging improvements
- 
-* 0.12.2
-- bumped python version to 2.26.0 (leia)
-- drm for restart
-- drm livestream license url
-- better quality selection handling for livestreams
 
 * 0.12.1
 - fixed schedule error (serviceapi) #102
@@ -33,7 +35,7 @@
 - python2/3 compatible
 - added 'play full video' for htmlscraper
 - show listitems are absolute now and can be added to favourites
-- minor fixes for serviceapi & htmlscraper 
+- minor fixes for serviceapi & htmlscraper
 
 0.9.2
 - fixed frontpage (new html markup)

--- a/plugin.video.orftvthek/resources/lib/Addon.py
+++ b/plugin.video.orftvthek/resources/lib/Addon.py
@@ -19,9 +19,9 @@ basepath = settings.getAddonInfo('path')
 translation = settings.getLocalizedString
 
 # hardcoded
-video_delivery_list = ["HLS", "Progressive"]
-video_quality_list = ["Q1A", "Q4A", "Q6A", "Q8C", "QXB"]
 videoProtocol = "http"
+videoQuality = "QXB"
+videoDelivery = "HLS"
 
 input_stream_protocol = 'mpd'
 input_stream_drm_version = 'com.widevine.alpha'
@@ -48,8 +48,6 @@ defaultbackdrop = os.path.join(media_path, "fanart_v2.jpg")
 
 # load settings
 useServiceAPI = Settings.serviceAPI()
-videoQuality = Settings.videoQuality(video_quality_list)
-videoDelivery = Settings.videoDelivery(video_delivery_list)
 autoPlayPrompt = Settings.autoPlayPrompt()
 usePlayAllPlaylist = Settings.playAllPlaylist()
 
@@ -205,7 +203,7 @@ def run():
             if is_helper.check_inputstream():
                 link = unqoute_url(link)
                 debugLog("Restart Source Link: %s" % link)
-                headers = "User-Agent=%s" % Settings.userAgent()
+                headers = "User-Agent=%s&Content-Type=text/xml" % Settings.userAgent()
                 if params.get('lic_url'):
                     lic_url = unqoute_url(params.get('lic_url'))
                     debugLog("Playing DRM protected Restart Stream")
@@ -218,7 +216,7 @@ def run():
                     play_item.setProperty('inputstream', is_helper.inputstream_addon)
                     play_item.setProperty('inputstream.adaptive.manifest_type', input_stream_protocol)
                     play_item.setProperty('inputstream.adaptive.license_type', input_stream_drm_version)
-                    play_item.setProperty('inputstream.adaptive.license_key', lic_url + '||R{SSM}|')
+                    play_item.setProperty('inputstream.adaptive.license_key', lic_url + '|' + headers + '|R{SSM}|')
                 else:
                     streaming_url, play_item = scraper.liveStreamRestart(link, 'hls')
                     debugLog("Playing Non-DRM protected Restart Stream")
@@ -226,9 +224,10 @@ def run():
                     play_item.setProperty('inputstream.adaptive.stream_headers', headers)
                     play_item.setProperty('inputstream.adaptive.manifest_type', 'hls')
                 debugLog("Restart Stream Url: %s; play_item: %s" % (streaming_url, play_item))
-                xbmcplugin.setResolvedUrl(pluginhandle, True, listitem=play_item)
-                listCallback(False, pluginhandle)
-                #xbmc.Player().play(streaming_url, play_item)
+                #This works on matrix. On Kodi <19 the stream wont play
+                #xbmcplugin.setResolvedUrl(pluginhandle, True, listitem=play_item)
+                #listCallback(False, pluginhandle)
+                xbmc.Player().play(streaming_url, play_item)
         except Exception as e:
             debugLog("Exception: %s" % ( e, ), xbmc.LOGDEBUG)
             debugLog("TB: %s" % ( traceback.format_exc(), ), xbmc.LOGDEBUG)
@@ -245,7 +244,7 @@ def run():
             import inputstreamhelper
             stream_url = unqoute_url(params.get('link'))
             lic_url = unqoute_url(params.get('lic_url'))
-            headers = "User-Agent=%s" % Settings.userAgent()
+            headers = "User-Agent=%s&Content-Type=text/xml" % Settings.userAgent()
             is_helper = inputstreamhelper.Helper(input_stream_protocol, drm=input_stream_drm_version)
             if is_helper.check_inputstream():
                 debugLog("Video Url: %s" % stream_url)
@@ -257,7 +256,7 @@ def run():
                 play_item.setProperty('inputstreamaddon', is_helper.inputstream_addon)
                 play_item.setProperty('inputstream.adaptive.manifest_type', input_stream_protocol)
                 play_item.setProperty('inputstream.adaptive.license_type', input_stream_drm_version)
-                play_item.setProperty('inputstream.adaptive.license_key', lic_url + '||R{SSM}|')
+                play_item.setProperty('inputstream.adaptive.license_key', lic_url + '|' + headers + '|R{SSM}|')
                 xbmcplugin.setResolvedUrl(pluginhandle, True, listitem=play_item)
                 listCallback(False, pluginhandle)
             else:

--- a/plugin.video.orftvthek/resources/lib/HtmlScraper.py
+++ b/plugin.video.orftvthek/resources/lib/HtmlScraper.py
@@ -740,13 +740,15 @@ class htmlScraper(Scraper):
         section = parseDOM(wrapper, name='section', attrs={'class': 'b-live-program.*?'})
         items = parseDOM(section, name='li', attrs={'class': 'channel orf.*?'})
 
+        if items:
+            debugLog("Found %d Livestream Channels" % len(items))
         for item in items:
             channel = parseDOM(item, name='img', attrs={'class': 'channel-logo'}, ret="alt")
             channel = replaceHTMLCodes(channel[0])
 
             debugLog("Processing %s Livestream" % channel)
             bundesland_article = parseDOM(item, name='li', attrs={'class': '.*?is-bundesland-heute.*?'}, ret='data-jsb')
-            article = parseDOM(item, name='article', attrs={'class': 'b-livestream-teaser is-live.*?'})
+            article = parseDOM(item, name='article', attrs={'class': 'b-livestream-teaser.*?'})
             if not len(bundesland_article) and len(article):
                 figure = parseDOM(article, name='figure', attrs={'class': 'teaser-img'}, ret=False)
                 image = parseDOM(figure, name='img', attrs={}, ret='data-src')

--- a/plugin.video.orftvthek/resources/lib/Settings.py
+++ b/plugin.video.orftvthek/resources/lib/Settings.py
@@ -27,24 +27,6 @@ def userAgent():
     return __addon__.getSetting('userAgent')
 
 
-def videoQuality(quality_list):
-    default_return_index = 2
-    videoQuality = __addon__.getSetting('videoQuality')
-    try:
-        return quality_list[int(videoQuality)]
-    except (IndexError, ValueError):
-        return quality_list[default_return_index]
-
-
-def videoDelivery(delivery_list):
-    default_return_index = 0
-    if serviceAPI():
-        videoDeliveryProgressive = __addon__.getSetting('videoDeliveryProgressive')
-        if videoDeliveryProgressive == "true":
-            return delivery_list[1]
-    return delivery_list[default_return_index]
-
-
 def autoPlayPrompt():
     return __addon__.getSetting("autoPlayPrompt") == "true"
 

--- a/plugin.video.orftvthek/resources/settings.xml
+++ b/plugin.video.orftvthek/resources/settings.xml
@@ -5,10 +5,8 @@
         <setting id="useSubtitles" type="bool" label="30029" default="false" />
         <setting id="enableBlacklist" type="bool" label="30043" visible="eq(1,false)" default="false" />
         <setting id="useServiceAPI" type="bool" label="30026" default="false" />
-        <setting id="videoDeliveryProgressive" label="30056" type="bool" visible="eq(-1,true)" default="false" />
-        <setting id="showLiveStreamSchedule" label="30061" type="bool" visible="eq(-2,true)" default="false" />
+        <setting id="showLiveStreamSchedule" label="30061" type="bool" visible="eq(-1,true)" default="false" />
         <setting id="usePlayAllPlaylist" label="30058" type="bool" default="true" />
-        <setting id="videoQuality" type="enum"  label="30022" lvalues="30023|30024|30025|30044|30053" default="3"/>
         <setting id="userAgent" default="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36" visible="false" />
     </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: ORF TVthek
  - Add-on ID: plugin.video.orftvthek
  - Version number: 0.12.4
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/s0faking/plugin.video.orftvthek
  
ORF TVthek - This plugin provides access to the Austrian "ORF TVthek"

### Description of changes:

v0.12.4 (30/01/2022)
            [fix] fixed drm content (license server error 500)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
