### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.10

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,10 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.10 (2022-04-29)
+- Fix watching from the tv guide (@mediaminister)
+- Fix season menu labels (@mediaminister)
+
 ### v2.5.9 (2022-04-20)
 - Fix broken menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.9" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.10" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,10 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.10 (2022-04-29)
+- Fix watching from the tv guide
+- Fix season menu labels
+
 v2.5.9 (2022-04-20)
 - Fix broken menu listings
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -286,6 +286,10 @@ msgctxt "#30121"
 msgid "12+"
 msgstr ""
 
+msgctxt "#30122"
+msgid "Cinema Canvas"
+msgstr ""
+
 msgctxt "#30128"
 msgid "Climate"
 msgstr ""

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -286,6 +286,10 @@ msgctxt "#30121"
 msgid "12+"
 msgstr "12+"
 
+msgctxt "#30122"
+msgid "Cinema Canvas"
+msgstr "Cinema Canvas"
+
 msgctxt "#30128"
 msgid "Climate"
 msgstr "Klimaat"

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -301,11 +301,11 @@ def play_latest(program):
     VRTPlayer().play_latest_episode(program=program)
 
 
-@plugin.route('/play/upnext/<video_id>')
-def play_upnext(video_id):
+@plugin.route('/play/upnext/<episode_id>')
+def play_upnext(episode_id):
     """The API interface to play the next episode of a program"""
     from vrtplayer import VRTPlayer
-    VRTPlayer().play_upnext(video_id=video_id)
+    VRTPlayer().play_upnext(episode_id=episode_id)
 
 
 @plugin.route('/play/airdate/<channel>/<start_date>')
@@ -321,6 +321,13 @@ def play_whatson_id(whatson_id):
     """The API interface to play a video by using a whatson_id"""
     from vrtplayer import VRTPlayer
     VRTPlayer().play_episode_by_whatson_id(whatson_id=whatson_id)
+
+
+@plugin.route('/play/episode/<episode_id>')
+def play_episode_id(episode_id):
+    """The API interface to play a video by using a episodeId"""
+    from vrtplayer import VRTPlayer
+    VRTPlayer().play_episode_by_episode_id(episode_id=episode_id)
 
 
 @plugin.route('/iptv/channels')

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -290,9 +290,10 @@ FEATURED = [
     # Inhoudsgerelateerd
     dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
     # dict(name='12+', id='12+', msgctxt=30121),
+    dict(name='Cinema canvas', id='cinema-canvas', msgctxt=30122),
     # Thema
     dict(name='Klimaat', id='klimaat', msgctxt=30128),
-    dict(name='Koers', id='koers', msgctxt=30129),
+    # dict(name='Koers', id='koers', msgctxt=30129),
     dict(name='De warmste week', id='de-warmste-week', msgctxt=30130),
 ]
 

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -190,12 +190,12 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
                 break
         self.onPlayerExit()
 
-    def add_upnext(self, video_id):
+    def add_upnext(self, episode_id):
         """Add Up Next url to Kodi Player"""
         # Reset vrtnu_resumepoints property
         set_property('vrtnu_resumepoints', None)
 
-        url = url_for('play_upnext', video_id=video_id)
+        url = url_for('play_upnext', episode_id=episode_id)
         self.update_position()
         self.update_total()
         if self.isPlaying() and self.total - self.last_pos < 1:
@@ -210,7 +210,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         if has_addon('service.upnext') and get_setting_bool('useupnext', default=True) and self.isPlaying():
             info_tag = self.getVideoInfoTag()
             next_info = self.apihelper.get_upnext(dict(
-                program=to_unicode(info_tag.getTVShowTitle()),
+                program_title=to_unicode(info_tag.getTVShowTitle()),
+                season_number=to_unicode(info_tag.getSeason()),
+                episode_number=to_unicode(info_tag.getEpisode()),
                 playcount=info_tag.getPlayCount(),
                 rating=info_tag.getRating(),
                 path=self.path,

--- a/plugin.video.vrt.nu/resources/lib/service.py
+++ b/plugin.video.vrt.nu/resources/lib/service.py
@@ -60,7 +60,7 @@ class VrtMonitor(Monitor, object):  # pylint: disable=useless-object-inheritance
             from base64 import b64decode
             data = loads(to_unicode(b64decode(hexdata[0])))
             log(2, '[Up Next notification] sender={sender}, method={method}, data={data}', sender=sender, method=method, data=to_unicode(data))
-            self._playerinfo.add_upnext(data.get('video_id'))
+            self._playerinfo.add_upnext(data.get('episode_id'))
 
     def onSettingsChanged(self):  # pylint: disable=invalid-name
         """Handler for changes to settings"""

--- a/plugin.video.vrt.nu/resources/lib/tvguide.py
+++ b/plugin.video.vrt.nu/resources/lib/tvguide.py
@@ -211,11 +211,11 @@ class TVGuide:
         """Return a playable plugin:// path for an episode"""
         now = datetime.now(dateutil.tz.tzlocal())
         end_date = dateutil.parser.parse(episode.get('endTime'))
-        if episode.get('url') and episode.get('vrt.whatson-id'):
-            return url_for('play_whatson_id', whatson_id=episode.get('vrt.whatson-id'))
+        if episode.get('url') and episode.get('episodeId'):
+            return url_for('play_episode_id', episode_id=episode.get('episodeId'))
         if now - timedelta(hours=24) <= end_date <= now:
             return url_for('play_air_date', channel, episode.get('startTime')[:19], episode.get('endTime')[:19])
-        return url_for('noop', whatsonid=episode.get('vrt.whatson-id', ''))
+        return url_for('noop', episode_id=episode.get('episodeId', ''))
 
     def get_epg_data(self):
         """Return EPG data"""
@@ -232,8 +232,8 @@ class TVGuide:
                 if epg_id not in epg_data:
                     epg_data[epg_id] = []
                 for episode in episodes:
-                    if episode.get('url') and episode.get('vrt.whatson-id'):
-                        path = url_for('play_whatson_id', whatson_id=episode.get('vrt.whatson-id'))
+                    if episode.get('url') and episode.get('episodeId'):
+                        path = url_for('play_episode_id', episode_id=episode.get('episodeId'))
                     else:
                         path = None
                     epg_data[epg_id].append(dict(

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -95,7 +95,9 @@ def reformat_url(url, url_type, domain='www.vrt.be'):
 
 def reformat_image_url(url):
     """Reformat images.vrt.be urls"""
-    return add_https_proto(url.replace('images.vrt.be/orig', 'images.vrt.be/w1920hx'))
+    if url:
+        return add_https_proto(url.replace('images.vrt.be/orig', 'images.vrt.be/w1920hx'))
+    return ''
 
 
 def program_to_url(program, url_type):
@@ -202,6 +204,8 @@ def play_url_to_id(url):
         play_id['video_url'] = video_to_api_url(url.split('play/url/')[1])
     elif 'play/whatson/' in url:
         play_id['whatson_id'] = url.split('play/whatson/')[1]
+    elif 'play/episode/' in url:
+        play_id['episode_id'] = url.split('play/episode/')[1]
     return play_id
 
 

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -376,11 +376,21 @@ class VRTPlayer:
             return
         self.play(video)
 
-    def play_upnext(self, video_id):
-        """Play the next episode of a program by video_id"""
-        video = self._apihelper.get_single_episode(video_id=video_id)
+    def play_episode_by_episode_id(self, episode_id):
+        """Play an episode of a program given the episode_id"""
+        video = self._apihelper.get_single_episode(episode_id=episode_id)
         if not video:
-            log_error('Play Up Next with video_id {video_id} failed', video_id=video_id)
+            log_error('Play episode by episode_id failed, episode_id {episode_id}', episode_id=episode_id)
+            ok_dialog(message=localize(30954))
+            end_of_directory()
+            return
+        self.play(video)
+
+    def play_upnext(self, episode_id):
+        """Play the next episode of a program by episode_id"""
+        video = self._apihelper.get_single_episode(episode_id=episode_id)
+        if not video:
+            log_error('Play Up Next with episodeId {episode_id} failed', episode_id=episode_id)
             ok_dialog(message=localize(30954))
             end_of_directory()
             return


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.10
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
