### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.15+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.15 (2022-08-31)
+- Fix add-on crash (@mediaminister)
+
 ### v2.5.14 (2022-08-29)
 - VRT MAX rebranding (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.14+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.15+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.15 (2022-08-31)
+- Fix add-on crash
+
 v2.5.14 (2022-08-29)
 - VRT MAX rebranding
 

--- a/plugin.video.vrt.nu/resources/lib/favorites.py
+++ b/plugin.video.vrt.nu/resources/lib/favorites.py
@@ -85,7 +85,7 @@ class Favorites:
                 'Accept': 'application/json',
             }
             querystring = 'tileType=program-poster&tileContentType=program&tileOrientation=portrait&layout=slider&title=Mijn+favoriete+programma%27s'
-            favorites_json = get_url_json(url='{}?{}'.format(self.FAVORITES_REST_URL, querystring), cache=None, headers=headers, raise_errors='all')
+            favorites_json = get_url_json(url='{}?{}'.format(self.FAVORITES_REST_URL, querystring), cache=None, headers=headers)
         return favorites_json
 
     def get_program_id_graphql(self, program_name):
@@ -181,13 +181,14 @@ class Favorites:
     def _generate_favorites_dict(favorites_json):
         """Generate a simple favorites dict with programIds and programNames"""
         favorites_dict = {}
-        for item in favorites_json.get(':items', []):
-            program_name = favorites_json.get(':items')[item].get('data').get('program').get('name')
-            program_id = favorites_json.get(':items')[item].get('data').get('program').get('id')
-            title = favorites_json.get(':items')[item].get('title')
-            favorites_dict[program_name] = dict(
-                program_id=program_id,
-                title=title)
+        if favorites_json is not None:
+            for item in favorites_json.get(':items', []):
+                program_name = favorites_json.get(':items')[item].get('data').get('program').get('name')
+                program_id = favorites_json.get(':items')[item].get('data').get('program').get('id')
+                title = favorites_json.get(':items')[item].get('title')
+                favorites_dict[program_name] = dict(
+                    program_id=program_id,
+                    title=title)
         return favorites_dict
 
     def manage(self):

--- a/plugin.video.vrt.nu/resources/lib/kodiutils.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiutils.py
@@ -1143,7 +1143,7 @@ def open_url(url, data=None, headers=None, method=None, cookiejar=None, follow_r
             ok_dialog(heading='HTTP Error {code}'.format(code=exc.code), message='{}\n{}'.format(url, exc.reason))
             log_error('HTTP Error {code}: {reason}', code=exc.code, reason=exc.reason)
             return None
-        if exc.code in (400, 403) and exc.headers.get('Content-Type') and 'application/json' in exc.headers.get('Content-Type'):
+        if exc.code in (400, 403, 503) and exc.headers.get('Content-Type') and 'application/json' in exc.headers.get('Content-Type'):
             return exc
         ok_dialog(heading='HTTP Error {code}'.format(code=exc.code), message='{}\n{}'.format(url, exc.reason))
         log_error('HTTP Error {code}: {reason}', code=exc.code, reason=exc.reason)

--- a/plugin.video.vrt.nu/resources/lib/resumepoints.py
+++ b/plugin.video.vrt.nu/resources/lib/resumepoints.py
@@ -253,7 +253,7 @@ class ResumePoints:
                 tileOrientation='landscape',
                 layout='slider',
                 title='Later kijken')
-            watchlater_json = get_url_json(url='{}?{}'.format(self.WATCHLATER_REST_URL, urlencode(payload)), cache=None, headers=headers, raise_errors='all')
+            watchlater_json = get_url_json(url='{}?{}'.format(self.WATCHLATER_REST_URL, urlencode(payload)), cache=None, headers=headers)
         return watchlater_json
 
     def get_continue(self):
@@ -273,7 +273,7 @@ class ResumePoints:
                 tileOrientation='landscape',
                 layout='slider',
                 title='Programma\'s verder kijken')
-            continue_json = get_url_json(url='{}?{}'.format(self.CONTINUE_REST_URL, urlencode(payload)), cache=None, headers=headers, raise_errors='all')
+            continue_json = get_url_json(url='{}?{}'.format(self.CONTINUE_REST_URL, urlencode(payload)), cache=None, headers=headers)
         return continue_json
 
     def set_watchlater_graphql(self, episode_id, title, watch_later=True):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.15+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.15 (2022-08-31)
- Fix add-on crash

v2.5.14 (2022-08-29)
- VRT MAX rebranding

v2.5.13 (2022-08-05)
- Support 1080p video on demand

v2.5.12 (2022-05-25)
- Fix playing from TV guide
- Fix listing programs with a single char in their name

v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
