### PR TITLE
[plugin.video.mlbtv@krypton] 2022.4.19

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.4.12" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.4.19" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.pytz" />
@@ -7,6 +7,7 @@
         <import addon="script.module.requests" />
         <import addon="inputstream.adaptive" optional="true"/>
         <import addon="script.module.kodi-six" />
+        <import addon="script.module.dateutil" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
@@ -20,7 +21,15 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - Fix game icon and fanart
+            - featured videos, including Big Inning
+            - audio-only streams
+            - unique game icons
+            - probable pitchers
+            - doubleheader/TBD start times
+            - restored "play all recaps" behavior when selecting date
+            - moved more text to language localization file
+            - additional AddonIsEnabled detection for inputstream adaptive
+            - code cleanup
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -9,6 +9,7 @@ gid = None
 teams_stream = None
 stream_date = None
 spoiler = 'True'
+featured_video = None
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -30,6 +31,9 @@ if 'stream_date' in params:
 
 if 'spoiler' in params:
     spoiler = urllib.unquote_plus(params["spoiler"])
+
+if 'featured_video' in params:
+    featured_video = urllib.unquote_plus(params["featured_video"])
 
 if mode is None:
     categories()
@@ -67,18 +71,22 @@ elif mode == 200:
 
         sys.exit()
 
+elif mode == 300:
+    # Featured Videos
+    featured_videos(featured_video)
+
+elif mode == 301:
+    featured_stream_select(featured_video, name)
+
 elif mode == 400:
     account = Account()
     account.logout()
     dialog = xbmcgui.Dialog()
     dialog.notification(LOCAL_STRING(30260), LOCAL_STRING(30261), ICON, 5000, False)
 
-elif mode == 500:
-    myTeamsGames()
-
 elif mode == 900:
-    getGamesForDate(stream_date)
-    playAllHighlights()
+    # play all recaps or condensed games for selected date
+    playAllHighlights(stream_date)
 
 elif mode == 999:
     sys.exit()

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -180,12 +180,24 @@ msgctxt "#30362"
 msgid "Goto Date"
 msgstr ""
 
+msgctxt "#30363"
+msgid "Featured Videos"
+msgstr ""
+
 msgctxt "#30365"
 msgid "Invalid Date"
 msgstr ""
 
 msgctxt "#30366"
 msgid "The date entered is not in the format required."
+msgstr ""
+
+msgctxt "#30367"
+msgid "MLB Big Inning"
+msgstr ""
+
+msgctxt "#30369"
+msgid "Big Inning may require inputstream adaptive to be enabled, or Kodi version 19+, to stream live properly"
 msgstr ""
 
 msgctxt "#30370"
@@ -201,7 +213,7 @@ msgid "Choose Stream Quality"
 msgstr ""
 
 msgctxt "#30375"
-msgid "Watch all the days highlights for "
+msgid "Watch all the day's highlights for "
 msgstr ""
 
 msgctxt "#30380"
@@ -224,4 +236,51 @@ msgctxt "#30384"
 msgid "No playable streams found"
 msgstr ""
 
+msgctxt "#30390"
+msgid "Choose Stream"
+msgstr ""
+
+msgctxt "#30391"
+msgid "Highlights"
+msgstr ""
+
+msgctxt "#30392"
+msgid " TV"
+msgstr ""
+
+msgctxt "#30393"
+msgid " Radio"
+msgstr ""
+
+msgctxt "#30394"
+msgid ""
+msgstr ""
+
+msgctxt "#30395"
+msgid " Spanish"
+msgstr ""
+
+msgctxt "#30396"
+msgid "Select a Start Point"
+msgstr ""
+
+msgctxt "#30398"
+msgid "Beginning"
+msgstr ""
+
+msgctxt "#30399"
+msgid "Live"
+msgstr ""
+
+msgctxt "#30400"
+msgid "View All"
+msgstr ""
+
+msgctxt "#30401"
+msgid "Recaps"
+msgstr ""
+
+msgctxt "#30402"
+msgid "Condensed Games"
+msgstr ""
 

--- a/plugin.video.mlbtv/resources/lib/account.py
+++ b/plugin.video.mlbtv/resources/lib/account.py
@@ -3,6 +3,8 @@ from resources.lib.utils import Util
 from resources.lib.globals import *
 from kodi_six import xbmc, xbmcaddon, xbmcgui
 import time, uuid
+import random
+import string
 
 if sys.version_info[0] > 2:
     from urllib.parse import quote
@@ -77,6 +79,10 @@ class Account:
         self.addon.setSetting('last_login', '')
         self.addon.setSetting('username', '')
         self.addon.setSetting('password', '')
+        self.addon.setSetting('okta_client_id', '')
+        self.addon.setSetting('session_token', '')
+        self.addon.setSetting('okta_access_token', '')
+        self.addon.setSetting('okta_access_token_expiry', '')
 
     def media_entitlement(self):
         if self.addon.getSetting('last_login') == '' or \
@@ -91,6 +97,145 @@ class Account:
         r = requests.get(url, headers=headers, verify=self.verify)
 
         return r.text
+
+    # the okta client id is used to get an okta access token (for featured videos like Big Inning)
+    # doesn't change, can be cached until logout
+    def okta_client_id(self):
+        if self.addon.getSetting('okta_client_id') == '':
+            xbmc.log('fetching okta_client_id')
+            url = 'https://www.mlbstatic.com/mlb.com/vendor/mlb-okta/mlb-okta.js'
+            headers = {
+                'User-Agent': UA_PC,
+                'Origin': 'https://www.mlb.com'
+            }
+
+            r = requests.get(url, headers=headers, verify=self.verify)
+            e = re.search('production:{clientId:"([^"]+)",', r.text)
+            if e:
+                xbmc.log('found okta_client_id')
+                okta_client_id = e.group(1)
+                xbmc.log('okta_client_id: ' + okta_client_id)
+                self.addon.setSetting(id='okta_client_id', value=okta_client_id)
+                return okta_client_id
+        else:
+            return self.addon.getSetting('okta_client_id')
+
+    # the session token is used to get an okta access token (for featured videos like Big Inning)
+    # doesn't change much, can be cached until logout or until reset by okta_access_token function as needed
+    def session_token(self):
+        xbmc.log('requesting new session_token')
+
+        # Check if username and password are provided
+        if self.username == '':
+            dialog = xbmcgui.Dialog()
+            self.username = dialog.input(LOCAL_STRING(30240), type=xbmcgui.INPUT_ALPHANUM)
+            self.addon.setSetting(id='username', value=self.username)
+
+        if self.password == '':
+            dialog = xbmcgui.Dialog()
+            self.password = dialog.input(LOCAL_STRING(30250), type=xbmcgui.INPUT_ALPHANUM,
+                                    option=xbmcgui.ALPHANUM_HIDE_INPUT)
+            self.addon.setSetting(id='password', value=self.password)
+
+        if self.username == '' or self.password == '':
+            sys.exit()
+        else:
+            url = 'https://ids.mlb.com/api/v1/authn'
+            headers = {
+                'User-Agent': UA_PC,
+                'Accept-Encoding': 'identity',
+                'Content-Type': 'application/json'
+            }
+            data = {
+              'username': self.username,
+              'password': self.password,
+              'options': {
+                'multiOptionalFactorEnroll': False,
+                'warnBeforePasswordExpired': True
+              }
+            }
+            r = requests.post(url, headers=headers, json=data, verify=self.verify)
+            xbmc.log(r.text)
+            if 'sessionToken' in r.json():
+                xbmc.log('found session_token')
+                session_token = r.json()['sessionToken']
+                self.addon.setSetting(id='session_token', value=session_token)
+
+    # generate a random string of specified length, using numbers and uppercase letters
+    # used for two variables in okta access token request
+    def get_random_string(self, length):
+        characters = string.ascii_uppercase + string.digits
+        result_str = ''.join(random.choice(characters) for i in range(length))
+        return result_str
+
+    # the okta access token is used to access featured videos like Big Inning
+    # can be cached until the specified expiry
+    def okta_access_token(self, retry=False):
+        # log in first, if needed
+        if self.addon.getSetting('last_login') == '' or \
+                (time.time() - float(self.addon.getSetting('last_login')) >= 86400):
+            self.login()
+        # check if we don't have it cached, or the cache has expired
+        if self.addon.getSetting('okta_access_token') == '' or \
+                parse(self.addon.getSetting('okta_access_token_expiry')) < datetime.now():
+            xbmc.log('okta access token not set or expired')
+            # check if we have a cached session token (shouldn't expire often)
+            if self.addon.getSetting('session_token') == '':
+                self.session_token()
+
+            url = 'https://ids.mlb.com/oauth2/aus1m088yK07noBfh356/v1/authorize'
+            xbmc.log('url : ' + url)
+            headers = {
+                'User-Agent': UA_PC,
+                'accept-encoding': 'identity'
+            }
+            data = {
+                'client_id': self.okta_client_id(),
+                'redirect_uri': 'https://www.mlb.com/login',
+                'response_type': 'id_token token',
+                'response_mode': 'okta_post_message',
+                'state': self.get_random_string(64),
+                'nonce': self.get_random_string(64),
+                'prompt': 'none',
+                'sessionToken': self.addon.getSetting('session_token'),
+                'scope': 'openid email'
+            }
+            r = requests.get(url, headers=headers, params=data, verify=self.verify)
+            # check if the response indicates we need a new session token
+            e = re.search("data.error = 'login_required'", r.text)
+            if e:
+                # if this is our second try, and we're still getting this error, just abort
+                if retry == True:
+                    xbmc.log('log in error, aborting')
+                    sys.exit()
+                else:
+                    xbmc.log('not logged in, trying again')
+                    self.addon.setSetting(id='session_token', value='')
+                    okta_access_token = self.okta_access_token(True)
+            else:
+                xbmc.log('logged in')
+                e = re.search("data.access_token = '([^']+)'", r.text)
+                if e:
+                    xbmc.log('found token')
+                    # new token response likely contains a hyphen that needs to be decoded/un-escaped
+                    okta_access_token = e.group(1).replace('\\x2D', '-')
+                    xbmc.log('token result: ' + okta_access_token)
+                    self.addon.setSetting(id='okta_access_token', value=okta_access_token)
+                    # default token expiry is 86400 seconds (24 hours)
+                    okta_access_token_expires_in = '86400'
+                    e = re.search("data.expires_in = '([^']+)'", r.text)
+                    if e:
+                        xbmc.log('found expiry')
+                        okta_access_token_expires_in = e.group(1)
+                        xbmc.log('expires in: ' + okta_access_token_expires_in)
+                    okta_access_token_expiry = datetime.now() + timedelta(seconds=int(okta_access_token_expires_in))
+                    xbmc.log('expiry: ' + str(okta_access_token_expiry))
+                    self.addon.setSetting(id='okta_access_token_expiry', value=str(okta_access_token_expiry))
+        else:
+            # cached token response likely contains a hyphen that needs to be decoded/un-escaped
+            okta_access_token = self.addon.getSetting('okta_access_token').replace('\\x2D', '-')
+
+        return okta_access_token
 
     def access_token(self):
         url = 'https://us.edge.bamgrid.com/token'

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -6,6 +6,8 @@ def categories():
     addDir(LOCAL_STRING(30360), 100, ICON, FANART)
     addDir(LOCAL_STRING(30361), 105, ICON, FANART)
     addDir(LOCAL_STRING(30362), 200, ICON, FANART)
+    # show Featured Videos in the main menu
+    addDir(LOCAL_STRING(30363), 300, ICON, FANART)
 
 
 def todays_games(game_day):
@@ -24,11 +26,12 @@ def todays_games(game_day):
 
     addPlaylist(date_display, str(game_day), 900, ICON, FANART)
 
-    # addPlaylist(date_display,display_day,'/playhighlights',999,ICON,FANART)
+    if ONLY_FREE_GAMES != 'true':
+        create_big_inning_listitem(game_day)
 
     #url = 'http://gdx.mlb.com/components/game/mlb/' + url_game_day + '/grid_ce.json'
     url = 'https://statsapi.mlb.com/api/v1/schedule'
-    url += '?hydrate=broadcasts(all),game(content(all)),linescore,team'
+    url += '?hydrate=broadcasts(all),game(content(all)),probablePitcher,linescore,team'
     url += '&sportId=1,51'
     url += '&date=' + game_day
 
@@ -38,11 +41,6 @@ def todays_games(game_day):
     xbmc.log(url)
     r = requests.get(url,headers=headers, verify=VERIFY)
     json_source = r.json()
-
-    global RECAP_PLAYLIST
-    global EXTENDED_PLAYLIST
-    RECAP_PLAYLIST.clear()
-    EXTENDED_PLAYLIST.clear()
 
     try:
         for game in json_source['dates'][0]['games']:
@@ -55,7 +53,8 @@ def todays_games(game_day):
 
 
 def create_game_listitem(game, game_day):
-    icon = ICON
+    #icon = ICON
+    icon = 'https://img.mlbstatic.com/mlb-photos/image/upload/ar_167:215,c_crop/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':fill:spot.png,w_1.0,h_1,x_0.5,y_0,fl_no_overflow,e_distort:100p:0:200p:0:200p:100p:0:100p/fl_relative,l_team:' + str(game['teams']['away']['team']['id']) + ':logo:spot:current,w_0.38,x_-0.25,y_-0.16/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':logo:spot:current,w_0.38,x_0.25,y_0.16/w_750/team/' + str(game['teams']['away']['team']['id']) + '/fill/spot.png'
     # http://mlb.mlb.com/mlb/images/devices/ballpark/1920x1080/2681.jpg
     # B&W
     # fanart = 'http://mlb.mlb.com/mlb/images/devices/ballpark/1920x1080/'+game['venue_id']+'.jpg'
@@ -88,14 +87,17 @@ def create_game_listitem(game, game_day):
     game_time = ''
     #if game['status']['abstractGameState'] == 'Preview':
     if game['status']['detailedState'].lower() == 'scheduled' or game['status']['detailedState'].lower() == 'pre-game':
-        game_time = game['gameDate']
-        game_time = stringToDate(game_time, "%Y-%m-%dT%H:%M:%SZ")
-        game_time = UTCToLocal(game_time)
-
-        if TIME_FORMAT == '0':
-            game_time = game_time.strftime('%I:%M %p').lstrip('0')
+        if game['status']['startTimeTBD'] == True:
+            game_time = 'TBD'
         else:
-            game_time = game_time.strftime('%H:%M')
+            game_time = game['gameDate']
+            game_time = stringToDate(game_time, "%Y-%m-%dT%H:%M:%SZ")
+            game_time = UTCToLocal(game_time)
+
+            if TIME_FORMAT == '0':
+                game_time = game_time.strftime('%I:%M %p').lstrip('0')
+            else:
+                game_time = game_time.strftime('%H:%M')
 
         game_time = colorString(game_time, UPCOMING)
 
@@ -139,6 +141,19 @@ def create_game_listitem(game, game_day):
     stream_date = str(game_day)
 
     desc = ''
+    if 'probablePitcher' in game['teams']['away'] and 'fullName' in game['teams']['away']['probablePitcher']:
+        desc += game['teams']['away']['probablePitcher']['fullName']
+    else:
+        desc += 'TBD'
+    desc += ' vs. '
+    if 'probablePitcher' in game['teams']['home'] and 'fullName' in game['teams']['home']['probablePitcher']:
+        desc += game['teams']['home']['probablePitcher']['fullName']
+    else:
+        desc += 'TBD'
+    if 'venue' in game and 'name' in game['venue']:
+        desc += ', from ' + game['venue']['name']
+    if 'description' in game and game['description'] != "":
+        desc += ' (' + game['description'] + ')'
     spoiler = 'True'
     if NO_SPOILERS == '1' or (NO_SPOILERS == '2' and fav_game) or (NO_SPOILERS == '3' and game_day == localToEastern()) or (NO_SPOILERS == '4' and game_day < localToEastern()) or game['status']['abstractGameState'] == 'Preview':
         spoiler = 'False'
@@ -148,10 +163,9 @@ def create_game_listitem(game, game_day):
         if 'linescore' in game: name += ' ' + colorString(str(game['linescore']['teams']['away']['runs']), SCORE_COLOR)
         name += ' at ' + home_team
         if 'linescore' in game: name += ' ' + colorString(str(game['linescore']['teams']['home']['runs']), SCORE_COLOR)
-        try:
-            desc = game['content']['editorial']['recap']['mlb']['headline']
-        except:
-            pass
+
+    if game['doubleHeader'] != 'N':
+        name += ' (Game ' + str(game['gameNumber']) + ')'
 
     name = name
     if fav_game:
@@ -166,32 +180,183 @@ def create_game_listitem(game, game_day):
         pass
 
 
-    # Set audio/video info based on stream quality setting
+    # Get audio/video info
     audio_info, video_info = getAudioVideoInfo()
     # 'duration':length
     info = {'plot': desc, 'tvshowtitle': 'MLB', 'title': title, 'originaltitle': title, 'aired': game_day, 'genre': LOCAL_STRING(700), 'mediatype': 'video'}
 
-    # Create Playlist for the days recaps and condensed
-    """
-    teams_stream = game['teams']['away']['team']['teamCode'] + game['teams']['home']['team']['teamCode']
-    try:
-        recap_url, condensed_url = get_highlight_links(teams_stream, stream_date)
-        global RECAP_PLAYLIST
-        listitem = xbmcgui.ListItem(title, thumbnailImage=icon)
-        listitem.setInfo(type="Video", infoLabels={"Title": title})
-        RECAP_PLAYLIST.add(recap_url, listitem)
-
-        global EXTENDED_PLAYLIST
-        listitem = xbmcgui.ListItem(title, thumbnailImage=icon)
-        listitem.setInfo(type="Video", infoLabels={"Title": title})
-        EXTENDED_PLAYLIST.add(condensed_url, listitem)
-    except:
-        pass
-    """
     # If set only show free games in the list
     if ONLY_FREE_GAMES == 'true' and not game['content']['media']['freeGame']:
         return 
     add_stream(name, title, game_pk, icon, fanart, info, video_info, audio_info, stream_date, spoiler)
+
+
+# fetch a list of featured videos
+def get_video_list(list_url=None):
+    # use the Featured on MLB.TV list (included Big Inning) if no list is specified
+    if list_url == None:
+        list_url = 'https://dapi.cms.mlbinfra.com/v2/content/en-us/sel-mlbtv-featured-svod-video-list'
+
+    headers = {
+        'User-Agent': UA_PC,
+        'Origin': 'https://www.mlb.com',
+        'Referer': 'https://www.mlb.com',
+        'Content-Type': 'application/json'
+    }
+    r = requests.get(list_url, headers=headers, verify=VERIFY)
+    json_source = r.json()
+    return json_source
+
+
+# display a list of featured videos
+def featured_videos(featured_video=None):
+    # if no list is specified, use the master list of lists
+    if featured_video == None:
+        featured_video = 'https://mastapi.mobile.mlbinfra.com/api/video/v1/playlist'
+
+    video_list = get_video_list(featured_video)
+    if 'items' in video_list:
+        for item in video_list['items']:
+            #xbmc.log(str(item))
+            if 'title' in item:
+                title = item['title']
+                liz=xbmcgui.ListItem(title)
+                liz.setInfo( type="Video", infoLabels={ "Title": title } )
+
+                # check if a video url is provided
+                if 'fields' in item:
+                    video_url = None
+                    if 'playbackScenarios' in item['fields']:
+                        for playback in item['fields']['playbackScenarios']:
+                            if playback['playback'] == 'hlsCloud':
+                                video_url = playback['location']
+                                break
+                    elif 'url' in item['fields']:
+                        video_url = item['fields']['url']
+                    if video_url is not None:
+                        xbmc.log('video url : ' + video_url)
+                        if 'thumbnail' in item and 'thumbnailUrl' in item['thumbnail']:
+                            thumbnail = item['thumbnail']['thumbnailUrl']
+                            # modify thumnail URL for use as icon and fanart
+                            icon = thumbnail.replace('w_250,h_250,c_thumb,g_auto,q_auto,f_jpg', 't_16x9/t_w1080')
+                            fanart = thumbnail.replace('w_250,h_250,c_thumb,g_auto,q_auto,f_jpg', 'g_auto,c_fill,ar_16:9,q_60,w_1920/e_gradient_fade:15,x_0.6,b_black')
+                        else:
+                            icon = ICON
+                            fanart = FANART
+                        liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
+                        liz.setProperty("IsPlayable", "true")
+                        u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(video_url)+"&name="+urllib.quote_plus(title)
+                        isFolder=False
+                # if no video url is provided, we assume it is just another list
+                else:
+                    list_url = item['url']
+                    xbmc.log('list url : ' + list_url)
+                    if list_url == "":
+                        continue
+                    u=sys.argv[0]+"?mode="+str(300)+"&featured_video="+urllib.quote_plus(list_url)
+                    isFolder=True
+
+                xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=isFolder)
+                xbmcplugin.setContent(addon_handle, 'episodes')
+
+        # if it's a long list, display a "Next" link if provided
+        if 'pagination' in video_list and 'nextUrl' in video_list['pagination']:
+            title = '[B]%s >>[/B]' % LOCAL_STRING(30011)
+            liz=xbmcgui.ListItem(title)
+            liz.setInfo( type="Video", infoLabels={ "Title": title } )
+            list_url = video_list['pagination']['nextUrl']
+            if list_url != "":
+                u=sys.argv[0]+"?mode="+str(300)+"&featured_video="+urllib.quote_plus(list_url)
+                isFolder=True
+                xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=isFolder)
+                xbmcplugin.setContent(addon_handle, 'episodes')
+
+
+# display a Big Inning item within a game list
+def create_big_inning_listitem(game_day):
+    try:
+        # check when we last fetched the Big Inning schedule
+        today = localToEastern()
+        big_inning_date = str(settings.getSetting(id="big_inning_date"))
+
+        # if we've already fetched it today, use the cached schedule
+        if big_inning_date == today:
+            xbmc.log('Using cached Big Inning schedule')
+            big_inning_schedule = json.loads(settings.getSetting(id="big_inning_schedule"))
+        # otherwise, fetch a new big inning schedule
+        else:
+            xbmc.log('Fetching Big Inning schedule')
+            settings.setSetting(id='big_inning_date', value=today)
+            url = 'https://www.mlb.com/live-stream-games/big-inning'
+
+            headers = {
+                'User-Agent': UA_PC,
+                'Origin': 'https://www.mlb.com',
+                'Referer': 'https://www.mlb.com'
+            }
+            r = requests.get(url,headers=headers, verify=VERIFY)
+            #xbmc.log(r.text)
+
+            # parse the schedule table
+            table = re.findall('<td>([^<]*)<\/td>', r.text)
+            xbmc.log('Number of fields in Big Inning schedule table: ' + str(len(table)))
+
+            counter = 0
+            table_iter = iter(table)
+            columns_in_table = 3
+            big_inning_schedule = {}
+            for field in table_iter:
+                date_display = table[counter]
+                xbmc.log('Checking date ' + date_display + ' from Big Inning schedule')
+                big_inning_date = parse(date_display).strftime('%Y-%m-%d')
+                xbmc.log('Formatted date ' + big_inning_date)
+                # ignore dates in the past
+                if big_inning_date >= today:
+                    big_inning_start = str(UTCToLocal(easternToUTC(parse(big_inning_date + ' ' + table[counter+1]))))
+                    big_inning_end = str(UTCToLocal(easternToUTC(parse(big_inning_date + ' ' + table[counter+2]))))
+                    big_inning_schedule[big_inning_date] = {'start': big_inning_start, 'end': big_inning_end}
+                counter = counter + columns_in_table
+                for i in range(columns_in_table - 1):
+                    next(table_iter, None)
+            # save the scraped schedule
+            settings.setSetting(id='big_inning_schedule', value=json.dumps(big_inning_schedule))
+
+        if game_day in big_inning_schedule:
+            xbmc.log(game_day + ' has a scheduled Big Inning broadcast')
+            display_title = LOCAL_STRING(30367)
+
+            big_inning_start = parse(big_inning_schedule[game_day]['start'])
+            big_inning_end = parse(big_inning_schedule[game_day]['end'])
+
+            # format the time for display
+            game_time = big_inning_start.strftime('%I:%M %p').lstrip('0') + ' - ' + big_inning_end.strftime('%I:%M %p').lstrip('0')
+            now = datetime.now()
+            if now < big_inning_start:
+                game_time = colorString(game_time, UPCOMING)
+            elif now > big_inning_end:
+                game_time = colorString(game_time, FINAL)
+            elif now >= big_inning_start and now <= big_inning_end:
+                display_title = BIG_INNING_LIVE_NAME
+                game_time = colorString(game_time, LIVE)
+            name = game_time + ' ' + display_title
+
+            desc = 'MLB Big Inning brings fans all the best action from around the league with live look-ins, breaking highlights and big moments as they happen all season long. Airing seven days a week on MLB.TV.'
+
+            # create the list item
+            liz=xbmcgui.ListItem(name)
+            liz.setInfo( type="Video", infoLabels={ "Title": display_title, 'plot': desc } )
+            liz.setProperty("IsPlayable", "true")
+            icon = 'https://img.mlbstatic.com/mlb-images/image/private/ar_16:9,g_auto,q_auto:good,w_372,c_fill,f_jpg/mlb/uwr8vepua4t1fe8uwyki'
+            fanart = 'https://img.mlbstatic.com/mlb-images/image/private/g_auto,c_fill,ar_16:9,q_60,w_1920/e_gradient_fade:15,x_0.6,b_black/mlb/uwr8vepua4t1fe8uwyki'
+            liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
+            u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(BIG_INNING_LIVE_NAME)+"&name="+urllib.quote_plus(BIG_INNING_LIVE_NAME)
+            xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=False)
+            xbmcplugin.setContent(addon_handle, 'episodes')
+        else:
+            xbmc.log(game_day + ' does not have a scheduled Big Inning broadcast')
+    except Exception as e:
+        xbmc.log('big inning error : ' + str(e))
+        pass
 
 
 def stream_select(game_pk, spoiler='True'):
@@ -206,18 +371,32 @@ def stream_select(game_pk, spoiler='True'):
         stream_title = []
         highlight_offset = 0
     else:
-        stream_title = ['Highlights']
+        stream_title = [LOCAL_STRING(30391)]
         highlight_offset = 1
     media_state = []
     content_id = []
-    epg = json_source['media']['epg'][0]['items']
+    # combine tv and radio items
+    epg = json_source['media']['epg'][0]['items'] + json_source['media']['epg'][2]['items']
     for item in epg:
         xbmc.log(str(item))
         if item['mediaState'] != 'MEDIA_OFF':
-            if IN_MARKET != 'Hide' or (item['mediaFeedType'] != 'IN_MARKET_HOME' and item['mediaFeedType'] != 'IN_MARKET_AWAY'):
-                title = str(item['mediaFeedType']).title()
+            # tv and radio items use different variables for home/away
+            if 'mediaFeedType' in item:
+                media_feed_type = str(item['mediaFeedType'])
+            else:
+                media_feed_type = str(item['type'])
+            if IN_MARKET != 'Hide' or (media_feed_type != 'IN_MARKET_HOME' and media_feed_type != 'IN_MARKET_AWAY'):
+                title = media_feed_type.title()
                 title = title.replace('_', ' ')
-                if 'HOME' in title.upper():
+                if 'mediaFeedType' in item:
+                    title += LOCAL_STRING(30392)
+                else:
+                    if item['language'] == 'en':
+                        title += LOCAL_STRING(30394)
+                    elif item['language'] == 'es':
+                        title += LOCAL_STRING(30395)
+                    title += LOCAL_STRING(30393)
+                if 'mediaFeedType' in item and ('HOME' in title.upper() or 'NATIONAL' in title.upper()):
                     media_state.insert(0, item['mediaState'])
                     content_id.insert(0, item['contentId'])
                     stream_title.insert(highlight_offset, title + " (" + item['callLetters'] + ")")
@@ -235,16 +414,22 @@ def stream_select(game_pk, spoiler='True'):
 
     stream_url = ''
     start = '1'
+    stream_type = 'video'
 
     dialog = xbmcgui.Dialog()
-    n = dialog.select('Choose Stream', stream_title)
-    if n > -1 and stream_title[n] != 'Highlights':
+    n = dialog.select(LOCAL_STRING(30390), stream_title)
+    if n == -1:
+        sys.exit()
+    elif n > -1 and stream_title[n] != LOCAL_STRING(30391):
+        # check if selected stream is a radio stream, which can't play with inputstream adaptive
+        if LOCAL_STRING(30393) in stream_title[n]:
+            stream_type = 'audio'
         account = Account()
         stream_url, headers, broadcast_start = account.get_stream(content_id[n-highlight_offset])
         if sys.argv[3] == 'resume:true':
             spoiler = "True"
-        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true':
-            p = dialog.select('Select a Start Point', ['Catch Up', 'Beginning', 'Live'])
+        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'video':
+            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30304), LOCAL_STRING(30398), LOCAL_STRING(30399)])
             if p == 0:
                 listitem = stream_to_listitem(stream_url, headers)
                 highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
@@ -256,23 +441,115 @@ def stream_select(game_pk, spoiler='True'):
                 spoiler = "True"
             elif p == -1:
                 sys.exit()
+        # don't offer to start live radio streams from beginning
+        elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'audio':
+            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30304), LOCAL_STRING(30399)])
+            if p == 0:
+                listitem = stream_to_listitem(stream_url, headers, 'True', '1', 'audio')
+                highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
+                sys.exit()
+            elif p == -1:
+                sys.exit()
 
     if '.m3u8' in stream_url:
-        play_stream(stream_url, headers, spoiler, start)
+        play_stream(stream_url, headers, spoiler, start, stream_type)
 
-    elif stream_title[n] == 'Highlights':
+    elif stream_title[n] == LOCAL_STRING(30391):
         highlight_select_stream(json_source['highlights']['highlights']['items'])
 
     else:
         sys.exit()
 
 
+# select a stream for a featured video
+def featured_stream_select(featured_video, name):
+    xbmc.log('video select')
+    account = Account()
+    video_url = None
+    # check if our request video is a URL
+    if featured_video.startswith('http'):
+        video_url = featured_video
+    # otherwise assume it is a video title (used to call Big Inning from the schedule)
+    else:
+        xbmc.log('must search for video url with title')
+        video_list = get_video_list()
+        if 'items' in video_list:
+            for item in video_list['items']:
+                #xbmc.log(str(item))
+                # use a fuzzy search to match live Big Inning title
+                # because it has contained extra whitespace at the end before
+                if featured_video in item['title']:
+                    xbmc.log('found fuzzy match')
+                    video_url = None
+                    if 'fields' in item:
+                        if 'playbackScenarios' in item['fields']:
+                            for playback in item['fields']['playbackScenarios']:
+                                if playback['playback'] == 'hlsCloud':
+                                    video_url = playback['location']
+                                    break
+                        elif 'url' in item['fields']:
+                            video_url = item['fields']['url']
+    if video_url is None:
+        xbmc.log('failed to find video URL for featured video')
+        sys.exit()
+
+    xbmc.log('video url : ' + video_url)
+    video_stream_url = None
+    # if it's not a Big Inning stream (fuzzy name search) and it is HLS (M3U8) or MP4, we can simply stream the URL we already have
+    if BIG_INNING_LIVE_NAME not in name and (video_url.endswith('.m3u8') or video_url.endswith('.mp4')):
+        video_stream_url = video_url
+    # otherwise we need to authenticate and get the stream URL
+    else:
+        xbmc.log('fetching video stream from url')
+        # need a special token for Big Inning
+        okta_access_token = account.okta_access_token()
+        if okta_access_token is None:
+            xbmc.log('failed to get necessary okta access token')
+            sys.exit()
+
+        headers = {
+            'User-Agent': UA_PC,
+            'Authorization': 'Bearer ' + okta_access_token,
+            'Accept': '*/*',
+            'Origin': 'https://www.mlb.com',
+            'Referer': 'https://www.mlb.com'
+        }
+        r = requests.get(video_url, headers=headers, verify=VERIFY)
+
+        text_source = r.text
+        #xbmc.log(text_source)
+
+        # sometimes the returned content is already a stream playlist
+        if text_source.startswith('#EXTM3U'):
+            xbmc.log('video url is already a stream playlist')
+            video_stream_url = video_url
+        # otherwise it is JSON containing the stream URL
+        else:
+            json_source = r.json()
+            if 'data' in json_source and len(json_source['data']) > 0 and 'value' in json_source['data'][0]:
+                video_stream_url = json_source['data'][0]['value']
+                xbmc.log('found video stream url : ' + video_stream_url)
+
+    if video_stream_url is not None:
+        headers = 'User-Agent=' + UA_PC
+        if '.m3u8' in video_stream_url and QUALITY == 'Always Ask':
+            video_stream_url = account.get_stream_quality(video_stream_url)
+        # known issue warning: on Kodi 18 Leia WITHOUT inputstream adaptive, Big Inning starts at the beginning and can't seek
+        # anyone with inputstream adaptive, or Kodi 19+, will not have this problem
+        if BIG_INNING_LIVE_NAME in name and KODI_VERSION < 19 and not xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
+            dialog = xbmcgui.Dialog()
+            dialog.ok(LOCAL_STRING(30370), LOCAL_STRING(30369))
+        play_stream(video_stream_url, headers)
+    else:
+        xbmc.log('unable to find stream for featured video')
+
+
 def highlight_select_stream(json_source, catchup=None):
     highlights = get_highlights(json_source)
     if not highlights and catchup is None:
-        msg = "No videos found."
+        msg = LOCAL_STRING(30383)
         dialog = xbmcgui.Dialog()
-        dialog.notification('Highlights', msg, ICON, 5000, False)
+        dialog.notification(LOCAL_STRING(30391), msg, ICON, 5000, False)
         xbmcplugin.setResolvedUrl(addon_handle, False, xbmcgui.ListItem())
         sys.exit()
 
@@ -305,10 +582,12 @@ def highlight_select_stream(json_source, catchup=None):
             playlist.add(catchup.getPath(), catchup)
 
         xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=playlist[0])
+    elif a == -1:
+        sys.exit()
 
 
-def play_stream(stream_url, headers, spoiler='True', start='1'):
-    listitem = stream_to_listitem(stream_url, headers, spoiler, start)
+def play_stream(stream_url, headers, spoiler='True', start='1', stream_type='video'):
+    listitem = stream_to_listitem(stream_url, headers, spoiler, start, stream_type)
     xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=listitem)
 
 
@@ -327,124 +606,49 @@ def get_highlights(items):
     return highlights
 
 
-def getGamesForDate(stream_date):
-    stream_date_new = stringToDate(stream_date, "%Y-%m-%d")
-    year = stream_date_new.strftime("%Y")
-    month = stream_date_new.strftime("%m")
-    day = stream_date_new.strftime("%d")
-
-    url = 'http://gdx.mlb.com/components/game/mlb/year_' + year + '/month_' + month + '/day_' + day + '/'
-    #req = urllib2.Request(url)
-    #req.add_header('Connection', 'close')
-    #req.add_header('User-Agent', UA_IPAD)
-
-    try:
-        r = requests.get(url, headers={'User-Agent': UA_IPAD})
-        # response = urllib2.urlopen(req)
-        html_data = r.text()
-        # response.close()
-    #except HTTPError as e:
-    except requests.exceptions.RequestException as e:
-        xbmc.log('The server couldn\'t fulfill the request.')
-        xbmc.log('Error code: ', e.code)
+# Play all recaps or condensed games when a date is selected
+def playAllHighlights(stream_date):
+    dialog = xbmcgui.Dialog()
+    n = dialog.select(LOCAL_STRING(30400), [LOCAL_STRING(30401), LOCAL_STRING(30402)])
+    if n == -1:
         sys.exit()
 
-    # <li><a href="gid_2016_03_13_arimlb_chamlb_1/"> gid_2016_03_13_arimlb_chamlb_1/</a></li>
-    match = re.compile('<li><a href="gid_(.+?)/">(.+?)</a></li>', re.DOTALL).findall(html_data)
-    global RECAP_PLAYLIST
-    global EXTENDED_PLAYLIST
-    RECAP_PLAYLIST.clear()
-    EXTENDED_PLAYLIST.clear()
+    url = 'https://statsapi.mlb.com/api/v1/schedule'
+    url += '?hydrate=game(content(highlights(highlights)))'
+    url += '&sportId=1,51'
+    url += '&date=' + stream_date
 
-    pDialog = xbmcgui.DialogProgressBG()
-    pDialog.create(LOCAL_STRING(30380), LOCAL_STRING(30381))
-    match_count = len(match)
-    if match_count == 0:
-        match_count = 1  # prevent division by zero when no games
-    perc_increments = 100 / match_count
-    first_time_thru = True
-    bandwidth = find(QUALITY, '(', ' kbps)')
+    headers = {
+        'User-Agent': UA_ANDROID
+    }
+    r = requests.get(url, headers, verify=VERIFY)
+    json_source = r.json()
 
-    for gid, junk in match:
-        pDialog.update(perc_increments, message=LOCAL_STRING(30382) + gid)
+    playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
+    playlist.clear()
+
+    for game in json_source['dates'][0]['games']:
         try:
-            recap, condensed, highlights = get_highlight_links(None, stream_date, gid)
-
-            if first_time_thru and QUALITY == 'Always Ask':
-                bandwidth = getStreamQuality(str(recap['url']))
-                first_time_thru = False
-
-            listitem = xbmcgui.ListItem(recap['title'], thumbnailImage=recap['icon'])
-            listitem.setInfo(type="Video", infoLabels={"Title": recap['title']})
-            RECAP_PLAYLIST.add(createHighlightStream(recap['url'], bandwidth), listitem)
-
-            listitem = xbmcgui.ListItem(condensed['title'], thumbnailImage=condensed['icon'])
-            listitem.setInfo(type="Video", infoLabels={"Title": condensed['title']})
-            EXTENDED_PLAYLIST.add(createHighlightStream(condensed['url'], bandwidth), listitem)
+            fanart = 'http://cd-images.mlbstatic.com/stadium-backgrounds/color/light-theme/1920x1080/%s.png' % game['venue']['id']
+            if 'highlights' in game['content']:
+                for item in game['content']['highlights']['highlights']['items']:
+                    try:
+                        title = item['headline']
+                        if (n == 0 and title.endswith(' Highlights')) or (n == 1 and item['headline'].startswith('CG: ')):
+                            for playback in item['playbacks']:
+                                if 'hlsCloud' in playback['name']:
+                                    clip_url = playback['url']
+                                    break
+                            listitem = xbmcgui.ListItem(clip_url)
+                            icon = item['image']['cuts'][0]['src']
+                            listitem.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
+                            listitem.setInfo(type="Video", infoLabels={"Title": title})
+                            xbmc.log('adding recap to playlist : ' + title)
+                            playlist.add(clip_url, listitem)
+                    except:
+                        pass
         except:
             pass
 
-        perc_increments += perc_increments
-
-    pDialog.close()
-
-
-def createHighlightStream(url, bandwidth):
-    if bandwidth != '' and int(bandwidth) < 4500:
-        url = url.replace('master_tablet_60.m3u8', 'asset_' + bandwidth + 'K.m3u8')
-
-    url = url + '|User-Agent=' + UA_IPAD
-
-    return url
-
-
-def get_highlight_links(teams_stream, stream_date):
-    stream_date = stringToDate(stream_date, "%Y-%m-%d")
-    year = stream_date.strftime("%Y")
-    month = stream_date.strftime("%m")
-    day = stream_date.strftime("%d")
-
-    #if gid is None:
-    away = teams_stream[:3].lower()
-    home = teams_stream[3:].lower()
-    #url = 'https://content.mlb.com/app/mlb/mobile/components/game/mlb/year_' + year + '/month_' + month + '/day_' + day + '/gid_' + year + '_' + month + '_' + day + '_' + away + 'mlb_' + home + 'mlb_1/media/mobile.xml'
-    url = 'https://content.mlb.com/app/mlb/mobile/components/game/mlb/year_%s/month_%s/day_%s/gid_%s_%s_%s_%smlb_%smlb_1/media/mobile.xml' % (
-    year, month, day, year, month, day, away, home)
-
-
-    headers = {
-        'User-Agent': UA_IPAD
-    }
-
-    r = requests.get(url, headers=headers, verify=VERIFY)
-    xml_data = r.text
-    match = re.compile('<media id="(.+?)"(.+?)<headline>(.+?)</headline>(.+?)<thumb type="22">(.+?)</thumb>(.+?)<url playback-scenario="HTTP_CLOUD_TABLET_60">(.+?)</url>', re.DOTALL).findall(xml_data)
-    #bandwidth = find(QUALITY, '(', ' kbps)')
-
-    recap = {}
-    condensed = {}
-    highlights = []
-
-    for media_id, media_tag, headline, junk1, icon, junk2, clip_url in match:
-        if 'media-type="T"' in media_tag:
-            # if bandwidth != '' and int(bandwidth) < 4500:
-            # clip_url = clip_url.replace('master_tablet_60.m3u8', 'asset_'+bandwidth+'K.m3u8')
-
-            # clip_url = clip_url + '|User-Agent='+UA_IPAD
-            highlights.append([clip_url, headline, icon])
-
-        if 'media-type="R"' in media_tag:
-            # icon = 'http://mediadownloads.mlb.com/mlbam/'+year+'/'+month+'/'+day+'/images/mlbf_'+media_id+'_th_43.jpg'
-            title = headline
-            recap = {'url': clip_url, 'icon': icon, 'title': headline}
-        elif 'media-type="C"' in media_tag:
-            # icon = 'http://mediadownloads.mlb.com/mlbam/'+year+'/'+month+'/'+day+'/images/mlbf_'+media_id+'_th_43.jpg'
-            title = headline
-            condensed = {'url': clip_url, 'icon': icon, 'title': headline}
-
-    return recap, condensed, highlights
-
-
-
-
+    xbmc.Player().play(playlist)
 

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -11,6 +11,10 @@
     <setting id='device_id' type='text' visible="false" default=''/>
     <setting id='last_login' type='text' visible="false" default=''/>
     <setting id='login_token' type='text' visible="false" default=''/>
+    <setting id="session_token" type="text" label="" default="" visible="false"/>
+    <setting id="okta_client_id" type="text" label="" default="" visible="false"/>
+    <setting id="okta_access_token" type="text" label="" default="" visible="false"/>
+    <setting id="okta_access_token_expiry" type="text" label="" default="" visible="false"/>
   </category>
 
   <category label="30159">
@@ -28,6 +32,10 @@
 
     <setting id="old_username" type="text" label="" default="" visible="false"/>
     <setting id="old_password" type="text" label="" default="" visible="false"/>
+
+    <setting id="stream_date" type="text" label="" default="" visible="false"/>
+    <setting id="big_inning_date" type="text" label="" default="" visible="false"/>
+    <setting id="big_inning_schedule" type="text" label="" default="" visible="false"/>
   </category>
   <!--Proxy-->
   <category label='30200'>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.4.19
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - featured videos, including Big Inning
            - audio-only streams
            - unique game icons
            - probable pitchers
            - doubleheader/TBD start times
            - restored "play all recaps" behavior when selecting date
            - moved more text to language localization file
            - additional AddonIsEnabled detection for inputstream adaptive
            - code cleanup
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
