### PR TITLE
[plugin.video.streamz@matrix] 1.1.1+matrix.1

### DIFF
--- a/plugin.video.streamz/CHANGELOG.md
+++ b/plugin.video.streamz/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.1.1](https://github.com/add-ons/plugin.video.streamz/tree/v1.1.1) (2022-06-06)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.1.0...v1.1.1)
+
+**Implemented enhancements:**
+
+- Allow to clear the cache and don't use bad cached values [\#48](https://github.com/add-ons/plugin.video.streamz/pull/48) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Fixed bugs:**
+
+- Changes for API 12 [\#47](https://github.com/add-ons/plugin.video.streamz/pull/47) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.1.0](https://github.com/add-ons/plugin.video.streamz/tree/v1.1.0) (2021-12-19)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.0.6...v1.1.0)

--- a/plugin.video.streamz/addon.xml
+++ b/plugin.video.streamz/addon.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.streamz" name="Streamz" version="1.1.0+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.streamz" name="Streamz" version="1.1.1+matrix.1" provider-name="Michaël Arnauts">
     <requires>
-        <import addon="xbmc.python" version="3.0.0"/>
-        <import addon="script.module.dateutil" version="2.6.0"/>
-        <import addon="script.module.pysocks" version="1.6.8" optional="true"/>
-        <import addon="script.module.requests" version="2.22.0"/>
-        <import addon="script.module.routing" version="0.2.0"/>
-        <import addon="script.module.pyjwt" version="1.6.4"/>
-        <import addon="script.module.inputstreamhelper" version="0.3.4"/>
+        <import addon="xbmc.python" version="3.0.0" />
+        <import addon="script.module.dateutil" version="2.6.0" />
+        <import addon="script.module.pysocks" version="1.6.8" optional="true" />
+        <import addon="script.module.requests" version="2.22.0" />
+        <import addon="script.module.routing" version="0.2.0" />
+        <import addon="script.module.pyjwt" version="1.6.4" />
+        <import addon="script.module.inputstreamhelper" version="0.3.4" />
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
     </extension>
-    <extension point="xbmc.service" library="service_entry.py"/>
+    <extension point="xbmc.service" library="service_entry.py" />
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Access the Streamz catalogue</summary>
         <description lang="en_GB">Streamz is a video-on-demand platform offering Flemish content from DPG Media, Telenet and VRT, but also including 'Home of HBO' content and blockbuster movies.</description>
@@ -22,9 +22,9 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door Streamz BV, en wordt aangeboden 'as is', zonder enige garantie. De Streamz naam en Streamz logo zijn eigendom van Streamz BV en worden gebruikt in overeenstemming met de 'fair use' regels.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.1.0 (2021-12-19)
-- Rework authentication with simplified login flow.
-</news>
+	<news>v1.1.1 (2022-06-06)
+- Update to API v12.
+- Add option to clear the cache.</news>
         <source>https://github.com/add-ons/plugin.video.streamz</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.streamz/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.streamz/resources/language/resource.language.en_gb/strings.po
@@ -133,6 +133,14 @@ msgctxt "#30704"
 msgid "Your account has no profiles defined. Please login on www.streamz.be and create a profile."
 msgstr ""
 
+msgctxt "#30706"
+msgid "The authentication tokens are removed."
+msgstr ""
+
+msgctxt "#30707"
+msgid "The cache has been cleared."
+msgstr ""
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr ""
@@ -256,4 +264,12 @@ msgstr ""
 
 msgctxt "#30895"
 msgid "Clear authentication tokens…"
+msgstr ""
+
+msgctxt "#30896"
+msgid "Cache"
+msgstr ""
+
+msgctxt "#30897"
+msgid "Clear cache…"
 msgstr ""

--- a/plugin.video.streamz/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.streamz/resources/language/resource.language.nl_nl/strings.po
@@ -135,6 +135,14 @@ msgctxt "#30704"
 msgid "Your account has no profiles defined. Please login on www.streamz.be and create a profile."
 msgstr "Uw account heeft geen profielen. Gelieve in te loggen op www.streamz.be en een profiel aan te maken."
 
+msgctxt "#30706"
+msgid "The authentication tokens are removed."
+msgstr "De authenticatietokens zijn gewist."
+
+msgctxt "#30707"
+msgid "The cache has been cleared."
+msgstr "De cache is leeg gemaakt."
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."
@@ -259,3 +267,11 @@ msgstr "Authenticatie"
 msgctxt "#30895"
 msgid "Clear authentication tokens…"
 msgstr "Verwijder authenticatietokens…"
+
+msgctxt "#30896"
+msgid "Cache"
+msgstr "Cache"
+
+msgctxt "#30897"
+msgid "Clear cache…"
+msgstr "Maak cache leeg…"

--- a/plugin.video.streamz/resources/lib/addon.py
+++ b/plugin.video.streamz/resources/lib/addon.py
@@ -56,6 +56,13 @@ def auth_clear_tokens():
     Authentication().clear_tokens()
 
 
+@routing.route('/auth/clear-cache')
+def auth_clear_cache():
+    """ Clear the cache """
+    from resources.lib.modules.authentication import Authentication
+    Authentication().clear_cache()
+
+
 @routing.route('/catalog/program/<program>')
 def show_catalog_program(program):
     """ Show a program from the catalog """

--- a/plugin.video.streamz/resources/lib/modules/authentication.py
+++ b/plugin.video.streamz/resources/lib/modules/authentication.py
@@ -137,3 +137,9 @@ class Authentication:
         """ Clear the authentication tokens """
         self._auth.logout()
         kodiutils.notification(message=kodiutils.localize(30706))
+
+    @staticmethod
+    def clear_cache():
+        """ Clear the cache """
+        kodiutils.invalidate_cache()
+        kodiutils.notification(message=kodiutils.localize(30707))

--- a/plugin.video.streamz/resources/lib/streamz/__init__.py
+++ b/plugin.video.streamz/resources/lib/streamz/__init__.py
@@ -7,11 +7,11 @@ API_ENDPOINT = 'https://lfvp-api.dpgmedia.net'
 API_ANDROID_ENDPOINT = 'https://lfvp-android-api.dpgmedia.net'
 
 # These seem to be hardcoded
-STOREFRONT_MAIN = 'eba52f64-92da-4fec-804b-278ebafc75fd'
-STOREFRONT_MOVIES = '4f163159-15c3-452c-b275-1747b144cfa0'
-STOREFRONT_SERIES = 'dba19d15-1ddf-49ef-8eb5-99c59a1fb377'
-STOREFRONT_KIDS = 'a53d1ec3-ab43-4942-9d31-4f4754b4f519'
-STOREFRONT_MAIN_KIDS = 'e0c175c0-a43c-4eed-bdca-e1e95a726bc0'
+STOREFRONT_MAIN = 'main'
+STOREFRONT_MOVIES = 'movies'
+STOREFRONT_SERIES = 'series'
+STOREFRONT_KIDS = 'kids'
+STOREFRONT_MAIN_KIDS = 'main'
 
 STOREFRONT_PAGE_CONTINUE_WATCHING = '7574469c-5d78-4878-84f5-c5729442eee4'
 

--- a/plugin.video.streamz/resources/lib/streamz/exceptions.py
+++ b/plugin.video.streamz/resources/lib/streamz/exceptions.py
@@ -12,7 +12,6 @@ class InvalidTokenException(Exception):
     """ Is thrown when the token is invalid. """
 
 
-
 class NoStreamzSubscriptionException(Exception):
     """ Is thrown when you don't have an subscription with Streamz. """
 

--- a/plugin.video.streamz/resources/lib/streamz/util.py
+++ b/plugin.video.streamz/resources/lib/streamz/util.py
@@ -32,8 +32,8 @@ class StreamzAdapter(BaseAdapter):
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'STREAMZ/11.19 (be.dpgmedia.streamz; build:14554; iOS 24) okhttp/4.9.1',
-    'x-app-version': '11',
+    'User-Agent': 'STREAMZ/12.16 (be.dpgmedia.streamz; build:16527; Android 24) okhttp/4.9.3',
+    'x-app-version': '12',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '24',

--- a/plugin.video.streamz/resources/settings.xml
+++ b/plugin.video.streamz/resources/settings.xml
@@ -30,6 +30,8 @@
         <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
         <setting label="30893" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
         <setting label="30894" type="lsep"/> <!-- Authentication -->
-        <setting label="30895" type="action" action="RunPlugin(plugin://plugin.video.vtm.go/auth/clear-tokens)"/>
+        <setting label="30895" type="action" action="RunPlugin(plugin://plugin.video.streamz/auth/clear-tokens)"/>
+        <setting label="30896" type="lsep"/> <!-- Cache -->
+        <setting label="30897" type="action" action="RunPlugin(plugin://plugin.video.streamz/auth/clear-cache)"/>
     </category>
 </settings>


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: Streamz
  - Add-on ID: plugin.video.streamz
  - Version number: 1.1.1+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.streamz

Streamz is a video-on-demand platform offering Flemish content from DPG Media, Telenet and VRT, but also including 'Home of HBO' content and blockbuster movies.

### What's new

v1.1.1 (2022-06-06)
- Update to API v12.
- Add option to clear the cache.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
