### PR TITLE
[plugin.video.mlbtv@matrix] 2022.5.19+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.6+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.19+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -12,6 +12,7 @@
     <extension point="xbmc.python.pluginsource" library="main.py">
         <provides>video</provides>
     </extension>
+    <extension point="xbmc.service" library="service.py" />
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <summary lang="en_GB">Watch live and archived games
@@ -21,10 +22,15 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - restored pass exceptions for game list items
-            - handle missing flags for postponements
-            - added setting for auto selecting a stream (favorite/home)
-            - added context menu item for choosing stream manually
+            - pad the end of archive videos if no spoilers (to avoid timeline spoilers)
+            - autoplay favorite team setting
+            - see scores at inning category
+            - hide bottom of 9th / extra innings as spoilers
+            - labels for suspended/resumed games/streams
+            - retain icon/fanart/probables through context menu navigation
+            - list favorite team's game(s) first
+            - removed unused/unnecessary settings (in market streams and proxy)
+            - added probable pitchers to game list titles
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -9,7 +9,12 @@ gid = None
 teams_stream = None
 stream_date = None
 spoiler = 'True'
+suspended = 'False'
+start_inning = 'False'
+icon = None
+fanart = None
 featured_video = None
+description = None
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -32,49 +37,92 @@ if 'stream_date' in params:
 if 'spoiler' in params:
     spoiler = urllib.unquote_plus(params["spoiler"])
 
+if 'suspended' in params:
+    suspended = urllib.unquote_plus(params["suspended"])
+
+if 'icon' in params:
+    icon = urllib.unquote_plus(params["icon"])
+
+if 'fanart' in params:
+    fanart = urllib.unquote_plus(params["fanart"])
+
+if 'start_inning' in params:
+    start_inning = urllib.unquote_plus(params["start_inning"])
+
 if 'featured_video' in params:
     featured_video = urllib.unquote_plus(params["featured_video"])
 
+if 'description' in params:
+    description = urllib.unquote_plus(params["description"])
+
+# default addon home screen
 if mode is None:
+    # autoplay fav team, if that setting is enabled and a live broadcast is in progress
+    if AUTO_PLAY_FAV == 'true' and FAV_TEAM != 'None':
+        live_game = live_fav_game()
+        if live_game is not None:
+            xbmc.log('Auto-playing live game ' + str(live_game))
+            xbmc.executebuiltin('PlayMedia("plugin://plugin.video.mlbtv/?mode=102&game_pk='+str(live_game)+'")')
+            xbmcplugin.endOfDirectory(addon_handle)
+    # if no autoplay, show the main options
     categories()
 
+# Today's Games
 elif mode == 100:
-    todays_games(None)
+    todays_games(None, start_inning)
 
+# Prev and Next
 elif mode == 101:
-    # Prev and Next
-    todays_games(game_day)
+    todays_games(game_day, start_inning)
+
+# autoplay, use an extra parameter to force auto stream selection
+elif mode == 102:
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, autoplay=True)
 
 # from context menu, use an extra parameter to force manual stream selection
 elif mode == 103:
-    stream_select(game_pk, spoiler, True)
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, from_context_menu=True)
 
+# normal stream selection
 elif mode == 104:
-    stream_select(game_pk, spoiler)
+    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart)
 
+# Yesterday's Games
 elif mode == 105:
-    # Yesterday's Games
-    game_day = localToEastern()
-    display_day = stringToDate(game_day, "%Y-%m-%d")
-    prev_day = display_day - timedelta(days=1)
-    todays_games(prev_day.strftime("%Y-%m-%d"))
+    todays_games(yesterdays_date(), start_inning)
 
 # highlights from context menu
 elif mode == 106:
-    list_highlights(game_pk)
+    list_highlights(game_pk, icon, fanart)
 
 # play all highlights for game from context menu
 elif mode == 107:
-    play_all_highlights_for_game(game_pk)
+    play_all_highlights_for_game(game_pk, fanart)
 
+# see yesterday's scores at inning
+elif mode == 108:
+    start_inning = 'False'
+    dialog = xbmcgui.Dialog()
+    innings = []
+    # show inning options from 1 to 12
+    for x in range(1, 13):
+        innings.append(LOCAL_STRING(30407) + ' ' + str(x))
+    n = dialog.select(LOCAL_STRING(30413), innings)
+    if n > -1:
+        start_inning = (n + 1)
+    game_day = yesterdays_date()
+    # Refresh will erase history, so navigating back won't bring up the inning prompt again
+    xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
+
+# Goto Date
 elif mode == 200:
-    # Goto Date
     search_txt = ''
     dialog = xbmcgui.Dialog()
     game_day = dialog.input('Enter date (yyyy-mm-dd)', type=xbmcgui.INPUT_ALPHANUM)
     mat = re.match('(\d{4})-(\d{2})-(\d{2})$', game_day)
     if mat is not None:
-        todays_games(game_day)
+        # Refresh will erase history, so navigating back won't bring up the date prompt again
+        xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
     else:
         if game_day != '':
             dialog = xbmcgui.Dialog()
@@ -82,28 +130,32 @@ elif mode == 200:
 
         sys.exit()
 
+# Featured Videos
 elif mode == 300:
-    # Featured Videos
     featured_videos(featured_video)
 
+# Featured stream select
 elif mode == 301:
-    featured_stream_select(featured_video, name)
+    featured_stream_select(featured_video, name, description)
 
+# Logout
 elif mode == 400:
     account = Account()
     account.logout()
     dialog = xbmcgui.Dialog()
     dialog.notification(LOCAL_STRING(30260), LOCAL_STRING(30261), ICON, 5000, False)
 
+# play all recaps or condensed games for selected date
 elif mode == 900:
-    # play all recaps or condensed games for selected date
     playAllHighlights(stream_date)
 
 elif mode == 999:
     sys.exit()
 
-if mode == 100:
+# don't cache today's games or addon home screen
+if mode == 100 or (mode is None and AUTO_PLAY_FAV == 'true' and FAV_TEAM != 'None'):
     xbmcplugin.endOfDirectory(addon_handle, cacheToDisc=False)
+# also don't cache previous/next days
 elif mode == 101:
     xbmcplugin.endOfDirectory(addon_handle, cacheToDisc=False, updateListing=True)
 else:

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -124,36 +124,8 @@ msgctxt "#30307"
 msgid "Auto-select favorite/home video stream"
 msgstr ""
 
-msgctxt "#30300"
-msgid "In Market Streams"
-msgstr ""
-
 msgctxt "#30700"
 msgid "Sports"
-msgstr ""
-
-msgctxt "#30200"
-msgid "Proxy Settings"
-msgstr ""
-
-msgctxt "#30210"
-msgid "Enabled"
-msgstr ""
-
-msgctxt "#30220"
-msgid "Server"
-msgstr ""
-
-msgctxt "#30230"
-msgid "Port"
-msgstr ""
-
-msgctxt "#30240"
-msgid "Username"
-msgstr ""
-
-msgctxt "#30250"
-msgid "Password"
 msgstr ""
 
 msgctxt "#30260"
@@ -334,4 +306,12 @@ msgstr ""
 
 msgctxt "#30411"
 msgid "Play All"
+msgstr ""
+
+msgctxt "#30412"
+msgid "Auto-play live favorite games when starting addon"
+msgstr ""
+
+msgctxt "#30413"
+msgid "See Yesterday's Scores at inning"
 msgstr ""

--- a/plugin.video.mlbtv/resources/lib/mlbmonitor.py
+++ b/plugin.video.mlbtv/resources/lib/mlbmonitor.py
@@ -20,43 +20,43 @@ class MLBMonitor(xbmc.Monitor):
             xbmc.log("MLB Monitor from " + self.mlb_monitor_started + " closing due to another monitor starting on " + new_mlb_monitor_started)
             self.mlb_monitor_started = ''
 
-    def skip_monitor(self, skip_type, content_id, game_pk, is_live, start_inning, start_inning_half):
-        xbmc.log("Skip monitor for " + content_id + " starting")
+    def skip_monitor(self, skip_type, game_pk, broadcast_start_timestamp, is_live, start_inning, start_inning_half):
+        xbmc.log("Skip monitor for " + game_pk + " starting")
 
         self.mlb_monitor_started = str(datetime.now())
         settings.setSetting(id='mlb_monitor_started', value=self.mlb_monitor_started)
-        xbmc.log("Skip monitor for " + content_id + " started at " + self.mlb_monitor_started)
+        xbmc.log("Skip monitor for " + game_pk + " started at " + self.mlb_monitor_started)
 
         # initialize player to monitor play time
         player = xbmc.Player()
         last_time = None
 
         # fetch skip markers
-        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, 0, start_inning, start_inning_half)
-        xbmc.log('Skip monitor for ' + content_id + ' skip markers : ' + str(skip_markers))
+        skip_markers = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, 0, start_inning, start_inning_half)
+        xbmc.log('Skip monitor for ' + game_pk + ' skip markers : ' + str(skip_markers))
 
         while not self.monitor.abortRequested():
             if self.monitor.waitForAbort(1):
-                xbmc.log("Skip monitor for " + content_id + " aborting")
+                xbmc.log("Skip monitor for " + game_pk + " aborting")
                 break
             elif len(skip_markers) == 0:
-                xbmc.log("Skip monitor for " + content_id + " closing due to no more skip markers")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to no more skip markers")
                 break
             elif self.stream_started == True and not xbmc.getCondVisibility("Player.HasMedia"):
-                xbmc.log("Skip monitor for " + content_id + " closing due to stream stopped")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to stream stopped")
                 break
             elif self.mlb_monitor_started == '':
-                xbmc.log("Skip monitor for " + content_id + " closing due to reset")
+                xbmc.log("Skip monitor for " + game_pk + " closing due to reset")
                 break
             elif xbmc.getCondVisibility("Player.HasMedia"):
                 if self.stream_started == False:
-                    xbmc.log("Skip monitor for " + content_id + " detected stream start")
+                    xbmc.log("Skip monitor for " + game_pk + " detected stream start")
                     self.stream_started = True
                     # just for fun, we can log our stream duration, to compare it against skip time detected
                     if start_inning == 0:
                         try:
                             total_stream_time = player.getTotalTime()
-                            xbmc.log('Skip monitor for ' + content_id + ' total stream time ' + str(timedelta(seconds=total_stream_time)))
+                            xbmc.log('Skip monitor for ' + game_pk + ' total stream time ' + str(timedelta(seconds=total_stream_time)))
                         except:
                             pass
                 current_time = player.getTime()
@@ -65,11 +65,11 @@ class MLBMonitor(xbmc.Monitor):
                     last_time = current_time
                     # remove any past skip markers so user can seek backward freely
                     while len(skip_markers) > 0 and current_time > skip_markers[0][1]:
-                        xbmc.log("Skip monitor for " + content_id + " removed skip marker at " + str(skip_markers[0][1]) + ", before current time " + str(current_time))
+                        xbmc.log("Skip monitor for " + game_pk + " removed skip marker at " + str(skip_markers[0][1]) + ", before current time " + str(current_time))
                         skip_markers.pop(0)
                     # seek to end of break if we fall within skip marker range, then remove marker so user can seek backward freely
                     if len(skip_markers) > 0 and current_time >= skip_markers[0][0] and current_time < skip_markers[0][1]:
-                        xbmc.log("Skip monitor for " + content_id + " processed skip marker at " + str(skip_markers[0][1]))
+                        xbmc.log("Skip monitor for " + game_pk + " processed skip marker at " + str(skip_markers[0][1]))
                         player.seekTime(skip_markers[0][1])
                         skip_markers.pop(0)
                         # since we just processed a skip marker, we can delay further processing a little bit
@@ -78,18 +78,18 @@ class MLBMonitor(xbmc.Monitor):
                     if len(skip_markers) == 0 and is_live == True and skip_type > 0:
                         # refresh current time, and look ahead slightly
                         current_time = player.getTime() + 10
-                        xbmc.log('Skip monitor for ' + content_id + ' refreshing skip markers from ' + str(current_time))
-                        skip_markers = self.get_skip_markers(skip_type, content_id, game_pk, current_time)
-                        xbmc.log('Skip monitor for ' + content_id + ' refreshed skip markers : ' + str(skip_markers))
+                        xbmc.log('Skip monitor for ' + game_pk + ' refreshing skip markers from ' + str(current_time))
+                        skip_markers = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, current_time)
+                        xbmc.log('Skip monitor for ' + game_pk + ' refreshed skip markers : ' + str(skip_markers))
             else:
                 if self.stream_started == False:
-                    xbmc.log("Skip monitor for " + content_id + " waiting for stream to start")
+                    xbmc.log("Skip monitor for " + game_pk + " waiting for stream to start")
                     self.stream_start_tries -= 1
                     if self.stream_start_tries < 1:
-                        xbmc.log("Skip monitor for " + content_id + " closing due to stream not starting")
+                        xbmc.log("Skip monitor for " + game_pk + " closing due to stream not starting")
                         break
 
-        xbmc.log("Skip monitor for " + content_id + " closed")
+        xbmc.log("Skip monitor for " + game_pk + " closed")
 
 
     # get the gameday data, which contains the event timestamps
@@ -109,148 +109,94 @@ class MLBMonitor(xbmc.Monitor):
 
 
     # calculate skip markers from gameday events
-    def get_skip_markers(self, skip_type, content_id, game_pk, current_time=0, start_inning=0, start_inning_half='top'):
-        xbmc.log('Skip monitor for ' + content_id + ' getting skip markers for skip type ' + str(skip_type))
+    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, current_time=0, start_inning=0, start_inning_half='top'):
+        xbmc.log('Skip monitor for ' + game_pk + ' getting skip markers for skip type ' + str(skip_type))
         if current_time > 0:
-            xbmc.log('Skip monitor for ' + content_id + ' searching beyond ' + str(current_time))
+            xbmc.log('Skip monitor for ' + game_pk + ' searching beyond ' + str(current_time))
 
         # initialize our list of skip times
         skip_markers = []
 
-        # first get the broadcast start time, so we can subtract it from the event timestamps
-        self.broadcast_start_timestamp = self.get_broadcast_start(content_id)
-        if self.broadcast_start_timestamp is None:
-            xbmc.log('Skip monitor for ' + content_id + ' failed to find broadcast start timestamp')
-            self.mlb_monitor_started = ''
-        else:
-            json_source = self.get_gameday_data(game_pk)
+        json_source = self.get_gameday_data(game_pk)
 
-            # calculate total skip time (for fun)
-            total_skip_time = 0
+        # calculate total skip time (for fun)
+        total_skip_time = 0
 
-            # make sure we have play data
-            if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
-                # assume the game starts in a break
-                break_start = 0
+        # make sure we have play data
+        if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
+            # assume the game starts in a break
+            break_start = 0
 
-                # keep track of inning, if skipping inning breaks only
-                previous_inning = 0
-                previous_inning_half = None
+            # keep track of inning, if skipping inning breaks only
+            previous_inning = 0
+            previous_inning_half = None
 
-                # make sure start inning is valid
-                if start_inning > 0:
-                    last_play_index = len(json_source['liveData']['plays']['allPlays']) - 1
-                    final_inning = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['inning']
-                    if start_inning >= final_inning:
-                        if start_inning > final_inning:
-                            start_inning = final_inning
-                        final_inning_half = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['halfInning']
-                        if start_inning_half == 'bottom' and final_inning_half == 'top':
-                            start_inning_half = final_inning_half
+            # make sure start inning is valid
+            if start_inning > 0:
+                last_play_index = len(json_source['liveData']['plays']['allPlays']) - 1
+                final_inning = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['inning']
+                if start_inning >= final_inning:
+                    if start_inning > final_inning:
+                        start_inning = final_inning
+                    final_inning_half = json_source['liveData']['plays']['allPlays'][last_play_index]['about']['halfInning']
+                    if start_inning_half == 'bottom' and final_inning_half == 'top':
+                        start_inning_half = final_inning_half
 
-                # loop through all plays
-                for play in json_source['liveData']['plays']['allPlays']:
-                    # exit loop after found inning, if not skipping any breaks
-                    if skip_type == 0 and len(skip_markers) == 1:
-                        break
-                    current_inning = play['about']['inning']
-                    current_inning_half = play['about']['halfInning']
-                    # make sure we're past our start inning
-                    if current_inning > start_inning or (current_inning == start_inning and (current_inning_half == start_inning_half or current_inning_half == 'bottom')):
-                        # loop through events within each play
-                        for index, playEvent in enumerate(play['playEvents']):
-                            # always exclude break types
-                            if 'event' in playEvent['details'] and playEvent['details']['event'] in BREAK_TYPES:
-                                # if we're in the process of skipping inning breaks, treat the first break type we find as another inning break
-                                if skip_type == 1 and previous_inning > 0:
-                                    break_start = (parse(playEvent['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
-                                    previous_inning = 0
-                                continue
-                            else:
-                                action_index = None
-                                # skip type 1 (breaks) and 2 (idle time) will look at all plays with an endTime
-                                if skip_type <= 2 and 'endTime' in playEvent:
-                                    action_index = index
-                                elif skip_type == 3:
-                                    # skip type 3 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
-                                    if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in ACTION_TYPES)):
-                                        continue
-                                    else:
-                                        # if the action is associated with another play or the event doesn't have an end time, use the previous event instead
-                                        if ('actionPlayId' in playEvent or 'endTime' not in playEvent) and index > 0:
-                                            action_index = index - 1
-                                        else:
-                                            action_index = index
-                                if action_index is None:
+            # loop through all plays
+            for play in json_source['liveData']['plays']['allPlays']:
+                # exit loop after found inning, if not skipping any breaks
+                if skip_type == 0 and len(skip_markers) == 1:
+                    break
+                current_inning = play['about']['inning']
+                current_inning_half = play['about']['halfInning']
+                # make sure we're past our start inning
+                if current_inning > start_inning or (current_inning == start_inning and (current_inning_half == start_inning_half or current_inning_half == 'bottom')):
+                    # loop through events within each play
+                    for index, playEvent in enumerate(play['playEvents']):
+                        # always exclude break types
+                        if 'event' in playEvent['details'] and playEvent['details']['event'] in BREAK_TYPES:
+                            # if we're in the process of skipping inning breaks, treat the first break type we find as another inning break
+                            if skip_type == 1 and previous_inning > 0:
+                                break_start = (parse(playEvent['startTime']) - broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                previous_inning = 0
+                            continue
+                        else:
+                            action_index = None
+                            # skip type 1 (breaks) and 2 (idle time) will look at all plays with an endTime
+                            if skip_type <= 2 and 'endTime' in playEvent:
+                                action_index = index
+                            elif skip_type == 3:
+                                # skip type 3 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
+                                if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in ACTION_TYPES)):
                                     continue
                                 else:
-                                    break_end = (parse(play['playEvents'][action_index]['startTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_START_PADDING
-                                    # if the break end should be greater than the current playback time
-                                    # and the break duration should be greater than than our specified minimum
-                                    # and if skip type is not 1 (inning breaks) or the inning has changed
-                                    # then we'll add the skip marker
-                                    # otherwise we'll ignore it and move on to the next one
-                                    if break_end > current_time and (break_end - break_start) >= MINIMUM_BREAK_DURATION and (skip_type != 1 or current_inning != previous_inning or current_inning_half != previous_inning_half):
-                                        skip_markers.append([break_start, break_end])
-                                        total_skip_time += break_end - break_start
-                                        previous_inning = current_inning
-                                        previous_inning_half = current_inning_half
-                                        # exit loop after found inning, if not skipping breaks
-                                        if skip_type == 0:
-                                            break
-                                    break_start = (parse(play['playEvents'][action_index]['endTime']) - self.broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
-                                    # add extra padding for overturned review plays
-                                    if 'reviewDetails' in play and play['reviewDetails']['isOverturned'] == True:
-                                        break_start += 40
+                                    # if the action is associated with another play or the event doesn't have an end time, use the previous event instead
+                                    if ('actionPlayId' in playEvent or 'endTime' not in playEvent) and index > 0:
+                                        action_index = index - 1
+                                    else:
+                                        action_index = index
+                            if action_index is None:
+                                continue
+                            else:
+                                break_end = (parse(play['playEvents'][action_index]['startTime']) - broadcast_start_timestamp).total_seconds() + EVENT_START_PADDING
+                                # if the break end should be greater than the current playback time
+                                # and the break duration should be greater than than our specified minimum
+                                # and if skip type is not 1 (inning breaks) or the inning has changed
+                                # then we'll add the skip marker
+                                # otherwise we'll ignore it and move on to the next one
+                                if break_end > current_time and (break_end - break_start) >= MINIMUM_BREAK_DURATION and (skip_type != 1 or current_inning != previous_inning or current_inning_half != previous_inning_half):
+                                    skip_markers.append([break_start, break_end])
+                                    total_skip_time += break_end - break_start
+                                    previous_inning = current_inning
+                                    previous_inning_half = current_inning_half
+                                    # exit loop after found inning, if not skipping breaks
+                                    if skip_type == 0:
+                                        break
+                                break_start = (parse(play['playEvents'][action_index]['endTime']) - broadcast_start_timestamp).total_seconds() + EVENT_END_PADDING
+                                # add extra padding for overturned review plays
+                                if 'reviewDetails' in play and play['reviewDetails']['isOverturned'] == True:
+                                    break_start += 40
 
-            xbmc.log('Skip monitor for ' + content_id + ' found ' + str(timedelta(seconds=total_skip_time)) + ' total skip time')
+        xbmc.log('Skip monitor for ' + game_pk + ' found ' + str(timedelta(seconds=total_skip_time)) + ' total skip time')
 
         return skip_markers
-
-
-    # get the airings data, which contains the start time of the broadcast
-    def get_airings_data(self, content_id):
-        xbmc.log('Skip monitor for ' + content_id + ' getting airings data')
-        url = 'https://search-api-mlbtv.mlb.com/svc/search/v2/graphql/persisted/query/core/Airings'
-        headers = {
-            'Accept': 'application/json',
-            'X-BAMSDK-Version': '4.3',
-            'X-BAMSDK-Platform': 'macintosh',
-            'User-Agent': UA_PC,
-            'Origin': 'https://www.mlb.com',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Content-type': 'application/json'
-        }
-        data = {
-            'variables': '%7B%22contentId%22%3A%22' + content_id + '%22%7D'
-        }
-        r = requests.get(url, headers=headers, params=data, verify=self.verify)
-        json_source = r.json()
-
-        return json_source
-
-
-    # get the start time of the broadcast, to subtract from event timestamps
-    def get_broadcast_start(self, content_id):
-        xbmc.log('Skip monitor for ' + content_id + ' getting broadcast start')
-        # if we've already retrieved it, just return that value
-        if self.broadcast_start_timestamp is not None:
-            return self.broadcast_start_timestamp
-        else:
-            broadcast_start_timestamp = None
-
-            json_source = self.get_airings_data(content_id)
-
-            # make sure we have milestone data
-            if 'data' in json_source and 'Airings' in json_source['data'] and len(json_source['data']['Airings']) > 0 and 'milestones' in json_source['data']['Airings'][0]:
-                for milestone in json_source['data']['Airings'][0]['milestones']:
-                    if milestone['milestoneType'] == 'BROADCAST_START':
-                        offset_index = 1
-                        startDatetime_index = 0
-                        if milestone['milestoneTime'][0]['type'] == 'offset':
-                            offset_index = 0
-                            startDatetime_index = 1
-                        broadcast_start_timestamp = parse(milestone['milestoneTime'][startDatetime_index]['startDatetime']) - timedelta(seconds=milestone['milestoneTime'][offset_index]['start'])
-                        break
-
-            return broadcast_start_timestamp

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -21,15 +21,14 @@
     <setting id="quality" type="labelenum" label="30160" values="Best Available|Always Ask" default="Best Available" />
     <setting id="cdn" type="labelenum" label="30165" values="Akamai|Level 3|No Preference" default="No Preference"/>
     <setting id="no_spoilers" type="enum" label="30170" lvalues="30171|30172|30173|30174|30175" />
-    <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Miami Marlins|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
+    <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
 
-    <setting id="in_market" type="labelenum" label="30300" default="Show" values="Show|Hide" />
-    
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
     <setting id="time_format" type="select" label="30301" lvalues="30302|30301" default="0" />
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
+    <setting id="auto_play_fav" type="bool" label="30412" default="false" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
 
     <setting id="old_username" type="text" label="" default="" visible="false"/>
@@ -39,14 +38,8 @@
     <setting id="big_inning_date" type="text" label="" default="" visible="false"/>
     <setting id="big_inning_schedule" type="text" label="" default="" visible="false"/>
     <setting id="mlb_monitor_started" type="text" label="" default="" visible="false"/>
-  </category>
-  <!--Proxy-->
-  <category label='30200'>
-    <setting id='use_proxy' type='bool' label='30210' default='false'/>
-    <setting id='proxy_server' type='text' label='30220' default=''/>
-    <setting id='proxy_port' type='number' label='30230' default=''/>
-    <setting id='proxy_user' type='text' label='30240' default=''/>
-    <setting id='proxy_pwd' type='text' label='30250' option='hidden' default=''/>
+    <setting id="auto_play_game_date" type="text" label="" default="" visible="false"/>
+    <setting id="auto_play_game_checked" type="text" label="" default="" visible="false"/>
   </category>
 </settings>
 

--- a/plugin.video.mlbtv/service.py
+++ b/plugin.video.mlbtv/service.py
@@ -1,0 +1,123 @@
+import threading
+
+import xbmc
+import requests
+
+try:
+    # Python3
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from socketserver import ThreadingMixIn
+    from urllib.parse import urljoin
+except:
+    # Python2
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    from SocketServer import ThreadingMixIn
+    from urlparse import urljoin
+
+HOST = '127.0.0.1'
+PORT = 43670
+PROXY_URL = 'http://' + HOST + ':' + str(PORT) + '/'
+STREAM_EXTENSION = '.m3u8'
+URI_START_DELIMETER = 'URI="'
+URI_END_DELIMETER = '"'
+KEY_TEXT = '-KEY:METHOD=AES-128'
+ENDLIST_TEXT = '#EXT-X-ENDLIST'
+REMOVE_IN_HEADERS = ['upgrade', 'host', 'accept-encoding', 'pad']
+REMOVE_OUT_HEADERS = ['date', 'server', 'transfer-encoding', 'keep-alive', 'connection', 'content-length', 'content-md5', 'access-control-allow-credentials', 'content-encoding']
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        return
+
+    def do_POST(self):
+        self.send_error(404)
+
+    def do_HEAD(self):
+        self.send_error(404)
+
+    def do_GET(self):
+        url = self.path.lstrip('/').strip('\\')
+        if not url.endswith(STREAM_EXTENSION):
+            self.send_error(404)
+
+        headers = {}
+        pad = 0
+        for key in self.headers:
+            if key.lower() not in REMOVE_IN_HEADERS:
+                headers[key] = self.headers[key]
+            elif key.lower() == 'pad':
+                pad = int(self.headers[key])
+
+        response = requests.get(url, headers=headers)
+
+        self.send_response(response.status_code)
+
+        for key in response.headers:
+            if key.lower() not in REMOVE_OUT_HEADERS:
+                if key.lower() == 'access-control-allow-origin':
+                    response.headers[key] = '*'
+                self.send_header(key, response.headers[key])
+
+        self.end_headers()
+
+        content = response.content.decode('utf8')
+
+        # change relative m3u8 urls to absolute urls by looking at each line
+        line_array = content.splitlines()
+        new_line_array = []
+        for line in line_array:
+            if line.startswith('#'):
+                # look for uri parameters within non-key "#" lines
+                if KEY_TEXT not in line and URI_START_DELIMETER in line:
+                    line_split = line.split(URI_START_DELIMETER)
+                    url_split = line_split[1].split(URI_END_DELIMETER, 1)
+                    absolute_url = urljoin(url, url_split[0])
+                    if absolute_url.endswith(STREAM_EXTENSION):
+                        absolute_url = PROXY_URL + absolute_url
+                    new_line = line_split[0] + URI_START_DELIMETER + absolute_url + URI_END_DELIMETER + url_split[1]
+                    new_line_array.append(new_line)
+                else:
+                    new_line_array.append(line)
+            elif line != '':
+                absolute_url = urljoin(url, line)
+                if absolute_url.endswith(STREAM_EXTENSION):
+                    absolute_url = PROXY_URL + absolute_url
+                new_line_array.append(absolute_url)
+
+        # pad the end of the stream by the requested number of segments
+        last_item_index = len(new_line_array)-1
+        if new_line_array[last_item_index] == ENDLIST_TEXT and int(pad) > 0:
+            new_line_array.pop()
+            last_item_index -= 1
+            url_line = None
+            extinf_line = None
+            while extinf_line is None:
+                if new_line_array[last_item_index].startswith('#EXTINF:5'):
+                    extinf_line = new_line_array[last_item_index]
+                    url_line = new_line_array[last_item_index+1]
+                    break
+                last_item_index -= 1
+            for x in range(0, pad):
+                new_line_array.append(extinf_line)
+                new_line_array.append(url_line)
+            new_line_array.append(ENDLIST_TEXT)
+
+        content = "\n".join(new_line_array)
+
+        # Output the new content
+        self.wfile.write(content.encode('utf8'))
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+server = ThreadedHTTPServer((HOST, PORT), RequestHandler)
+server.allow_reuse_address = True
+httpd_thread = threading.Thread(target=server.serve_forever)
+httpd_thread.start()
+
+xbmc.Monitor().waitForAbort()
+
+server.shutdown()
+server.server_close()
+server.socket.close()
+httpd_thread.join()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.5.19+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - pad the end of archive videos if no spoilers (to avoid timeline spoilers)
            - autoplay favorite team setting
            - see scores at inning category
            - hide bottom of 9th / extra innings as spoilers
            - labels for suspended/resumed games/streams
            - retain icon/fanart/probables through context menu navigation
            - list favorite team's game(s) first
            - removed unused/unnecessary settings (in market streams and proxy)
            - added probable pitchers to game list titles
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
