### PR TITLE
[plugin.video.rtpplay@matrix] 6.0.1

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.0" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.1" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -22,11 +22,8 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            Version 6.0.0 (16/10/2021)
-                - Drop python 2 support (@guipenedo) - The addon will be only available for matrix and up
-                - New version based on the mobile api (@guipenedo)
-                - Cleanup estudoemcasa (@enen92)
-                - Fix paginated search (@enen92)
+            Version 6.0.1 (17/04/2022)
+                - Fixed auth after mobile api changes (@guipenedo)
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/lib/rtpplayapi/api.py
+++ b/plugin.video.rtpplay/resources/lib/rtpplayapi/api.py
@@ -30,7 +30,7 @@ class RTPPlayAPI:
         return RTPPlayConfig(r)
 
     def __get_key(self, current_time_millis):
-        RTP_PLAY_AUTH_KEY = "bdaafc5451445b65a10dc615e63d7ffe"
+        RTP_PLAY_AUTH_KEY = "KlWSOwcxTqIHrXQvqYLSaVmTkaoCh28I"
         key = ""
         i = 0
         for j in range(len(RTP_PLAY_AUTH_KEY)):
@@ -60,11 +60,12 @@ class RTPPlayAPI:
         current_time_millis = str(round(time.time() * 1000))
         key = self.__get_key(current_time_millis)
         msg = current_time_millis + self.config.AUTH_URL_ENDPOINT
-        headers = {'RTP-Play-Auth': 'RTPPLAY_MOBILE_ANDROID',
+        headers = {'RTP-Play-Auth': 'MOBILE_ANDROID_RTPPLAY_UPDATE',
                    'RTP-Play-Auth-Hash': self.__encode(key, msg),
-                   'RTP-Play-Auth-Timestamp': current_time_millis}
+                   'RTP-Play-Auth-Timestamp': current_time_millis,
+                   'User-Agent': 'okhttp/3.12.8'}
         logger.debug("Token headers:", headers)
-        r = requests.post(self.config.AUTH_URL_ENDPOINT, headers=headers).json()
+        r = requests.get(self.config.AUTH_URL_ENDPOINT, headers=headers).json()
         if "error" not in r:
             self.AUTH_TOKEN = r["token"]["token"]
             self.AUTH_TOKEN_LIFETIME = r["token"]["expire"] * 1000
@@ -81,7 +82,8 @@ class RTPPlayAPI:
             # unable to fetch token
             return
         headers = {'Authorization': 'Bearer ' + self.AUTH_TOKEN,
-                   'RTP-Play-Auth-Timestamp': str(current_time_millis)}
+                   'RTP-Play-Auth-Timestamp': str(current_time_millis),
+                   'User-Agent': 'okhttp/3.12.8'}
         logger.debug(url)
         r = requests.get(self.config.BASE_API_URL_ENDPOINT + url, headers=headers).json()
         if "error" not in r or r["error"] != "Not Authenticated" or not retry:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 6.0.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 6.0.1 (17/04/2022)
                - Fixed auth after mobile api changes (@guipenedo)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
