### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.11+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.11 (2022-05-15)
+- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu (@mediaminister)
+
 ### v2.5.10 (2022-04-29)
 - Fix watching from the tv guide (@mediaminister)
 - Fix season menu labels (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.10+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT NU" version="2.5.11+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.11 (2022-05-15)
+- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu
+
 v2.5.10 (2022-04-29)
 - Fix watching from the tv guide
 - Fix season menu labels

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -316,13 +316,6 @@ def play_air_date(channel, start_date, end_date=None):
     VRTPlayer().play_episode_by_air_date(channel, start_date, end_date)
 
 
-@plugin.route('/play/whatson/<whatson_id>')
-def play_whatson_id(whatson_id):
-    """The API interface to play a video by using a whatson_id"""
-    from vrtplayer import VRTPlayer
-    VRTPlayer().play_episode_by_whatson_id(whatson_id=whatson_id)
-
-
 @plugin.route('/play/episode/<episode_id>')
 def play_episode_id(episode_id):
     """The API interface to play a video by using a episodeId"""

--- a/plugin.video.vrt.nu/resources/lib/data.py
+++ b/plugin.video.vrt.nu/resources/lib/data.py
@@ -290,7 +290,7 @@ FEATURED = [
     # Inhoudsgerelateerd
     dict(name='Kortfilm', id='kortfilm', msgctxt=30120),
     # dict(name='12+', id='12+', msgctxt=30121),
-    dict(name='Cinema canvas', id='cinema-canvas', msgctxt=30122),
+    # dict(name='Cinema canvas', id='cinema-canvas', msgctxt=30122),
     # Thema
     dict(name='Klimaat', id='klimaat', msgctxt=30128),
     # dict(name='Koers', id='koers', msgctxt=30129),

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -7,7 +7,7 @@ from apihelper import ApiHelper
 from favorites import Favorites
 from helperobjects import TitleItem
 from kodiutils import (colour, delete_cached_thumbnail, end_of_directory, get_addon_info,
-                       get_setting, get_setting_bool, get_setting_int, has_credentials,
+                       get_setting, get_setting_bool, has_credentials,
                        has_inputstream_adaptive, localize, kodi_version_major, log_error,
                        ok_dialog, play, set_setting, show_listing, ttl, url_for,
                        wait_for_resumepoints)
@@ -283,18 +283,16 @@ class VRTPlayer:
         # My favorites menus may need more up-to-date favorites
         self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
-        page = realpage(page)
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='recent')
 
         # Add 'More...' entry at the end
-        if len(episode_items) == get_setting_int('itemsperpage', default=50):
-            recent = 'favorites_recent' if use_favorites else 'recent'
-            episode_items.append(TitleItem(
-                label=colour(localize(30300)),
-                path=url_for(recent, page=page + 1),
-                art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
-                info_dict={},
-            ))
+        recent = 'favorites_recent' if use_favorites else 'recent'
+        episode_items.append(TitleItem(
+            label=colour(localize(30300)),
+            path=url_for(recent, page=realpage(page) + 1),
+            art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
+            info_dict={},
+        ))
 
         show_listing(episode_items, category=30020, sort=sort, ascending=ascending, content=content, cache=False)
 
@@ -304,21 +302,17 @@ class VRTPlayer:
         # My favorites menus may need more up-to-date favorites
         self._favorites.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
         self._resumepoints.refresh(ttl=ttl('direct' if use_favorites else 'indirect'))
-        page = realpage(page)
-        items_per_page = get_setting_int('itemsperpage', default=50)
-        sort_key = 'offTime'
-        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, items_per_page=items_per_page, use_favorites=use_favorites,
-                                                                                variety='offline', sort_key=sort_key)
+        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, use_favorites=use_favorites, variety='offline')
 
         # Add 'More...' entry at the end
-        if len(episode_items) == items_per_page:
-            offline = 'favorites_offline' if use_favorites else 'offline'
-            episode_items.append(TitleItem(
-                label=localize(30300),
-                path=url_for(offline, page=page + 1),
-                art_dict=dict(thumb='DefaultYear.png'),
-                info_dict={},
-            ))
+        # if len(episode_items) == items_per_page:
+        offline = 'favorites_offline' if use_favorites else 'offline'
+        episode_items.append(TitleItem(
+            label=localize(30300),
+            path=url_for(offline, page=realpage(page) + 1),
+            art_dict=dict(thumb='DefaultYear.png'),
+            info_dict={},
+        ))
 
         show_listing(episode_items, category=30022, sort=sort, ascending=ascending, content=content, cache=False)
 
@@ -361,16 +355,6 @@ class VRTPlayer:
             return
         if not video:
             log_error('Play episode by air date failed, channel {channel}, start_date {start}', channel=channel, start=start_date)
-            ok_dialog(message=localize(30954))
-            end_of_directory()
-            return
-        self.play(video)
-
-    def play_episode_by_whatson_id(self, whatson_id):
-        """Play an episode of a program given the whatson_id"""
-        video = self._apihelper.get_single_episode(whatson_id=whatson_id)
-        if not video:
-            log_error('Play episode by whatson_id failed, whatson_id {whatson_id}', whatson_id=whatson_id)
             ok_dialog(message=localize(30954))
             end_of_directory()
             return


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT NU
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.11+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT NU is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT NU

[I]The VRT NU add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
