### PR TITLE
 [plugin.video.cbc-sports] 1.0.5

### DIFF
--- a/plugin.video.cbc-sports/addon.xml
+++ b/plugin.video.cbc-sports/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.4" provider-name="Jbinkley60">
+<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.5" provider-name="Jbinkley60">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.beautifulsoup4" version="4.3.2"/>

--- a/plugin.video.cbc-sports/changelog.txt
+++ b/plugin.video.cbc-sports/changelog.txt
@@ -1,3 +1,9 @@
+Version 1.0.5
+
+-  Added a generic check for all improperly formatted times being returned by the CBC
+   sports website.  Now an item will not be displayed if the time format is wrong vs.
+   causing an exception error and many items not being displayed.
+
 Version 1.0.4
 
 -  Added another check / fix for improperly formatted time on the CBC Sports website

--- a/plugin.video.cbc-sports/resources/lib/common.py
+++ b/plugin.video.cbc-sports/resources/lib/common.py
@@ -6,21 +6,24 @@ import xbmcgui, xbmcaddon, xbmcplugin, xbmc
 def timeConvert(orgtime):				#  Verify CBC Sports time format
 
 
-    if len(orgtime) == 20 and orgtime[2] == '/' and orgtime[5] == '/' and orgtime[13] == ':':
-        retime = orgtime
-    elif orgtime[13] != ':' and len(orgtime) == 19:
-        retime = retime[:13] + ':' + retime[13:]
-    elif orgtime[2] != '/' and len(orgtime) == 19:
-        retime = retime[:2] + '/' + retime[2:]
-    elif orgtime[5] != '/' and len(orgtime) == 19:
-        retime = retime[:5] + '/' + retime[5:]
-    else:
-        retime = 'invalid'
+    try:
+        if len(orgtime) == 20 and orgtime[2] == '/' and orgtime[5] == '/' and orgtime[13] == ':':
+            retime = orgtime
+        elif orgtime[13] != ':' and len(orgtime) == 19:
+            retime = retime[:13] + ':' + retime[13:]
+        elif orgtime[2] != '/' and len(orgtime) == 19:
+            retime = retime[:2] + '/' + retime[2:]
+        elif orgtime[5] != '/' and len(orgtime) == 19:
+            retime = retime[:5] + '/' + retime[5:]
+        else:
+            retime = 'invalid'
 
-    if int(orgtime[11:13]) > 24:
-        retime = 'invalid'     
+        if int(orgtime[11:13]) > 24:
+            retime = 'invalid'     
 
-    return(retime)
+        return(retime)
+    except:
+        return('invalid')  
 
 
 def logging_level(cbclog):	


### PR DESCRIPTION
Description

v1.0.5 is a minor update to add a generic time stamp check for the CBC Sports website to avoid exception errors.

Get the latest headlines, opinion, and videos from CBC Sports. Watch live events, replays, and highlights. Some content blocked outside of Canada.

Checklist:

[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
[X ] Each add-on submission should be a single commit with using the following style: [script.foo.bar] v1.0.0
[X ] My code follows the add-on rules and piracy stance of this project.
[X ] I have read the CONTRIBUTING document
Each add-on submission should be a single commit with using the following style: [script.foo.bar] 1.0.0

Additional information :

    Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
    [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
    Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
    [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
    This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
    Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
    If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team