### PR TITLE
[plugin.video.mlbtv@matrix] 2022.5.6+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.5+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.6+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -21,11 +21,10 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - options to automatically skip breaks and non-action pitches
-            - option to start at specific inning
-            - improved Big Inning stream retrieval
-            - perfect game / no hitter flags
-            - fix free games only
+            - restored pass exceptions for game list items
+            - handle missing flags for postponements
+            - added setting for auto selecting a stream (favorite/home)
+            - added context menu item for choosing stream manually
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -45,6 +45,9 @@ elif mode == 101:
     # Prev and Next
     todays_games(game_day)
 
+# from context menu, use an extra parameter to force manual stream selection
+elif mode == 103:
+    stream_select(game_pk, spoiler, True)
 
 elif mode == 104:
     stream_select(game_pk, spoiler)
@@ -55,6 +58,14 @@ elif mode == 105:
     display_day = stringToDate(game_day, "%Y-%m-%d")
     prev_day = display_day - timedelta(days=1)
     todays_games(prev_day.strftime("%Y-%m-%d"))
+
+# highlights from context menu
+elif mode == 106:
+    list_highlights(game_pk)
+
+# play all highlights for game from context menu
+elif mode == 107:
+    play_all_highlights_for_game(game_pk)
 
 elif mode == 200:
     # Goto Date

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -120,6 +120,10 @@ msgctxt "#30306"
 msgid "Ask to automatically skip breaks"
 msgstr ""
 
+msgctxt "#30307"
+msgid "Auto-select favorite/home video stream"
+msgstr ""
+
 msgctxt "#30300"
 msgid "In Market Streams"
 msgstr ""
@@ -328,3 +332,6 @@ msgctxt "#30410"
 msgid "Bottom"
 msgstr ""
 
+msgctxt "#30411"
+msgid "Play All"
+msgstr ""

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -45,6 +45,7 @@ FAV_TEAM = str(settings.getSetting(id="fav_team"))
 TEAM_NAMES = settings.getSetting(id="team_names")
 TIME_FORMAT = settings.getSetting(id="time_format")
 SINGLE_TEAM = str(settings.getSetting(id='single_team'))
+AUTO_SELECT_STREAM = str(settings.getSetting(id='auto_select_stream'))
 CATCH_UP = str(settings.getSetting(id='catch_up'))
 ASK_TO_SKIP = str(settings.getSetting(id='ask_to_skip'))
 ONLY_FREE_GAMES = str(settings.getSetting(id="only_free_games"))
@@ -209,6 +210,9 @@ def add_stream(name, title, game_pk, icon=None, fanart=None, info=None, video_in
         liz.addStreamInfo('video', video_info)
     if audio_info is not None:
         liz.addStreamInfo('audio', audio_info)
+
+    # add Choose Stream and Highlights as context menu items
+    liz.addContextMenuItems([(LOCAL_STRING(30390), 'PlayMedia(plugin://plugin.video.mlbtv/?mode='+str(103)+'&name='+urllib.quote_plus(name)+'&game_pk='+urllib.quote_plus(str(game_pk))+'&stream_date='+urllib.quote_plus(str(stream_date))+'&spoiler='+urllib.quote_plus(str(spoiler))+')'), (LOCAL_STRING(30391), 'Container.Update(plugin://plugin.video.mlbtv/?mode='+str(106)+'&name='+urllib.quote_plus(name)+'&game_pk='+urllib.quote_plus(str(game_pk))+')')])
 
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=False)
     xbmcplugin.setContent(addon_handle, 'episodes')

--- a/plugin.video.mlbtv/resources/lib/mlbmonitor.py
+++ b/plugin.video.mlbtv/resources/lib/mlbmonitor.py
@@ -89,9 +89,6 @@ class MLBMonitor(xbmc.Monitor):
                         xbmc.log("Skip monitor for " + content_id + " closing due to stream not starting")
                         break
 
-            # wait 1 second until next loop iteration
-            xbmc.sleep(1000)
-
         xbmc.log("Skip monitor for " + content_id + " closed")
 
 

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -27,6 +27,7 @@
     
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
     <setting id="time_format" type="select" label="30301" lvalues="30302|30301" default="0" />
+    <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.5.6+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - restored pass exceptions for game list items
            - handle missing flags for postponements
            - added setting for auto selecting a stream (favorite/home)
            - added context menu item for choosing stream manually
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
