### PR TITLE
[plugin.video.retrospect] v5.5.8+matrix.1

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.5.7+matrix.1"
+        version="5.5.8+matrix.1"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -122,7 +122,7 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.5.7 - Changelog - 2022-07-12[/B]
+        <news>[B]Retrospect v5.5.8 - Changelog - 2022-07-17[/B]
 
 This minor update mainly fixes NPO and KetNet channels.
 

--- a/plugin.video.retrospect/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/plugin.video.retrospect/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1366,9 +1366,15 @@ class Channel(chn_class.Channel):
 
         # get the subtitle
         if fetch_subtitles:
-            sub_title_url = "https://rs.poms.omroep.nl/v1/api/subtitles/%s/nl_NL/CAPTION.vtt" % (episode_id,)
+            sub_title_url = "https://assetscdn.npostart.nl/subtitles/original/nl/%s.vtt" % (episode_id,)
             sub_title_path = subtitlehelper.SubtitleHelper.download_subtitle(
                 sub_title_url, episode_id + ".nl.srt", format='srt')
+
+            if not sub_title_path:
+                sub_title_url = "https://rs.poms.omroep.nl/v1/api/subtitles/%s/nl_NL/CAPTION.vtt" % (episode_id,)
+                sub_title_path = subtitlehelper.SubtitleHelper.download_subtitle(
+                    sub_title_url, episode_id + ".nl.srt", format='srt')
+
             if sub_title_path:
                 item.subtitle = sub_title_path
 

--- a/plugin.video.retrospect/channels/channel.nos/nosnl/chn_nosnl.py
+++ b/plugin.video.retrospect/channels/channel.nos/nosnl/chn_nosnl.py
@@ -101,7 +101,7 @@ class Channel(chn_class.Channel):
         live_title = LanguageHelper.get_localized_string(LanguageHelper.LiveTv)
 
         cats = {
-            "Meest Bekeken": "https://api.nos.nl/mobile/videos/most-viewed/phone.json",
+            # "Meest Bekeken": "https://api.nos.nl/mobile/videos/most-viewed/phone.json",
             "Nieuws": "https://api.nos.nl/nosapp/v3/items?mainCategories=nieuws&types=video&limit={0}".format(self.__pageSize),
             "Sport": "https://api.nos.nl/nosapp/v3/items?mainCategories=sport&types=video&limit={0}".format(self.__pageSize),
             "Alles": "https://api.nos.nl/nosapp/v3/items?types=video&limit={0}".format(self.__pageSize),


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Quick fix for missed commit.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
