### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.10+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,10 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.10 (2022-04-29)
+- Fix watching from the tv guide (@mediaminister)
+- Fix season menu labels (@mediaminister)
+
 ### v2.5.9 (2022-04-20)
 - Fix broken menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.9" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.10+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
     <import addon="script.module.dateutil" version="2.8.0"/>
     <import addon="script.module.inputstreamhelper" version="0.4.3"/>
     <import addon="script.module.routing" version="0.2.3"/>
-    <import addon="xbmc.python" version="2.25.0"/>
+    <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="resources/lib/addon_entry.py">
     <provides>video</provides>
@@ -42,6 +42,10 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.10 (2022-04-29)
+- Fix watching from the tv guide
+- Fix season menu labels
+
 v2.5.9 (2022-04-20)
 - Fix broken menu listings
 

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -323,6 +323,13 @@ def play_whatson_id(whatson_id):
     VRTPlayer().play_episode_by_whatson_id(whatson_id=whatson_id)
 
 
+@plugin.route('/play/episode/<episode_id>')
+def play_episode_id(episode_id):
+    """The API interface to play a video by using a episodeId"""
+    from vrtplayer import VRTPlayer
+    VRTPlayer().play_episode_by_episode_id(episode_id=episode_id)
+
+
 @plugin.route('/iptv/channels')
 def iptv_channels():
     """Return JSON-M3U formatted data for all live channels"""

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -292,7 +292,7 @@ FEATURED = [
     # dict(name='12+', id='12+', msgctxt=30121),
     # Thema
     dict(name='Klimaat', id='klimaat', msgctxt=30128),
-    dict(name='Koers', id='koers', msgctxt=30129),
+    #dict(name='Koers', id='koers', msgctxt=30129),
     dict(name='De warmste week', id='de-warmste-week', msgctxt=30130),
 ]
 

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -111,7 +111,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         self.quit.clear()
         self.update_position()
         self.update_total()
-        self.push_upnext()
+        # FIXME: Up Next is broken because we can't get single episode data, see line 84
+        # self.push_upnext()
 
         # StreamPosition thread keeps running when watching multiple episode with "Up Next"
         # only start StreamPosition thread when it doesn't exist yet.

--- a/plugin.video.vrt.nu/resources/lib/tvguide.py
+++ b/plugin.video.vrt.nu/resources/lib/tvguide.py
@@ -211,11 +211,11 @@ class TVGuide:
         """Return a playable plugin:// path for an episode"""
         now = datetime.now(dateutil.tz.tzlocal())
         end_date = dateutil.parser.parse(episode.get('endTime'))
-        if episode.get('url') and episode.get('vrt.whatson-id'):
-            return url_for('play_whatson_id', whatson_id=episode.get('vrt.whatson-id'))
+        if episode.get('url') and episode.get('episodeId'):
+            return url_for('play_episode_id', episode_id=episode.get('episodeId'))
         if now - timedelta(hours=24) <= end_date <= now:
             return url_for('play_air_date', channel, episode.get('startTime')[:19], episode.get('endTime')[:19])
-        return url_for('noop', whatsonid=episode.get('vrt.whatson-id', ''))
+        return url_for('noop', episode_id=episode.get('episodeId', ''))
 
     def get_epg_data(self):
         """Return EPG data"""

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -376,6 +376,16 @@ class VRTPlayer:
             return
         self.play(video)
 
+    def play_episode_by_episode_id(self, episode_id):
+        """Play an episode of a program given the episode_id"""
+        video = self._apihelper.get_single_episode(episode_id=episode_id)
+        if not video:
+            log_error('Play episode by episode_id failed, episode_id {episode_id}', episode_id=episode_id)
+            ok_dialog(message=localize(30954))
+            end_of_directory()
+            return
+        self.play(video)
+
     def play_upnext(self, video_id):
         """Play the next episode of a program by video_id"""
         video = self._apihelper.get_single_episode(video_id=video_id)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.10+matrix.1
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
