### PR TITLE
[plugin.video.mlbtv@krypton] 2022.5.5

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.4.19" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.6" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.pytz" />
@@ -21,15 +21,7 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - featured videos, including Big Inning
-            - audio-only streams
-            - unique game icons
-            - probable pitchers
-            - doubleheader/TBD start times
-            - restored "play all recaps" behavior when selecting date
-            - moved more text to language localization file
-            - additional AddonIsEnabled detection for inputstream adaptive
-            - code cleanup
+            - improve free game check
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -109,11 +109,15 @@ msgid "24 Hour Clock (ex. 18:00)"
 msgstr ""
 
 msgctxt "#30304"
-msgid "Catch Up"
+msgid "Ask to Catch Up, start from beginning, or from inning"
 msgstr ""
 
 msgctxt "#30305"
 msgid "Show only free games"
+msgstr ""
+
+msgctxt "#30306"
+msgid "Ask to automatically skip breaks"
 msgstr ""
 
 msgctxt "#30300"
@@ -193,6 +197,10 @@ msgid "The date entered is not in the format required."
 msgstr ""
 
 msgctxt "#30367"
+msgid "LIVE NOW: "
+msgstr ""
+
+msgctxt "#30368"
 msgid "MLB Big Inning"
 msgstr ""
 
@@ -264,6 +272,10 @@ msgctxt "#30396"
 msgid "Select a Start Point"
 msgstr ""
 
+msgctxt "#30397"
+msgid "Catch Up"
+msgstr ""
+
 msgctxt "#30398"
 msgid "Beginning"
 msgstr ""
@@ -282,5 +294,37 @@ msgstr ""
 
 msgctxt "#30402"
 msgid "Condensed Games"
+msgstr ""
+
+msgctxt "#30403"
+msgid "Automatically Skip"
+msgstr ""
+
+msgctxt "#30404"
+msgid "Skip nothing"
+msgstr ""
+
+msgctxt "#30405"
+msgid "Skip breaks plus idle time"
+msgstr ""
+
+msgctxt "#30406"
+msgid "Skip breaks, idle time, and non-action pitches"
+msgstr ""
+
+msgctxt "#30407"
+msgid "Inning"
+msgstr ""
+
+msgctxt "#30408"
+msgid "Skip breaks"
+msgstr ""
+
+msgctxt "#30409"
+msgid "Top"
+msgstr ""
+
+msgctxt "#30410"
+msgid "Bottom"
 msgstr ""
 

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -46,7 +46,14 @@ TEAM_NAMES = settings.getSetting(id="team_names")
 TIME_FORMAT = settings.getSetting(id="time_format")
 SINGLE_TEAM = str(settings.getSetting(id='single_team'))
 CATCH_UP = str(settings.getSetting(id='catch_up'))
+ASK_TO_SKIP = str(settings.getSetting(id='ask_to_skip'))
 ONLY_FREE_GAMES = str(settings.getSetting(id="only_free_games"))
+
+#Monitor setting
+MLB_MONITOR_STARTED = settings.getSetting(id='mlb_monitor_started')
+if MLB_MONITOR_STARTED != '' and not xbmc.getCondVisibility("Player.HasMedia"):
+    xbmc.log("MLB Monitor detection resetting due to no stream playing")
+    settings.setSetting(id='mlb_monitor_started', value='')
 
 #Proxy Settings
 PROXY_ENABLED = str(settings.getSetting(id='use_proxy'))
@@ -83,7 +90,7 @@ else:
     MASTER_FILE_TYPE = 'master_wired60.m3u8'
     PLAYBACK_SCENARIO = 'HTTP_CLOUD_WIRED_60'
 
-
+API_URL = 'https://statsapi.mlb.com'
 #User Agents
 UA_IPAD = 'AppleCoreMedia/1.0 ( iPad; compatible; 3ivx HLS Engine/2.0.0.382; Win8; x64; 264P AACP AC3P AESD CLCP HTPC HTPI HTSI MP3P MTKA)'
 UA_PC = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
@@ -91,9 +98,15 @@ UA_ANDROID = 'okhttp/3.12.1'
 
 VERIFY = True
 
-#Big Inning
-BIG_INNING_LIVE_NAME = 'LIVE NOW: MLB Big Inning'
-
+#Skip monitor
+#These are the break events to ignore
+BREAK_TYPES = ['Game Advisory', 'Pitching Substitution', 'Offensive Substitution', 'Defensive Sub', 'Defensive Switch', 'Runner Placed On Base']
+#These are the action events to keep, in addition to the last event of each at-bat, if we're skipping non-decision pitches
+ACTION_TYPES = ['Wild Pitch', 'Passed Ball', 'Stolen Base', 'Caught Stealing', 'Pickoff', 'Error', 'Out', 'Balk', 'Defensive Indiff']
+#Pad events at both start (-) and end (+)
+EVENT_START_PADDING = -5
+EVENT_END_PADDING = 8
+MINIMUM_BREAK_DURATION = 10
 
 def find(source,start_str,end_str):    
     start = source.find(start_str)

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -1,5 +1,6 @@
 from resources.lib.globals import *
 from .account import Account
+from .mlbmonitor import MLBMonitor
 
 
 def categories():
@@ -30,8 +31,9 @@ def todays_games(game_day):
         create_big_inning_listitem(game_day)
 
     #url = 'http://gdx.mlb.com/components/game/mlb/' + url_game_day + '/grid_ce.json'
-    url = 'https://statsapi.mlb.com/api/v1/schedule'
-    url += '?hydrate=broadcasts(all),game(content(all)),probablePitcher,linescore,team'
+    url = API_URL + '/api/v1/schedule'
+    # url += '?hydrate=broadcasts(all),game(content(all)),probablePitcher,linescore,team,flags'
+    url += '?hydrate=game(content(media(epg))),probablePitcher,linescore,team,flags'
     url += '&sportId=1,51'
     url += '&date=' + game_day
 
@@ -42,11 +44,11 @@ def todays_games(game_day):
     r = requests.get(url,headers=headers, verify=VERIFY)
     json_source = r.json()
 
-    try:
-        for game in json_source['dates'][0]['games']:
-            create_game_listitem(game, game_day)
-    except:
-        pass
+    # try:
+    for game in json_source['dates'][0]['games']:
+        create_game_listitem(game, game_day)
+    # except:
+    #     pass
 
     next_day = display_day + timedelta(days=1)
     addDir('[B]%s >>[/B]' % LOCAL_STRING(30011), 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"))
@@ -74,6 +76,10 @@ def create_game_listitem(game, game_day):
 
     title = away_team + ' at ' + home_team
     title = title
+
+    is_free = False
+    if 'content' in game and 'media' in game['content'] and 'freeGame' in game['content']['media']:
+        is_free = game['content']['media']['freeGame']
 
     fav_game = False
     if game['teams']['away']['team']['name'] in FAV_TEAM:
@@ -164,6 +170,12 @@ def create_game_listitem(game, game_day):
         name += ' at ' + home_team
         if 'linescore' in game: name += ' ' + colorString(str(game['linescore']['teams']['home']['runs']), SCORE_COLOR)
 
+        # added flags
+        if game['flags']['perfectGame'] == True:
+            name += ' ' + colorString('(Perfect Game)', CRITICAL)
+        elif game['flags']['noHitter'] == True:
+            name += ' ' + colorString('(No-Hitter)', CRITICAL)
+
     if game['doubleHeader'] != 'N':
         name += ' (Game ' + str(game['gameNumber']) + ')'
 
@@ -171,14 +183,8 @@ def create_game_listitem(game, game_day):
     if fav_game:
         name = '[B]' + name + '[/B]'
 
-    # Label free game of the day if applicable
-    try:
-        if game['content']['media']['freeGame']:
-            # and game_day >= localToEastern(): 
-            name = colorString(name, FREE)
-    except:
-        pass
-
+    if is_free:
+        name = colorString(name, FREE)
 
     # Get audio/video info
     audio_info, video_info = getAudioVideoInfo()
@@ -186,8 +192,8 @@ def create_game_listitem(game, game_day):
     info = {'plot': desc, 'tvshowtitle': 'MLB', 'title': title, 'originaltitle': title, 'aired': game_day, 'genre': LOCAL_STRING(700), 'mediatype': 'video'}
 
     # If set only show free games in the list
-    if ONLY_FREE_GAMES == 'true' and not game['content']['media']['freeGame']:
-        return 
+    if ONLY_FREE_GAMES == 'true' and not is_free:
+        return
     add_stream(name, title, game_pk, icon, fanart, info, video_info, audio_info, stream_date, spoiler)
 
 
@@ -323,7 +329,7 @@ def create_big_inning_listitem(game_day):
 
         if game_day in big_inning_schedule:
             xbmc.log(game_day + ' has a scheduled Big Inning broadcast')
-            display_title = LOCAL_STRING(30367)
+            display_title = LOCAL_STRING(30368)
 
             big_inning_start = parse(big_inning_schedule[game_day]['start'])
             big_inning_end = parse(big_inning_schedule[game_day]['end'])
@@ -336,7 +342,7 @@ def create_big_inning_listitem(game_day):
             elif now > big_inning_end:
                 game_time = colorString(game_time, FINAL)
             elif now >= big_inning_start and now <= big_inning_end:
-                display_title = BIG_INNING_LIVE_NAME
+                display_title = LOCAL_STRING(30367) + LOCAL_STRING(30368)
                 game_time = colorString(game_time, LIVE)
             name = game_time + ' ' + display_title
 
@@ -349,7 +355,7 @@ def create_big_inning_listitem(game_day):
             icon = 'https://img.mlbstatic.com/mlb-images/image/private/ar_16:9,g_auto,q_auto:good,w_372,c_fill,f_jpg/mlb/uwr8vepua4t1fe8uwyki'
             fanart = 'https://img.mlbstatic.com/mlb-images/image/private/g_auto,c_fill,ar_16:9,q_60,w_1920/e_gradient_fade:15,x_0.6,b_black/mlb/uwr8vepua4t1fe8uwyki'
             liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
-            u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(BIG_INNING_LIVE_NAME)+"&name="+urllib.quote_plus(BIG_INNING_LIVE_NAME)
+            u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(LOCAL_STRING(30367) + LOCAL_STRING(30368))+"&name="+urllib.quote_plus(LOCAL_STRING(30367) + LOCAL_STRING(30368))
             xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=False)
             xbmcplugin.setContent(addon_handle, 'episodes')
         else:
@@ -360,7 +366,7 @@ def create_big_inning_listitem(game_day):
 
 
 def stream_select(game_pk, spoiler='True'):
-    url = 'https://statsapi.mlb.com/api/v1/game/' + game_pk + '/content'
+    url = API_URL + '/api/v1/game/' + game_pk + '/content'
     headers = {
         'User-Agent': UA_ANDROID
     }
@@ -415,6 +421,11 @@ def stream_select(game_pk, spoiler='True'):
     stream_url = ''
     start = '1'
     stream_type = 'video'
+    skip_possible = False
+    skip_type = 0
+    is_live = False
+    start_inning = 0
+    start_inning_half = 'top'
 
     dialog = xbmcgui.Dialog()
     n = dialog.select(LOCAL_STRING(30390), stream_title)
@@ -428,31 +439,66 @@ def stream_select(game_pk, spoiler='True'):
         stream_url, headers, broadcast_start = account.get_stream(content_id[n-highlight_offset])
         if sys.argv[3] == 'resume:true':
             spoiler = "True"
+            if stream_type == 'video':
+                skip_possible = True
         elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'video':
-            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30304), LOCAL_STRING(30398), LOCAL_STRING(30399)])
+            is_live = True
+            start_options = [LOCAL_STRING(30397), LOCAL_STRING(30398), LOCAL_STRING(30399)]
+            # add inning start options
+            for x in range(1, 12):
+                start_options.append(LOCAL_STRING(30409) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
+                start_options.append(LOCAL_STRING(30410) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
+            p = dialog.select(LOCAL_STRING(30396), start_options)
             if p == 0:
                 listitem = stream_to_listitem(stream_url, headers)
                 highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
                 sys.exit()
-            elif p == 1:
+            elif p == 1 or p > 2:
                 spoiler = "False"
                 start = broadcast_start
+                skip_possible = True
+                if p > 2:
+                    p = p - 2
+                    start_inning = int(round(((p+0.5) / 2), 0))
+                    if (p % 2) == 0 and ((p+1) % 2) == 1:
+                        start_inning_half = 'bottom'
             elif p == 2:
                 spoiler = "True"
             elif p == -1:
                 sys.exit()
         # don't offer to start live radio streams from beginning
         elif epg[0]['mediaState'] == "MEDIA_ON" and CATCH_UP == 'true' and stream_type == 'audio':
-            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30304), LOCAL_STRING(30399)])
+            p = dialog.select(LOCAL_STRING(30396), [LOCAL_STRING(30397), LOCAL_STRING(30399)])
             if p == 0:
                 listitem = stream_to_listitem(stream_url, headers, 'True', '1', 'audio')
                 highlight_select_stream(json_source['highlights']['highlights']['items'], listitem)
                 sys.exit()
             elif p == -1:
                 sys.exit()
+        elif stream_type == 'video':
+            skip_possible = True
+            # For archive games, offer to start at inning if catch up is enabled
+            if CATCH_UP == 'true':
+                start_options = [LOCAL_STRING(30398)]
+                # add inning start options
+                for x in range(1, 12):
+                    start_options.append(LOCAL_STRING(30409) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
+                    start_options.append(LOCAL_STRING(30410) + ' ' + LOCAL_STRING(30407) + ' ' + str(x))
+                p = dialog.select(LOCAL_STRING(30396), start_options)
+                if p > 0:
+                    start_inning = int(round(((p+0.5) / 2), 0))
+                    if (p % 2) == 0 and ((p+1) % 2) == 1:
+                        start_inning_half = 'bottom'
+                elif p == -1:
+                    sys.exit()
+
+    if skip_possible == True and ASK_TO_SKIP == 'true':
+        skip_type = dialog.select(LOCAL_STRING(30403), [LOCAL_STRING(30404), LOCAL_STRING(30408), LOCAL_STRING(30405), LOCAL_STRING(30406)])
+        if skip_type == -1:
+            sys.exit()
 
     if '.m3u8' in stream_url:
-        play_stream(stream_url, headers, spoiler, start, stream_type)
+        play_stream(stream_url, headers, spoiler, start, stream_type, skip_type, content_id[n-highlight_offset], game_pk, is_live, start_inning, start_inning_half)
 
     elif stream_title[n] == LOCAL_STRING(30391):
         highlight_select_stream(json_source['highlights']['highlights']['items'])
@@ -476,10 +522,9 @@ def featured_stream_select(featured_video, name):
         if 'items' in video_list:
             for item in video_list['items']:
                 #xbmc.log(str(item))
-                # use a fuzzy search to match live Big Inning title
-                # because it has contained extra whitespace at the end before
-                if featured_video in item['title']:
-                    xbmc.log('found fuzzy match')
+                # live Big Inning title should start with LIVE and contain Big Inning
+                if (featured_video == (LOCAL_STRING(30367) + LOCAL_STRING(30368)) and item['title'].startswith('LIVE') and 'Big Inning' in item['title']) or featured_video == item['title']:
+                    xbmc.log('found match')
                     video_url = None
                     if 'fields' in item:
                         if 'playbackScenarios' in item['fields']:
@@ -495,8 +540,8 @@ def featured_stream_select(featured_video, name):
 
     xbmc.log('video url : ' + video_url)
     video_stream_url = None
-    # if it's not a Big Inning stream (fuzzy name search) and it is HLS (M3U8) or MP4, we can simply stream the URL we already have
-    if BIG_INNING_LIVE_NAME not in name and (video_url.endswith('.m3u8') or video_url.endswith('.mp4')):
+    # if it's not a Big Inning stream and it is HLS (M3U8) or MP4, we can simply stream the URL we already have
+    if (not name.startswith('LIVE') or (name.startswith('LIVE') and 'Big Inning' not in name)) and (video_url.endswith('.m3u8') or video_url.endswith('.mp4')):
         video_stream_url = video_url
     # otherwise we need to authenticate and get the stream URL
     else:
@@ -536,7 +581,7 @@ def featured_stream_select(featured_video, name):
             video_stream_url = account.get_stream_quality(video_stream_url)
         # known issue warning: on Kodi 18 Leia WITHOUT inputstream adaptive, Big Inning starts at the beginning and can't seek
         # anyone with inputstream adaptive, or Kodi 19+, will not have this problem
-        if BIG_INNING_LIVE_NAME in name and KODI_VERSION < 19 and not xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
+        if name.startswith('LIVE') and 'Big Inning' in name and KODI_VERSION < 19 and not xbmc.getCondVisibility('System.HasAddon(inputstream.adaptive)'):
             dialog = xbmcgui.Dialog()
             dialog.ok(LOCAL_STRING(30370), LOCAL_STRING(30369))
         play_stream(video_stream_url, headers)
@@ -586,9 +631,12 @@ def highlight_select_stream(json_source, catchup=None):
         sys.exit()
 
 
-def play_stream(stream_url, headers, spoiler='True', start='1', stream_type='video'):
+def play_stream(stream_url, headers, spoiler='True', start='1', stream_type='video', skip_type=0, content_id=None, game_pk=None, is_live=False, start_inning=0, start_inning_half='top'):
     listitem = stream_to_listitem(stream_url, headers, spoiler, start, stream_type)
     xbmcplugin.setResolvedUrl(handle=addon_handle, succeeded=True, listitem=listitem)
+    if skip_type > 0 or start_inning > 0:
+        mlbmonitor = MLBMonitor()
+        mlbmonitor.skip_monitor(skip_type, content_id, game_pk, is_live, start_inning, start_inning_half)
 
 
 def get_highlights(items):
@@ -613,7 +661,7 @@ def playAllHighlights(stream_date):
     if n == -1:
         sys.exit()
 
-    url = 'https://statsapi.mlb.com/api/v1/schedule'
+    url = API_URL + '/api/v1/schedule'
     url += '?hydrate=game(content(highlights(highlights)))'
     url += '&sportId=1,51'
     url += '&date=' + stream_date

--- a/plugin.video.mlbtv/resources/lib/mlbmonitor.py
+++ b/plugin.video.mlbtv/resources/lib/mlbmonitor.py
@@ -1,0 +1,259 @@
+from resources.lib.utils import Util
+from resources.lib.globals import *
+
+class MLBMonitor(xbmc.Monitor):
+    stream_started = False
+    stream_start_tries = 5
+    verify = True
+    broadcast_start_timestamp = None
+
+    def __init__(self, *args, **kwargs):
+        xbmc.log("MLB Monitor init")
+        self.monitor = xbmc.Monitor()
+
+    # override the onSettingsChanged method to detect if a new MLB monitor has started (so we can close this one)
+    def onSettingsChanged(self):
+        xbmc.log("MLB Monitor detected settings changed")
+        settings = xbmcaddon.Addon(id='plugin.video.mlbtv')
+        new_mlb_monitor_started = str(settings.getSetting(id="mlb_monitor_started"))
+        if self.mlb_monitor_started != new_mlb_monitor_started:
+            xbmc.log("MLB Monitor from " + self.mlb_monitor_started + " closing due to another monitor starting on " + new_mlb_monitor_started)
+            self.mlb_monitor_started = ''
+
+    def skip_monitor(self, skip_type, content_id, game_pk, is_live, start_inning, start_inning_half):
+        xbmc.log("Skip monitor for " + content_id + " starting")
+
+        self.mlb_monitor_started = str(datetime.now())
+        settings.setSetting(id='mlb_monitor_started', value=self.mlb_monitor_started)
+        xbmc.log("Skip monitor for " + content_id + " started at " + self.mlb_monitor_started)
+
+        # initialize player to monitor play time
+        player = xbmc.Player()
+        last_time = None
+
+        # fetch skip markers
+        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, 0, start_inning, start_inning_half)
+        xbmc.log('Skip monitor for ' + content_id + ' skip markers : ' + str(skip_markers))
+
+        while not self.monitor.abortRequested():
+            if self.monitor.waitForAbort(1):
+                xbmc.log("Skip monitor for " + content_id + " aborting")
+                break
+            elif len(skip_markers) == 0:
+                xbmc.log("Skip monitor for " + content_id + " closing due to no more skip markers")
+                break
+            elif self.stream_started == True and not xbmc.getCondVisibility("Player.HasMedia"):
+                xbmc.log("Skip monitor for " + content_id + " closing due to stream stopped")
+                break
+            elif self.mlb_monitor_started == '':
+                xbmc.log("Skip monitor for " + content_id + " closing due to reset")
+                break
+            elif xbmc.getCondVisibility("Player.HasMedia"):
+                if self.stream_started == False:
+                    xbmc.log("Skip monitor for " + content_id + " detected stream start")
+                    self.stream_started = True
+                    # just for fun, we can log our stream duration, to compare it against skip time detected
+                    if start_inning == 0:
+                        try:
+                            total_stream_time = player.getTotalTime()
+                            xbmc.log('Skip monitor for ' + content_id + ' total stream time ' + str(timedelta(seconds=total_stream_time)))
+                        except:
+                            pass
+                current_time = player.getTime()
+                # make sure we're not paused, and current time is valid (less than 10 hours) -- sometimes Kodi was returning a crazy large current time as the stream was starting
+                if current_time > 0 and current_time != last_time and current_time < 36000:
+                    last_time = current_time
+                    # remove any past skip markers so user can seek backward freely
+                    while len(skip_markers) > 0 and current_time > skip_markers[0][1]:
+                        xbmc.log("Skip monitor for " + content_id + " removed skip marker at " + str(skip_markers[0][1]) + ", before current time " + str(current_time))
+                        skip_markers.pop(0)
+                    # seek to end of break if we fall within skip marker range, then remove marker so user can seek backward freely
+                    if len(skip_markers) > 0 and current_time >= skip_markers[0][0] and current_time < skip_markers[0][1]:
+                        xbmc.log("Skip monitor for " + content_id + " processed skip marker at " + str(skip_markers[0][1]))
+                        player.seekTime(skip_markers[0][1])
+                        skip_markers.pop(0)
+                        # since we just processed a skip marker, we can delay further processing a little bit
+                        xbmc.sleep(2000)
+                    # if we've run out of skip markers and it's a live event and we're skipping things, check for more
+                    if len(skip_markers) == 0 and is_live == True and skip_type > 0:
+                        # refresh current time, and look ahead slightly
+                        current_time = player.getTime() + 10
+                        xbmc.log('Skip monitor for ' + content_id + ' refreshing skip markers from ' + str(current_time))
+                        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, current_time)
+                        xbmc.log('Skip monitor for ' + content_id + ' refreshed skip markers : ' + str(skip_markers))
+            else:
+                if self.stream_started == False:
+                    xbmc.log("Skip monitor for " + content_id + " waiting for stream to start")
+                    self.stream_start_tries -= 1
+                    if self.stream_start_tries < 1:
+                        xbmc.log("Skip monitor for " + content_id + " closing due to stream not starting")
+                        break
+
+            # wait 1 second until next loop iteration
+            xbmc.sleep(1000)
+
+        xbmc.log("Skip monitor for " + content_id + " closed")
+
+
+    # get the gameday data, which contains the event timestamps
+    def get_gameday_data(self, game_pk):
+        xbmc.log('Skip monitor for ' + game_pk + ' getting gameday data')
+
+        url = API_URL + '/api/v1.1/game/' + game_pk + '/feed/live'
+        headers = {
+            'User-agent': UA_PC,
+            'Origin': 'https://www.mlb.com',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Content-type': 'application/json'
+        }
+        r = requests.get(url, headers=headers, verify=self.verify)
+        json_source = r.json()
+        return json_source
+
+
+    # calculate skip markers from gameday events
+    def get_skip_markers(self, skip_type, content_id, game_pk, current_time=0, start_inning=0, start_inning_half='top'):
+        xbmc.log('Skip monitor for ' + content_id + ' getting skip markers for skip type ' + str(skip_type))
+        if current_time > 0:
+            xbmc.log('Skip monitor for ' + content_id + ' searching beyond ' + str(current_time))
+
+        # initialize our list of skip times
+        skip_markers = []
+
+        # first get the broadcast start time, so we can subtract it from the event timestamps
+        self.broadcast_start_timestamp = self.get_broadcast_start(content_id)
+        if self.broadcast_start_timestamp is None:
+            xbmc.log('Skip monitor for ' + content_id + ' failed to find broadcast start timestamp')
+            self.mlb_monitor_started = ''
+        else:
+            json_source = self.get_gameday_data(game_pk)
+
+            # calculate total skip time (for fun)
+            total_skip_time = 0
+
+            # make sure we have play data
+            if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
+                # assume the game starts in a break
+                break_start = 0
+
+                # keep track of inning, if skipping inning breaks only
+                previous_inning = 0
+                previous_inning_half = None
+
+                # make sure start inning is valid
+                if start_inning > 0:
+                    last_play_index = len(json_source['liveData']['plays']['allPlays']) - 1
+                    final_inning = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['inning']
+                    if start_inning >= final_inning:
+                        if start_inning > final_inning:
+                            start_inning = final_inning
+                        final_inning_half = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['halfInning']
+                        if start_inning_half == 'bottom' and final_inning_half == 'top':
+                            start_inning_half = final_inning_half
+
+                # loop through all plays
+                for play in json_source['liveData']['plays']['allPlays']:
+                    # exit loop after found inning, if not skipping any breaks
+                    if skip_type == 0 and len(skip_markers) == 1:
+                        break
+                    current_inning = play['about']['inning']
+                    current_inning_half = play['about']['halfInning']
+                    # make sure we're past our start inning
+                    if current_inning > start_inning or (current_inning == start_inning and (current_inning_half == start_inning_half or current_inning_half == 'bottom')):
+                        # loop through events within each play
+                        for index, playEvent in enumerate(play['playEvents']):
+                            # always exclude break types
+                            if 'event' in playEvent['details'] and playEvent['details']['event'] in BREAK_TYPES:
+                                # if we're in the process of skipping inning breaks, treat the first break type we find as another inning break
+                                if skip_type == 1 and previous_inning > 0:
+                                    break_start = (parse(playEvent['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                    previous_inning = 0
+                                continue
+                            else:
+                                action_index = None
+                                # skip type 1 (breaks) and 2 (idle time) will look at all plays with an endTime
+                                if skip_type <= 2 and 'endTime' in playEvent:
+                                    action_index = index
+                                elif skip_type == 3:
+                                    # skip type 3 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
+                                    if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in ACTION_TYPES)):
+                                        continue
+                                    else:
+                                        # if the action is associated with another play or the event doesn't have an end time, use the previous event instead
+                                        if ('actionPlayId' in playEvent or 'endTime' not in playEvent) and index > 0:
+                                            action_index = index - 1
+                                        else:
+                                            action_index = index
+                                if action_index is None:
+                                    continue
+                                else:
+                                    break_end = (parse(play['playEvents'][action_index]['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_START_PADDING
+                                    # if the break end should be greater than the current playback time
+                                    # and the break duration should be greater than than our specified minimum
+                                    # and if skip type is not 1 (inning breaks) or the inning has changed
+                                    # then we'll add the skip marker
+                                    # otherwise we'll ignore it and move on to the next one
+                                    if break_end > current_time and (break_end - break_start) >= MINIMUM_BREAK_DURATION and (skip_type != 1 or current_inning != previous_inning or current_inning_half != previous_inning_half):
+                                        skip_markers.append([break_start, break_end])
+                                        total_skip_time += break_end - break_start
+                                        previous_inning = current_inning
+                                        previous_inning_half = current_inning_half
+                                        # exit loop after found inning, if not skipping breaks
+                                        if skip_type == 0:
+                                            break
+                                    break_start = (parse(play['playEvents'][action_index]['endTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                    # add extra padding for overturned review plays
+                                    if 'reviewDetails' in play and play['reviewDetails']['isOverturned'] == True:
+                                        break_start += 40
+
+            xbmc.log('Skip monitor for ' + content_id + ' found ' + str(timedelta(seconds=total_skip_time)) + ' total skip time')
+
+        return skip_markers
+
+
+    # get the airings data, which contains the start time of the broadcast
+    def get_airings_data(self, content_id):
+        xbmc.log('Skip monitor for ' + content_id + ' getting airings data')
+        url = 'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings'
+        headers = {
+            'Accept': 'application/json',
+            'X-BAMSDK-Version': '4.3',
+            'X-BAMSDK-Platform': 'macintosh',
+            'User-Agent': UA_PC,
+            'Origin': 'https://www.mlb.com',
+            'Accept-Encoding': 'gzip, deflate, br',
+            'Content-type': 'application/json'
+        }
+        data = {
+            'variables': '%7B%22contentId%22%3A%22' + content_id + '%22%7D'
+        }
+        r = requests.get(url, headers=headers, params=data, verify=self.verify)
+        json_source = r.json()
+
+        return json_source
+
+
+    # get the start time of the broadcast, to subtract from event timestamps
+    def get_broadcast_start(self, content_id):
+        xbmc.log('Skip monitor for ' + content_id + ' getting broadcast start')
+        # if we've already retrieved it, just return that value
+        if self.broadcast_start_timestamp is not None:
+            return self.broadcast_start_timestamp
+        else:
+            broadcast_start_timestamp = None
+
+            json_source = self.get_airings_data(content_id)
+
+            # make sure we have milestone data
+            if 'data' in json_source and 'Airings' in json_source['data'] and len(json_source['data']['Airings']) > 0 and 'milestones' in json_source['data']['Airings'][0]:
+                for milestone in json_source['data']['Airings'][0]['milestones']:
+                    if milestone['milestoneType'] == 'BROADCAST_START':
+                        offset_index = 1
+                        startDatetime_index = 0
+                        if milestone['milestoneTime'][0]['type'] == 'offset':
+                            offset_index = 0
+                            startDatetime_index = 1
+                        broadcast_start_timestamp = parse(milestone['milestoneTime'][startDatetime_index]['startDatetime']) - timedelta(seconds=milestone['milestoneTime'][offset_index]['start'])
+                        break
+
+            return broadcast_start_timestamp

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -28,6 +28,7 @@
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
     <setting id="time_format" type="select" label="30301" lvalues="30302|30301" default="0" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
+    <setting id="ask_to_skip" type="bool" label="30306" default="true" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
 
     <setting id="old_username" type="text" label="" default="" visible="false"/>
@@ -36,6 +37,7 @@
     <setting id="stream_date" type="text" label="" default="" visible="false"/>
     <setting id="big_inning_date" type="text" label="" default="" visible="false"/>
     <setting id="big_inning_schedule" type="text" label="" default="" visible="false"/>
+    <setting id="mlb_monitor_started" type="text" label="" default="" visible="false"/>
   </category>
   <!--Proxy-->
   <category label='30200'>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.5.5
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - options to automatically skip breaks and non-action pitches
            - option to start at specific inning
            - improved Big Inning stream retrieval
            - perfect game / no hitter flags
            - fix free games only
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
