### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.9

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.9 (2022-04-20)
+- Fix broken menu listings (@mediaminister)
+
 ### v2.5.8 (2022-04-14)
 - Fix watching VRT NU abroad (@mediaminister)
 - Fix webscraping video attributes (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.8" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.9" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.9 (2022-04-20)
+- Fix broken menu listings
+
 v2.5.8 (2022-04-14)
 - Fix watching VRT NU abroad
 - Fix webscraping video attributes
@@ -73,36 +76,6 @@ v2.5.1 (2021-04-07)
 
 v2.5.0 (2021-03-29)
 - Add new categories to featured menu
-
-v2.4.5 (2021-02-05)
-- Fix watching livestreams with DRM enabled
-- Warn user that InputStream Adaptive is needed for timeshifting
-
-v2.4.4 (2021-01-25)
-- Fix watching VRT NU abroad
-
-v2.4.3 (2021-01-21)
-- Add new channel "Podium 19"
-- Add livestream cache to speed up playback
-- Use InputStream Adaptive to play HLS
-- Don't log credentials in the Kodi debug log
-
-v2.4.2 (2020-12-18)
-- Fix missing seasons (for 'Thuis') in TV Show menu
-- Fix missing favourite programs in 'My programs' menuu
-- Allow IPTV Manager and Kodi Logfile Uploader installation from add-on settingsu
-- Updated Categories menu
-- Fix date parsing on Windows
-
-v2.4.1 (2020-10-31)
-- Add new category "Nostalgia"
-- Add poster support
-- Add product placement and "kijkwijzer" metadata
-- Get categories from online JSON
-- Improvements to connection error handling
-- Improvements to virtual subclip support
-- Extend soon offline menu to seven days
-- Improve Up Next support
     </news>
     <assets>
       <icon>resources/media/icon.png</icon>

--- a/plugin.video.vrt.nu/resources/lib/favorites.py
+++ b/plugin.video.vrt.nu/resources/lib/favorites.py
@@ -175,7 +175,7 @@ class Favorites:
 
     def programs(self):
         """Return all favorite programs"""
-        return self._favorites.keys()
+        return list(self._favorites.keys())
 
     @staticmethod
     def _generate_favorites_dict(favorites_json):
@@ -203,7 +203,7 @@ class Favorites:
             return value.get('title')
 
         items = [dict(program_id=value.get('program_id'), program_name=key,
-                      title=unquote(value.get('title'))) for key, value in sorted(self._favorites.items(), key=by_title)]
+                      title=unquote(value.get('title'))) for key, value in sorted(list(self._favorites.items()), key=by_title)]
         titles = [item['title'] for item in items]
         preselect = list(range(0, len(items)))
         selected = multiselect(localize(30420), options=titles, preselect=preselect)  # Please select/unselect to follow/unfollow

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -81,7 +81,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
                 return
 
         # Get episode data needed to update resumepoints from VRT NU Search API
-        episode = self.apihelper.get_single_episode_data(video_id=ep_id.get('video_id'), whatson_id=ep_id.get('whatson_id'), video_url=ep_id.get('video_url'))
+        # FIXME: Getting single episode data is broken, VRT NU Search API return a http error 400
+        # episode = self.apihelper.get_single_episode_data(video_id=ep_id.get('video_id'), whatson_id=ep_id.get('whatson_id'), video_url=ep_id.get('video_url'))
+        episode = None
 
         # Avoid setting resumepoints without episode data
         if episode is None:

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -57,6 +57,8 @@ def strip_newlines(text):
 
 def html_to_kodi(text):
     """Convert VRT HTML content into Kodi formatted text"""
+    if text is None:
+        return ''
     for key, val in HTML_MAPPING:
         text = key.sub(val, text)
     return unescape(text).strip()

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -248,7 +248,7 @@ class VRTPlayer:
                 media = self._apihelper.get_featured_media_from_web(feature.split('jcr_')[1])
                 if media.get('mediatype') == 'episodes':
                     variety = 'featured.{name}'.format(name=media.get('name').strip().lower().replace(' ', '_'))
-                    media_items, sort, ascending, content = self._apihelper.list_episodes(whatson_id=media.get('medialist'), variety=variety)
+                    media_items, sort, ascending, content = self._apihelper.list_episodes(episode_id=media.get('medialist'), variety=variety)
                 elif media.get('mediatype') == 'tvshows':
                     feature = None
                     media_items = self._apihelper.list_tvshows(feature=feature, programs=media.get('medialist'))
@@ -306,7 +306,7 @@ class VRTPlayer:
         self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         page = realpage(page)
         items_per_page = get_setting_int('itemsperpage', default=50)
-        sort_key = 'assetOffTime'
+        sort_key = 'offTime'
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, items_per_page=items_per_page, use_favorites=use_favorites,
                                                                                 variety='offline', sort_key=sort_key)
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.9
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
