### PR TITLE
[plugin.video.tekthing] 1.0.5+matrix.1 marked Broken for matrix

### DIFF
--- a/plugin.video.tekthing/addon.py
+++ b/plugin.video.tekthing/addon.py
@@ -21,8 +21,8 @@ LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join( xbmcaddon.Addon().getAddonInfo('path'), 'resources' )
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
 RSS_URL = "http://feeds.feedburner.com/Tekthing"
-DATE = "2019-03-13"
-VERSION = "1.0.4"
+DATE = "2022-06-20"
+VERSION = "1.0.5"
 
 
 def getParams():

--- a/plugin.video.tekthing/addon.xml
+++ b/plugin.video.tekthing/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.tekthing"
        name="Tekthing"
-       version="1.0.4+matrix.1"
+       version="1.0.5+matrix.1"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="3.0.0"/>
@@ -28,5 +28,6 @@
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.jpg</fanart>
     </assets>
+	<broken>Marked addon BROKEN due to discontinued show</broken>		
   </extension>
 </addon>

--- a/plugin.video.tekthing/changelog.txt
+++ b/plugin.video.tekthing/changelog.txt
@@ -1,3 +1,6 @@
+v1.0.5 (2022-06-20)
+- Marked addon BROKEN due to discontinued show
+
 v1.0.4 (2019-03-13)
 - fixed finding of videos
 - removing non-ascii characters in title in parameters to prevent UnicodeDecodeError: 'ascii' codec can't decode ...


### PR DESCRIPTION
### Description
v1.0.5 (2022-06-20)
- Marked addon BROKEN due to discontinued show
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
