### PR TITLE
[plugin.video.mlbtv@matrix] 2022.8.23+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.6.29+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.8.23+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,10 +22,15 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - live game changer based on leverage index
-            - streamlined blackout detection
-            - reduced autoplay checks
-            - improved monitor logging
+            - playback: added away radio streams to national games (using same proxy as video padding)
+            - game list: fixed bug for games completed early
+            - game changer: expanded initial game selection, if no games are active
+            - game changer: added display times
+            - game changer and skip options: improved break detection
+            - blackout labels: increased times to more closely match actual availability
+            - highlights: changed from HLS to MP4 because HLS wasn't starting at beginning properly
+            - YouTube games: enabled option to watch in YouTube addon (YouTube addon on Android may need to be limited to 480p to play properly)
+            - big inning: find stream even when it is not featured yet
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -325,7 +325,7 @@ msgid "Zip code (5 digits, for blackout labels)"
 msgstr ""
 
 msgctxt "#30416"
-msgid "Disable video length padding (in case of proxy conflict)"
+msgid "Disable proxy (used for padding and alternate audio)"
 msgstr ""
 
 msgctxt "#30417"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.8.23+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - playback: added away radio streams to national games (using same proxy as video padding)
            - game list: fixed bug for games completed early
            - game changer: expanded initial game selection, if no games are active
            - game changer: added display times
            - game changer and skip options: improved break detection
            - blackout labels: increased times to more closely match actual availability
            - highlights: changed from HLS to MP4 because HLS wasn't starting at beginning properly
            - YouTube games: enabled option to watch in YouTube addon (YouTube addon on Android may need to be limited to 480p to play properly)
            - big inning: find stream even when it is not featured yet
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
