### PR TITLE
[plugin.video.cnet.podcasts] 1.1.7 Marked Broken

### DIFF
--- a/plugin.video.cnet.podcasts/addon.xml
+++ b/plugin.video.cnet.podcasts/addon.xml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cnet.podcasts"
        name="CNET Podcasts"
-       version="1.1.6"
+       version="1.1.7"
        provider-name="Skipmode A1, Divingmule">
   <requires>
     <import addon="xbmc.python"                   version="2.14.0"/>
-    <import addon="script.module.beautifulsoup4"  version="4.3.1"/>
+    <import addon="script.module.beautifulsoup4"  version="4.3.2"/>
 	<import addon="script.module.requests"        version="2.4.3"/>
     <import addon="script.module.future"          version="0.0.1"/>
   	<import addon="script.module.html5lib"        version="0.999.0"/>
@@ -20,10 +20,11 @@
 	<disclaimer lang="en">For bugs, requests or general questions visit the CNET Podcasts thread on the Kodi Video Add-ons forum.</disclaimer>
     <language>en</language>
     <platform>all</platform>
-    <license>GNU GENERAL PUBLIC LICENSE. Version 3, June 2007</license>
+    <license>GPL-2.0-or-later</license>
     <forum>http://forum.xbmc.org/showthread.php?tid=192868</forum>
     <website>http://www.cnet.com/cnet-podcasts</website>
     <email></email>
     <source>https://github.com/skipmodea1/plugin.video.cnet.podcasts</source>
+    <broken>Marked addon BROKEN due to major website update</broken>
   </extension>
 </addon>

--- a/plugin.video.cnet.podcasts/changelog.txt
+++ b/plugin.video.cnet.podcasts/changelog.txt
@@ -1,8 +1,13 @@
+v1.1.7 (2022-06-08)
+- Marked addon BROKEN due to major website update
+
 v1.1.6 (2018-01-20)
 - addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
 Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.
 - removed caching
 - adding a setting to only view all video category
+
+        <broken>Marked addon BROKEN due to major website update</broken>
 
 v1.1.5 (2017-07-16)
 - rolling back changed foldername for strings because that doesn't work for gotham

--- a/plugin.video.cnet.podcasts/default.py
+++ b/plugin.video.cnet.podcasts/default.py
@@ -23,8 +23,8 @@ LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources', 'images')
 HEADERS = {'User-agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:24.0) Gecko/20100101 Firefox/24.0','Referer': 'http://www.cnet.com'}
 BASE_URL = 'http://www.cnet.com/cnet-podcasts/'
-DATE = "2018-01-20"
-VERSION = "1.1.6"
+DATE = "2022-06-08"
+VERSION = "1.1.7"
 
 
 def cache_categories():


### PR DESCRIPTION
### Description
v1.1.7 (2022-06-08)
- Marked addon BROKEN due to major website update
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
