### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.17

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,11 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.17 (2022-09-21)
+- Fix watching VRT MAX abroad (@mediaminister)
+- Fix 'My Programs' menu (@mediaminister)
+- Fix login issue on Raspberry Pi (@mediaminister)
+
 ### v2.5.16 (2022-09-13)
 - Fix 'My Programs' menu (@mediaminister)
 - Hide resumepoints error messages (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.16" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.17" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,11 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.17 (2022-09-21)
+- Fix watching VRT MAX abroad
+- Fix 'My Programs' menu
+- Fix login issue on Raspberry Pi
+
 v2.5.16 (2022-09-13)
 - Fix 'My Programs' menu
 - Hide resumepoints error messages

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -162,14 +162,6 @@ msgctxt "#30051"
 msgid "My episodes that will soon be offline"
 msgstr ""
 
-msgctxt "#30052"
-msgid "Watch later"
-msgstr ""
-
-msgctxt "#30053"
-msgid "The videos you like to watch later"
-msgstr ""
-
 msgctxt "#30054"
 msgid "Continue watching"
 msgstr ""
@@ -411,22 +403,6 @@ msgctxt "#30334"
 msgid "In 2 days"
 msgstr ""
 
-msgctxt "#30401"
-msgid "Watch later"
-msgstr ""
-
-msgctxt "#30402"
-msgid "Remove from watch later"
-msgstr ""
-
-msgctxt "#30403"
-msgid "Add {title} to watch later"
-msgstr ""
-
-msgctxt "#30404"
-msgid "Remove {title} from watch later"
-msgstr ""
-
 msgctxt "#30409"
 msgid "episode"
 msgstr ""
@@ -594,7 +570,7 @@ msgid "Enable watching activity"
 msgstr ""
 
 msgctxt "#30748"
-msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT MAX account."
+msgid "This enables 'continue watching' menus and syncs playback position between different devices using the same VRT MAX account."
 msgstr ""
 
 msgctxt "#30749"
@@ -1012,7 +988,7 @@ msgid "This program can only be played from an European Union member state. It i
 msgstr ""
 
 msgctxt "#30975"
-msgid "Failed to get user token from VRT MAX"
+msgid "Failed to get access token from VRT MAX"
 msgstr ""
 
 msgctxt "#30976"

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -162,14 +162,6 @@ msgctxt "#30051"
 msgid "My episodes that will soon be offline"
 msgstr "Mijn afleveringen die binnenkort verdwijnen"
 
-msgctxt "#30052"
-msgid "Watch later"
-msgstr "Later bekijken"
-
-msgctxt "#30053"
-msgid "The videos you like to watch later"
-msgstr "Mijn afleveringen die ik later wil bekijken"
-
 msgctxt "#30054"
 msgid "Continue watching"
 msgstr "Verder kijken"
@@ -411,22 +403,6 @@ msgctxt "#30334"
 msgid "In 2 days"
 msgstr "Overmorgen"
 
-msgctxt "#30401"
-msgid "Watch later"
-msgstr "Later bekijken"
-
-msgctxt "#30402"
-msgid "Remove from watch later"
-msgstr "Niet later bekijken"
-
-msgctxt "#30403"
-msgid "Add {title} to watch later"
-msgstr "{title} later bekijken"
-
-msgctxt "#30404"
-msgid "Remove {title} from watch later"
-msgstr "{title} niet later bekijken"
-
 msgctxt "#30409"
 msgid "episode"
 msgstr "aflevering"
@@ -594,8 +570,8 @@ msgid "Enable watching activity"
 msgstr "Toon kijkactiviteit"
 
 msgctxt "#30748"
-msgid "This enables 'watch later' and 'continue watching' menus and syncs playback position between different devices using the same VRT MAX account."
-msgstr "Dit activeert 'kijk later' en 'verderkijken' menu's and synchroniseert de afspeelpositie tussen verschillende toestellen die hetzelfde VRT MAX account gebruiken."
+msgid "This enables 'continue watching' menus and syncs playback position between different devices using the same VRT MAX account."
+msgstr "Dit activeert 'verderkijken' menu's and synchroniseert de afspeelpositie tussen verschillende toestellen die hetzelfde VRT MAX account gebruiken."
 
 msgctxt "#30749"
 msgid "Add Movies subsection"
@@ -1012,8 +988,8 @@ msgid "This program can only be played from an European Union member state. It i
 msgstr "Dit programma kan alleen afgespeeld worden vanuit een lidstaat van de Europese Unie. Het wordt geblokkeerd op jouw geografische locatie op basis van je IP-adres. Meer info op https://www.vrt.be/vrtmax/help/country/"
 
 msgctxt "#30975"
-msgid "Failed to get user token from VRT MAX"
-msgstr "Ophalen van het gebruikerstoken van VRT MAX is mislukt"
+msgid "Failed to get access token from VRT MAX"
+msgstr "Ophalen van het toegangstoken van VRT MAX is mislukt"
 
 msgctxt "#30976"
 msgid "Failed to (un)follow program '{program}' at VRT MAX"

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -60,20 +60,6 @@ def unfollow(program_name, title, program_id=None):
     Favorites().unfollow(program_name=program_name, title=to_unicode(unquote_plus(from_unicode(title))), program_id=program_id, move_down=move_down)
 
 
-@plugin.route('/watchlater/<episode_id>/<title>')
-def watchlater(episode_id, title):
-    """The API interface to watch an episode used by the context menu"""
-    from resumepoints import ResumePoints
-    ResumePoints().watchlater(episode_id=episode_id, title=to_unicode(unquote_plus(from_unicode(title))))
-
-
-@plugin.route('/unwatchlater/<episode_id>/<title>')
-def unwatchlater(episode_id, title):
-    """The API interface to unwatch an episode used by the context menu"""
-    from resumepoints import ResumePoints
-    ResumePoints().unwatchlater(episode_id=episode_id, title=to_unicode(unquote_plus(from_unicode(title))))
-
-
 @plugin.route('/favorites')
 def favorites_menu():
     """The My favorites menu"""
@@ -147,13 +133,6 @@ def resumepoints_refresh():
     from resumepoints import ResumePoints
     ResumePoints().refresh(ttl=0)
     notification(message=localize(30983))
-
-
-@plugin.route('/resumepoints/watchlater')
-def resumepoints_watchlater():
-    """The resumepoints watchlater listing"""
-    from vrtplayer import VRTPlayer
-    VRTPlayer().show_watchlater_menu(page=1)
 
 
 @plugin.route('/programs')

--- a/plugin.video.vrt.nu/resources/lib/apihelper.py
+++ b/plugin.video.vrt.nu/resources/lib/apihelper.py
@@ -99,7 +99,7 @@ class ApiHelper:
         label = self._metadata.get_label(tvshow)
 
         if program:
-            context_menu, favorite_marker, _ = self._metadata.get_context_menu(tvshow, program, cache_file)
+            context_menu, favorite_marker = self._metadata.get_context_menu(tvshow, program, cache_file)
             label += favorite_marker
 
         return TitleItem(
@@ -126,7 +126,7 @@ class ApiHelper:
         # Titletype
         titletype = None
         # FIXME: Find a better way to determine cache file and mixed episodes titletype
-        if variety and variety.startswith('featured.') or variety in ('continue', 'offline', 'recent', 'watchlater'):
+        if variety and variety.startswith('featured.') or variety in ('continue', 'offline', 'recent'):
             titletype = 'mixed_episodes'
         else:
             titletype = variety
@@ -253,8 +253,8 @@ class ApiHelper:
         label, sort, ascending = self._metadata.get_label(episode, titletype, return_sort=True)
 
         if program:
-            context_menu, favorite_marker, watchlater_marker = self._metadata.get_context_menu(episode, program, cache_file)
-            label += favorite_marker + watchlater_marker
+            context_menu, favorite_marker = self._metadata.get_context_menu(episode, program, cache_file)
+            label += favorite_marker
 
         info_labels = self._metadata.get_info_labels(episode)
         # FIXME: Due to a bug in Kodi, ListItem.Title is used when Sort methods are used, not ListItem.Label
@@ -546,11 +546,6 @@ class ApiHelper:
             if variety == 'oneoff':
                 params['facets[episodeNumber]'] = '[0,1]'  # This to avoid VRT MAX metadata errors (see #670)
                 params['facets[programType]'] = 'oneoff'
-
-            if variety == 'watchlater':
-                self._resumepoints.refresh_watchlater(ttl=ttl('direct'))
-                episode_ids = self._resumepoints.watchlater_ids()
-                params['facets[episodeId]'] = '[%s]' % (','.join(episode_ids))
 
             if variety == 'continue':
                 self._resumepoints.refresh_continue(ttl=ttl('direct'))

--- a/plugin.video.vrt.nu/resources/lib/favorites.py
+++ b/plugin.video.vrt.nu/resources/lib/favorites.py
@@ -126,8 +126,8 @@ class Favorites:
                 operationName='Favs',
                 variables=dict(
                     listId='dynamic:/vrtnu.model.json@favorites-list-video',
-                    endCursor='1643276998214',
-                    pageSize=10,
+                    endCursor='',
+                    pageSize=1000,
                 ),
                 query=graphql,
             )
@@ -180,12 +180,14 @@ class Favorites:
             graphql_query = """
                 mutation setFavorite($input: FavoriteActionInput!) {
                   setFavorite(input: $input) {
+                    __typename
                     id
                     favorite
                   }
                 }
             """
             payload = dict(
+                operationName='setFavorite',
                 variables=dict(
                     input=dict(
                         id=program_id,
@@ -229,14 +231,18 @@ class Favorites:
     def _generate_favorites_dict(favorites_json):
         """Generate a simple favorites dict with programIds and programNames"""
         favorites_dict = {}
-        if favorites_json is not None:
-            for item in favorites_json.get('data').get('list').get('paginated').get('edges'):
-                program_name = url_to_program(item.get('node').get('action').get('link'))
-                program_id = item.get('node').get('id')
-                title = item.get('node').get('title')
-                favorites_dict[program_name] = dict(
-                    program_id=program_id,
-                    title=title)
+        try:
+            if favorites_json:
+                edges = favorites_json.get('data', {}).get('list', {}).get('paginated', {}).get('edges', {})
+                for item in edges:
+                    program_name = url_to_program(item.get('node').get('action').get('link'))
+                    program_id = item.get('node').get('id')
+                    title = item.get('node').get('title')
+                    favorites_dict[program_name] = dict(
+                        program_id=program_id,
+                        title=title)
+        except AttributeError:
+            pass
         return favorites_dict
 
     def manage(self):

--- a/plugin.video.vrt.nu/resources/lib/kodiutils.py
+++ b/plugin.video.vrt.nu/resources/lib/kodiutils.py
@@ -1221,7 +1221,7 @@ def get_cached_url_json(url, cache, headers=None, ttl=None, fail=None):  # pylin
 
 def refresh_caches(cache_file=None):
     """Invalidate the needed caches and refresh container"""
-    files = ['favorites.json', 'oneoff.json', 'resume_points.json', 'watchlater.json']
+    files = ['favorites.json', 'oneoff.json', 'resume_points.json']
     if cache_file and cache_file not in files:
         files.append(cache_file)
     invalidate_caches(*files)

--- a/plugin.video.vrt.nu/resources/lib/metadata.py
+++ b/plugin.video.vrt.nu/resources/lib/metadata.py
@@ -13,7 +13,7 @@ except ImportError:  # Python 2
 
 from data import CHANNELS, SECONDS_MARGIN
 from kodiutils import colour, get_setting_bool, localize, localize_datelong, log, url_for
-from utils import (capitalize, find_entry, from_unicode, html_to_kodi, reformat_url,
+from utils import (find_entry, from_unicode, html_to_kodi, reformat_url,
                    reformat_image_url, shorten_link, to_unicode, unescape)
 
 
@@ -55,41 +55,7 @@ class Metadata:
         """Get context menu"""
         from addon import plugin
         favorite_marker = ''
-        watchlater_marker = ''
         context_menu = []
-
-        # WATCH LATER
-        if self._resumepoints.is_activated():
-            episode_id = api_data.get('episodeId')
-
-            # VRT MAX Search API
-            if api_data.get('episodeType'):
-                title = api_data.get('title')
-
-            # VRT MAX Schedule API (some are missing vrt.whatson-id)
-            elif api_data.get('vrt.whatson-id') or api_data.get('startTime'):
-                title = api_data.get('title')
-
-            if episode_id is not None:
-                # We need to ensure forward slashes are quoted
-                title = to_unicode(quote_plus(from_unicode(title)))
-                if self._resumepoints.is_watchlater(episode_id):
-                    extras = {}
-                    # If we are in a watchlater menu, move cursor down before removing a favorite
-                    if plugin.path.startswith('/resumepoints/watchlater'):
-                        extras = dict(move_down=True)
-                    # Unwatch context menu
-                    context_menu.append((
-                        capitalize(localize(30402)),
-                        'RunPlugin(%s)' % url_for('unwatchlater', episode_id=episode_id, title=title, **extras)
-                    ))
-                    watchlater_marker = '[COLOR={highlighted}]ᶫ[/COLOR]'
-                else:
-                    # Watch context menu
-                    context_menu.append((
-                        capitalize(localize(30401)),
-                        'RunPlugin(%s)' % url_for('watchlater', episode_id=episode_id, title=title)
-                    ))
 
         # FOLLOW PROGRAM
         if self._favorites.is_activated():
@@ -138,7 +104,7 @@ class Metadata:
         # GO TO PROGRAM
         if api_data.get('programType') != 'oneoff' and program_name:
             if plugin.path.startswith(('/favorites/offline', '/favorites/recent', '/offline', '/recent',
-                                       '/resumepoints/continue', '/resumepoints/watchlater', '/tvguide')):
+                                       '/resumepoints/continue', '/tvguide')):
                 context_menu.append((
                     localize(30417),  # Go to program
                     'Container.Update(%s)' % url_for('programs', program_name=program_name, season='allseasons')
@@ -150,7 +116,7 @@ class Metadata:
             'RunPlugin(%s)' % url_for('delete_cache', cache_file=cache_file)
         ))
 
-        return context_menu, colour(favorite_marker), colour(watchlater_marker)
+        return context_menu, colour(favorite_marker)
 
     @staticmethod
     def get_asset_str(api_data):

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -293,6 +293,4 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
             position=position,
             total=total,
             path=self.path,
-            episode_id=self.episode_id,
-            episode_title=self.episode_title
         )

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -123,9 +123,9 @@ class StreamService:
                 return data
 
         if api_data.is_live_stream:
-            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'live')
+            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'live', roaming=roaming)
         else:
-            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'ondemand')
+            playertoken = self._tokenresolver.get_token('vrtPlayerToken', 'ondemand', roaming=roaming)
 
         # Construct api_url and get video json
         if not playertoken:
@@ -264,7 +264,7 @@ class StreamService:
 
         # VRT Geoblock: failed to get stream, now try again with roaming enabled
         if stream_json.get('code') in self._GEOBLOCK_ERROR_CODES:
-            log_error('VRT Geoblock: {msg}', msg=stream_json.get('message'))
+            log_error('VRT Geoblock: {msg}', msg=stream_json)
             if not roaming:
                 return self.get_stream(video, roaming=True, api_data=api_data)
 

--- a/plugin.video.vrt.nu/resources/lib/tvguide.py
+++ b/plugin.video.vrt.nu/resources/lib/tvguide.py
@@ -171,13 +171,13 @@ class TVGuide:
         episode_items = []
         for episode in episodes:
             program = url_to_program(episode.get('url', ''))
-            context_menu, favorite_marker, watchlater_marker = self._metadata.get_context_menu(episode, program, cache_file)
+            context_menu, favorite_marker = self._metadata.get_context_menu(episode, program, cache_file)
             label = self._metadata.get_label(episode)
             path = self.get_episode_path(episode, channel)
             # Playable item
             if '/play/' in path:
                 is_playable = True
-                label += favorite_marker + watchlater_marker
+                label += favorite_marker
             # Non-actionable item
             else:
                 is_playable = False

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -138,14 +138,8 @@ class VRTPlayer:
                       info_dict=dict(plot=localize(30051))),
         ]
 
-        # Only add 'My watch later' and 'Continue watching' when it has been activated
+        # Only add 'Continue watching' when it has been activated
         if self._resumepoints.is_activated():
-            favorites_items.append(TitleItem(
-                label=localize(30052),  # My watch later
-                path=url_for('resumepoints_watchlater'),
-                art_dict=dict(thumb='DefaultVideoPlaylists.png'),
-                info_dict=dict(plot=localize(30053)),
-            ))
             favorites_items.append(TitleItem(
                 label=localize(30054),  # Continue Watching
                 path=url_for('resumepoints_continue'),
@@ -315,16 +309,6 @@ class VRTPlayer:
         ))
 
         show_listing(episode_items, category=30022, sort=sort, ascending=ascending, content=content, cache=False)
-
-    def show_watchlater_menu(self, page=0):
-        """The VRT MAX add-on 'My watch later' listing menu"""
-
-        # My watch later menu may need more up-to-date favorites
-        self._favorites.refresh(ttl=ttl('direct'))
-        self._resumepoints.refresh(ttl=ttl('direct'))
-        page = realpage(page)
-        episode_items, sort, ascending, content = self._apihelper.list_episodes(page=page, variety='watchlater')
-        show_listing(episode_items, category=30052, sort=sort, ascending=ascending, content=content, cache=False)
 
     def show_continue_menu(self, page=0):
         """The VRT MAX add-on 'Continue waching' listing menu"""


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.17
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.17 (2022-09-21)
- Fix watching VRT MAX abroad
- Fix 'My Programs' menu
- Fix login issue on Raspberry Pi

v2.5.16 (2022-09-13)
- Fix 'My Programs' menu
- Hide resumepoints error messages
- Implement new login api

v2.5.15 (2022-08-31)
- Fix add-on crash

v2.5.14 (2022-08-29)
- VRT MAX rebranding

v2.5.13 (2022-08-05)
- Support 1080p video on demand

v2.5.12 (2022-05-25)
- Fix playing from TV guide
- Fix listing programs with a single char in their name

v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
