### PR TITLE
[plugin.video.mlbtv@krypton] 2022.6.9

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.5.19" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.6.9" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.pytz" />
@@ -22,15 +22,12 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - pad the end of archive videos if no spoilers (to avoid timeline spoilers)
-            - autoplay favorite team setting
-            - see scores at inning category
-            - hide bottom of 9th / extra innings as spoilers
-            - labels for suspended/resumed games/streams
-            - retain icon/fanart/probables through context menu navigation
-            - list favorite team's game(s) first
-            - removed unused/unnecessary settings (in market streams and proxy)
-            - added probable pitchers to game list titles
+            - optional zip code setting to detect and label blackout streams (does not circumvent blackouts)
+            - tweaked skip timings, particularly for non-action pitches and overturned reviews
+            - option to disable video length padding (in case of proxy conflicts)
+            - restored 24-hour time format label, applied it to Big Inning listitem
+            - label regional national games
+            - added additional action play type in skip monitor
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -11,6 +11,7 @@ stream_date = None
 spoiler = 'True'
 suspended = 'False'
 start_inning = 'False'
+blackout = 'False'
 icon = None
 fanart = None
 featured_video = None
@@ -49,6 +50,9 @@ if 'fanart' in params:
 if 'start_inning' in params:
     start_inning = urllib.unquote_plus(params["start_inning"])
 
+if 'blackout' in params:
+    blackout = urllib.unquote_plus(params["blackout"])
+
 if 'featured_video' in params:
     featured_video = urllib.unquote_plus(params["featured_video"])
 
@@ -77,15 +81,15 @@ elif mode == 101:
 
 # autoplay, use an extra parameter to force auto stream selection
 elif mode == 102:
-    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, autoplay=True)
+    stream_select(game_pk, spoiler, suspended, start_inning, blackout, description, name, icon, fanart, autoplay=True)
 
 # from context menu, use an extra parameter to force manual stream selection
 elif mode == 103:
-    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart, from_context_menu=True)
+    stream_select(game_pk, spoiler, suspended, start_inning, blackout, description, name, icon, fanart, from_context_menu=True)
 
 # normal stream selection
 elif mode == 104:
-    stream_select(game_pk, spoiler, suspended, start_inning, description, name, icon, fanart)
+    stream_select(game_pk, spoiler, suspended, start_inning, blackout, description, name, icon, fanart)
 
 # Yesterday's Games
 elif mode == 105:

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -57,7 +57,7 @@ msgid "CDN"
 msgstr ""
 
 msgctxt "#30170"
-msgid "Hide Scores"
+msgid "Hide Scores & Timeline Spoilers"
 msgstr ""
 
 msgctxt "#30171"
@@ -314,4 +314,16 @@ msgstr ""
 
 msgctxt "#30413"
 msgid "See Yesterday's Scores at inning"
+msgstr ""
+
+msgctxt "#30414"
+msgid "Watch in YouTube Add-on"
+msgstr ""
+
+msgctxt "#30415"
+msgid "Zip code (5 digits, for blackout labels)"
+msgstr ""
+
+msgctxt "#30416"
+msgid "Disable video length padding (in case of proxy conflict)"
 msgstr ""

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -5,6 +5,9 @@
     <setting id="username" type="text" label="30140" default=""/>
     <setting id="password" type="text" label="30150" option="hidden" default=""/>
     <setting id="single_team" type="bool" label="30151" default="false"/>
+    <setting id="zip_code" type="number" label="30415" default=""/>
+    <setting id="old_zip_code" type="number" label="" default="" visible="false"/>
+    <setting id="blackout_teams" type="text" label="" default="[]" visible="false"/>
     <setting label="30156" type="action" action="RunPlugin(plugin://plugin.video.mlbtv/?url=junk&amp;mode=400)" option="close" />
     <!--Hidden-->
     <setting id='session_key' type='text' visible="false" default=''/>
@@ -21,10 +24,11 @@
     <setting id="quality" type="labelenum" label="30160" values="Best Available|Always Ask" default="Best Available" />
     <setting id="cdn" type="labelenum" label="30165" values="Akamai|Level 3|No Preference" default="No Preference"/>
     <setting id="no_spoilers" type="enum" label="30170" lvalues="30171|30172|30173|30174|30175" />
+    <setting id="disable_video_padding" type="bool" label="30416" default="false" />
     <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
 
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
-    <setting id="time_format" type="select" label="30301" lvalues="30302|30301" default="0" />
+    <setting id="time_format" type="select" label="30301" lvalues="30302|30303" default="0" />
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.6.9
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - optional zip code setting to detect and label blackout streams (does not circumvent blackouts)
            - tweaked skip timings, particularly for non-action pitches and overturned reviews
            - option to disable video length padding (in case of proxy conflicts)
            - restored 24-hour time format label, applied it to Big Inning listitem
            - label regional national games
            - added additional action play type in skip monitor
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
