### PR TITLE
[plugin.video.vtm.go@matrix] 1.3.1+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.3.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.1) (2022-06-01)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.0...v1.3.1)
+
+**Fixed bugs:**
+
+- Upgrade VTMGO REST API to version 12 [\#325](https://github.com/add-ons/plugin.video.vtm.go/pull/325) ([CasvanDongen](https://github.com/CasvanDongen))
+
 ## [v1.3.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.0) (2021-12-19)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.2.12...v1.3.0)

--- a/plugin.video.vtm.go/LICENSE
+++ b/plugin.video.vtm.go/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.0+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.1+matrix.1" provider-name="Michaël Arnauts">
     <requires>
-        <import addon="xbmc.python" version="3.0.0"/>
-        <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.requests" version="2.22.0"/>
-        <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="script.module.pyjwt" version="1.6.4"/>
-        <import addon="script.module.inputstreamhelper" version="0.3.4"/>
+        <import addon="xbmc.python" version="3.0.0" />
+        <import addon="script.module.dateutil" version="2.6.0" />
+        <import addon="script.module.pysocks" version="1.6.8" optional="true" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.routing" version="0.2.0" />
+        <import addon="script.module.pyjwt" version="1.6.4" />
+        <import addon="script.module.inputstreamhelper" version="0.3.4" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
     </extension>
-    <extension point="xbmc.service" library="service_entry.py"/>
+    <extension point="xbmc.service" library="service_entry.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Access the VTM GO library</summary>
         <description lang="en_GB">This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.</description>
@@ -22,9 +22,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.3.0 (2021-12-19)
-- Rework authentication with simplified login flow.
-- Remove broken features (library, A-Z).</news>
+	<news>v1.3.1 (2022-06-01)
+- Use new API</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/addon_entry.py
+++ b/plugin.video.vtm.go/addon_entry.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 from xbmcaddon import Addon
 
-from resources.lib import kodiutils, kodilogging
+from resources.lib import kodilogging, kodiutils
 
 # Reinitialise ADDON every invocation to fix an issue that settings are not fresh.
 kodiutils.ADDON = Addon()
@@ -13,6 +13,7 @@ kodilogging.ADDON = Addon()
 
 if __name__ == '__main__':
     from sys import argv
+
     from resources.lib.addon import run
 
     run(argv)

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -7,10 +7,10 @@ API_ENDPOINT = 'https://lfvp-api.dpgmedia.net'
 API_ANDROID_ENDPOINT = 'https://lfvp-android-api.dpgmedia.net'
 
 # These seem to be hardcoded
-STOREFRONT_MAIN = '9620cc0b-0f97-4d96-902a-827dcfd0b227'
-STOREFRONT_MOVIES = 'e3fc0750-f110-4808-ae5f-246846ff940f'
-STOREFRONT_SERIES = '1c683de4-3fb0-4cc4-9d9c-c365eba1b155'
-STOREFRONT_KIDS = '73f34fbf-301c-4deb-b366-13ba39e25996'
+STOREFRONT_MAIN = 'main'
+STOREFRONT_MOVIES = 'movies'
+STOREFRONT_SERIES = 'series'
+STOREFRONT_KIDS = 'kids'
 
 
 class Profile:

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -16,8 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTMGO/11.19 (be.vmma.vtm.zenderapp; build:14554; iOS 24) okhttp/4.9.1',
-    'x-app-version': '11',
+    'User-Agent': 'VTMGO/12.12 (be.vmma.vtm.zenderapp; build:16424; Android 24) okhttp/4.9.3',
+    'x-app-version': '12',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '24',

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
@@ -26,7 +26,7 @@ CONTENT_TYPE_EPISODE = 'EPISODE'
 
 
 class ApiUpdateRequired(Exception):
-    """ Is thrown when the an API update is required. """
+    """ Is thrown when an API update is required. """
 
 
 class VtmGo:
@@ -42,10 +42,11 @@ class VtmGo:
         """ Return the mode that should be used for API calls """
         return 'vtmgo-kids' if self.get_product() == 'VTM_GO_KIDS' else 'vtmgo'
 
-    def get_config(self):
+    @staticmethod
+    def get_config():
         """ Returns the config for the app """
         # This is currently not used
-        response = util.http_get(API_ANDROID_ENDPOINT + '/vtmgo/config', token=self._tokens.access_token)
+        response = util.http_get(API_ANDROID_ENDPOINT + '/vtmgo/config')
         info = json.loads(response.text)
 
         # This contains a player.updateIntervalSeconds that could be used to notify VTM GO about the playing progress
@@ -106,7 +107,7 @@ class VtmGo:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('row', {}).get('teasers'):
+        for item in result.get('teasers'):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                 items.append(self._parse_movie_teaser(item))
 
@@ -222,7 +223,7 @@ class VtmGo:
             thumb=movie.get('teaserImageUrl'),
             fanart=movie.get('bigPhotoUrl'),
             year=movie.get('productionYear'),
-            geoblocked=movie.get('geoBlocked'),
+            geoblocked=movie.get('blockedFor') == 'GEO',
             remaining=movie.get('remainingDaysAvailable'),
             legal=movie.get('legalIcons'),
             # aired=movie.get('broadcastTimestamp'),
@@ -248,29 +249,34 @@ class VtmGo:
             response = util.http_get(API_ENDPOINT + '/%s/programs/%s' % (self._mode(), program_id),
                                      token=self._tokens.access_token if self._tokens else None,
                                      profile=self._tokens.profile if self._tokens else None)
-            info = json.loads(response.text)
-            program = info.get('program', {})
+            program = json.loads(response.text)
             kodiutils.set_cache(['program', program_id], program)
 
         channel = self._parse_channel(program.get('channelLogoUrl'))
 
         seasons = {}
-        for item_season in program.get('seasons', []):
+        for item_season in program.get('seasonIndices', []):
             episodes = {}
 
-            for item_episode in item_season.get('episodes', []):
+            # Fetch season
+            season_response = util.http_get(API_ENDPOINT + '/%s/programs/%s/seasons/%s' % (self._mode(), program_id, item_season),
+                                            token=self._tokens.access_token if self._tokens else None,
+                                            profile=self._tokens.profile if self._tokens else None)
+            season = json.loads(season_response.text)
+
+            for item_episode in season.get('episodes', []):
                 episodes[item_episode.get('index')] = Episode(
                     episode_id=item_episode.get('id'),
                     program_id=program_id,
                     program_name=program.get('name'),
                     number=item_episode.get('index'),
-                    season=item_season.get('index'),
+                    season=item_season,
                     name=item_episode.get('name'),
                     description=item_episode.get('description'),
                     duration=item_episode.get('durationSeconds'),
                     thumb=item_episode.get('bigPhotoUrl'),
                     fanart=item_episode.get('bigPhotoUrl'),
-                    geoblocked=program.get('geoBlocked'),
+                    geoblocked=program.get('blockedFor') == 'GEO',
                     remaining=item_episode.get('remainingDaysAvailable'),
                     channel=channel,
                     legal=program.get('legalIcons'),
@@ -279,8 +285,8 @@ class VtmGo:
                     watched=item_episode.get('doneWatching', False),
                 )
 
-            seasons[item_season.get('index')] = Season(
-                number=item_season.get('index'),
+            seasons[item_season] = Season(
+                number=item_season,
                 episodes=episodes,
                 channel=channel,
                 legal=program.get('legalIcons'),
@@ -291,9 +297,9 @@ class VtmGo:
             name=program.get('name'),
             description=program.get('description'),
             year=program.get('productionYear'),
-            thumb=program.get('teaserImageUrl'),
-            fanart=program.get('bigPhotoUrl'),
-            geoblocked=program.get('geoBlocked'),
+            thumb=program.get('landscapeTeaserImageUrl'),
+            fanart=program.get('backgroundImageUrl'),
+            geoblocked=program.get('blockedFor') == 'GEO',
             seasons=seasons,
             channel=channel,
             legal=program.get('legalIcons'),
@@ -413,7 +419,7 @@ class VtmGo:
             movie_id=item.get('target', {}).get('id'),
             name=item.get('title'),
             thumb=item.get('imageUrl'),
-            geoblocked=item.get('geoBlocked'),
+            geoblocked=item.get('blockedFor') == 'GEO',
         )
 
     def _parse_program_teaser(self, item, cache=CACHE_ONLY):
@@ -429,8 +435,8 @@ class VtmGo:
         return Program(
             program_id=item.get('target', {}).get('id'),
             name=item.get('title'),
-            thumb=item.get('imageUrl'),
-            geoblocked=item.get('geoBlocked'),
+            thumb=item.get('largeImageUrl'),
+            geoblocked=item.get('blockedFor') == 'GEO',
         )
 
     def _parse_episode_teaser(self, item, cache=CACHE_ONLY):
@@ -448,7 +454,7 @@ class VtmGo:
             program_name=item.get('title'),
             name=item.get('label'),
             description=episode.description if episode else None,
-            geoblocked=item.get('geoBlocked'),
+            geoblocked=item.get('blockedFor') == 'GEO',
             thumb=item.get('imageUrl'),
             progress=item.get('playerPositionSeconds'),
             watched=False,

--- a/plugin.video.vtm.go/service_entry.py
+++ b/plugin.video.vtm.go/service_entry.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 from xbmcaddon import Addon
 
-from resources.lib import kodiutils, kodilogging
+from resources.lib import kodilogging, kodiutils
 
 # Reinitialise ADDON every invocation to fix an issue that settings are not fresh.
 kodiutils.ADDON = Addon()


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.3.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.3.1 (2022-06-01)
- Use new API

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
