### PR TITLE
[plugin.video.rtpplay@matrix] 6.0.3

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.2" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.3" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -22,8 +22,9 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            Version 6.0.2 (20/07/2022)
-                - Minor fix to prefer hls over dash for now (until we have support for ISA)
+            Version 6.0.3 (15/08/2022)
+                - Add support for inputstream.adaptive
+                - Minor fixes
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.en_gb/strings.po
@@ -71,3 +71,11 @@ msgstr ""
 msgctxt "#32013"
 msgid "Live Radio"
 msgstr ""
+
+msgctxt "#32014"
+msgid "Prefer inputstream.adaptive addon for playback"
+msgstr ""
+
+msgctxt "#32015"
+msgid "All programs"
+msgstr ""

--- a/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
+++ b/plugin.video.rtpplay/resources/language/resource.language.pt_pt/strings.po
@@ -71,3 +71,11 @@ msgstr "TV em direto"
 msgctxt "#32013"
 msgid "Live Radio"
 msgstr "Radio em direto"
+
+msgctxt "#32014"
+msgid "Prefer inputstream.adaptive addon for playback"
+msgstr "Preferir addon inputstream.adaptive para reprodução"
+
+msgctxt "#32015"
+msgid "All programs"
+msgstr "Todos os programas"

--- a/plugin.video.rtpplay/resources/lib/kodiutils.py
+++ b/plugin.video.rtpplay/resources/lib/kodiutils.py
@@ -84,9 +84,11 @@ def format_date(date):
 
 
 def get_stream_url(source):
-    if "hls_url" in source:
+    if "hls_url_new" in source:
+        return source["hls_url_new"]
+    elif "hls_url" in source:
         return source["hls_url"]
-    if "dash_stream_name" in source:
+    elif "dash_stream_name" in source:
         return source["dash_stream_name"]
     return source["stream"]["clean"]["standard"]
 

--- a/plugin.video.rtpplay/resources/settings.xml
+++ b/plugin.video.rtpplay/resources/settings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <setting id="debug" type="bool" label="32003" default="false"/>
+    <setting id="use_isa" type="bool" label="32014" default="true"/>
 </settings>
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 6.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 6.0.3 (15/08/2022)
                - Add support for inputstream.adaptive
                - Minor fixes
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
