### PR TITLE
[plugin.video.vtm.go@matrix] 1.3.2+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.3.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.2) (2022-06-06)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.1...v1.3.2)
+
+**Fixed bugs:**
+
+- Allow to clear cache, and don't use empty cached items [\#330](https://github.com/add-ons/plugin.video.vtm.go/pull/330) ([michaelarnauts](https://github.com/michaelarnauts))
+- Throw decent error on a geoblock exception [\#329](https://github.com/add-ons/plugin.video.vtm.go/pull/329) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix empty movie entries in list after play [\#327](https://github.com/add-ons/plugin.video.vtm.go/pull/327) ([tatankat](https://github.com/tatankat))
+
 ## [v1.3.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.1) (2022-06-01)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.0...v1.3.1)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.1+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.2+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,8 +22,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.3.1 (2022-06-01)
-- Use new API</news>
+	<news>v1.3.2 (2022-06-06)
+- Fix empty items due to corrupted cache.
+- Show better error message when you are geoblocked.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
@@ -196,6 +196,10 @@ msgctxt "#30706"
 msgid "The authentication tokens are removed."
 msgstr ""
 
+msgctxt "#30707"
+msgid "The cache has been cleared."
+msgstr ""
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr ""
@@ -348,4 +352,12 @@ msgstr ""
 
 msgctxt "#30895"
 msgid "Clear authentication tokens…"
+msgstr ""
+
+msgctxt "#30896"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30897"
+msgid "Clear cache…"
 msgstr ""

--- a/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
@@ -201,6 +201,10 @@ msgctxt "#30706"
 msgid "The authentication tokens are removed."
 msgstr "De authenticatietokens zijn gewist."
 
+msgctxt "#30707"
+msgid "The cache has been cleared."
+msgstr "De cache is leeg gemaakt."
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
@@ -353,3 +357,11 @@ msgstr "Authenticatie"
 msgctxt "#30895"
 msgid "Clear authentication tokens…"
 msgstr "Verwijder authenticatietokens…"
+
+msgctxt "#30896"
+msgid "Cache"
+msgstr "Cache"
+
+msgctxt "#30897"
+msgid "Clear cache…"
+msgstr "Maak cache leeg…"

--- a/plugin.video.vtm.go/resources/lib/addon.py
+++ b/plugin.video.vtm.go/resources/lib/addon.py
@@ -46,6 +46,13 @@ def auth_clear_tokens():
     Authentication().clear_tokens()
 
 
+@routing.route('/auth/clear-cache')
+def auth_clear_cache():
+    """ Clear the cache """
+    from resources.lib.modules.authentication import Authentication
+    Authentication().clear_cache()
+
+
 @routing.route('/channels')
 def show_channels():
     """ Shows Live TV channels """

--- a/plugin.video.vtm.go/resources/lib/modules/authentication.py
+++ b/plugin.video.vtm.go/resources/lib/modules/authentication.py
@@ -65,3 +65,9 @@ class Authentication:
         """ Clear the authentication tokens """
         self._auth.logout()
         kodiutils.notification(message=kodiutils.localize(30706))
+
+    @staticmethod
+    def clear_cache():
+        """ Clear the cache """
+        kodiutils.invalidate_cache()
+        kodiutils.notification(message=kodiutils.localize(30707))

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
@@ -206,13 +206,12 @@ class VtmGo:
         else:
             movie = None
 
-        if movie is None:
+        if not movie:
             # Fetch from API
             response = util.http_get(API_ENDPOINT + '/%s/movies/%s' % (self._mode(), movie_id),
                                      token=self._tokens.access_token if self._tokens else None,
                                      profile=self._tokens.profile if self._tokens else None)
-            info = json.loads(response.text)
-            movie = info.get('movie', {})
+            movie = json.loads(response.text)
             kodiutils.set_cache(['movie', movie_id], movie)
 
         return Movie(
@@ -220,8 +219,9 @@ class VtmGo:
             name=movie.get('name'),
             description=movie.get('description'),
             duration=movie.get('durationSeconds'),
-            thumb=movie.get('teaserImageUrl'),
-            fanart=movie.get('bigPhotoUrl'),
+            thumb=movie.get('landscapeTeaserImageUrl'),
+            # portraitthumb=movie.get('portraitTeaserImageUrl'),
+            fanart=movie.get('backgroundImageUrl'),
             year=movie.get('productionYear'),
             geoblocked=movie.get('blockedFor') == 'GEO',
             remaining=movie.get('remainingDaysAvailable'),
@@ -244,7 +244,7 @@ class VtmGo:
         else:
             program = None
 
-        if program is None:
+        if not program:
             # Fetch from API
             response = util.http_get(API_ENDPOINT + '/%s/programs/%s' % (self._mode(), program_id),
                                      token=self._tokens.access_token if self._tokens else None,

--- a/plugin.video.vtm.go/resources/settings.xml
+++ b/plugin.video.vtm.go/resources/settings.xml
@@ -37,5 +37,7 @@
         <setting label="30893" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
         <setting label="30894" type="lsep"/> <!-- Authentication -->
         <setting label="30895" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/auth/clear-tokens)"/>
+        <setting label="30896" type="lsep"/> <!-- Cache -->
+        <setting label="30897" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/auth/clear-cache)"/>
     </category>
 </settings>


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.3.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.3.2 (2022-06-06)
- Fix empty items due to corrupted cache.
- Show better error message when you are geoblocked.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
