### PR TITLE
[plugin.video.viervijfzes@matrix] 0.4.8+matrix.1

### DIFF
--- a/plugin.video.viervijfzes/CHANGELOG.md
+++ b/plugin.video.viervijfzes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.4.8](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.8) (2022-07-07)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.7...v0.4.8)
+
+**Fixed bugs:**
+
+- Fix API [\#105](https://github.com/add-ons/plugin.video.viervijfzes/pull/105) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.4.7](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.7) (2022-02-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.6...v0.4.7)

--- a/plugin.video.viervijfzes/addon.xml
+++ b/plugin.video.viervijfzes/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.7+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.8+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -21,8 +21,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by SBS Belgium and is provided 'as is' without any warranty of any kind. The Play4, Play5 and Play6 logos are property of SBS Belgium.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	    <news>v0.4.7 (2022-02-04)
-- Fix My List.</news>
+	    <news>v0.4.8 (2022-07-07)
+- Fix Addon due to API changes.</news>
         <source>https://github.com/add-ons/plugin.video.viervijfzes</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
@@ -689,8 +689,8 @@ class ContentApi:
             season=data.get('seasonNumber'),
             season_uuid=season_uuid,
             number=episode_number,
-            aired=datetime.fromtimestamp(data.get('createdDate')),
-            expiry=datetime.fromtimestamp(data.get('unpublishDate')) if data.get('unpublishDate') else None,
+            aired=datetime.fromtimestamp(int(data.get('createdDate'))),
+            expiry=datetime.fromtimestamp(int(data.get('unpublishDate'))) if data.get('unpublishDate') else None,
             rating=data.get('parentalRating'),
             stream=data.get('path'),
         )


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: GoPlay
  - Add-on ID: plugin.video.viervijfzes
  - Version number: 0.4.8+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.viervijfzes

Deze add-on geeft toegang tot de programma's die aangeboden worden op de websites van Play4, Play5 en Play6.

### What's new

v0.4.8 (2022-07-07)
- Fix Addon due to API changes.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
