### PR TITLE
[plugin.video.nbcsnliveextra@matrix] 2022.10.5+matrix.1

### DIFF
--- a/plugin.video.nbcsnliveextra/addon.xml
+++ b/plugin.video.nbcsnliveextra/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.2.10+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nbcsnliveextra" name="NBC Sports Live Extra" version="2022.10.5+matrix.1" provider-name="eracknaphobia">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.adobepass" />
@@ -16,7 +16,7 @@
     <summary lang="en_GB">Watch NBCSN Live Extra</summary>
     <description lang="en_GB">NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network</description>
     <news>
-        - Fix playback failing by always setting inputstream license headers
+        - Update and fix filter by Sport
     </news>
     <language>en</language>
     <platform>all</platform>

--- a/plugin.video.nbcsnliveextra/nbcsn.py
+++ b/plugin.video.nbcsnliveextra/nbcsn.py
@@ -49,7 +49,9 @@ def scrape_videos(url):
         json_source = json_source['showCase']
 
     for item in json_source:
-        if 'show-all' in filter_list or item['sport'] in filter_list:
+        # if 'show-all' in filter_list or item['sport'] in filter_list:
+        #     build_video_link(item)
+        if 'show-all' in filter_list or any(x in item['tags'] for x in filter_list):
             build_video_link(item)
 
 

--- a/plugin.video.nbcsnliveextra/resources/lib/globals.py
+++ b/plugin.video.nbcsnliveextra/resources/lib/globals.py
@@ -36,30 +36,29 @@ KODI_VERSION = float(re.findall(r'\d{2}\.\d{1}', xbmc.getInfoLabel("System.Build
 
 filter_ids = [
     "show-all",
-    "nbc-nfl",
-    "nbc-premier-league",
-    "nbc-nascar",
-    "nbc-nhl",
-    "nbc-golf",
-    "nbc-pga",
+    "nfl",
+    "premier-league",
+    "nascar",
+    "nhl",
+    "golf",
+    "pga",
     "nbc-nd",
-    "nbc-college-football",
-    "nbc-f1",
-    "nbc-nba",
-    "nbc-mlb",
-    "nbc-rugby",
-    "nbc-horses",
-    "nbc-tennis",
-    "nbc-indy",
-    "nbc-moto",
-    "nbc-olympic-sports",
+    "college football",
+    "nba",
+    "mlb",
+    "rugby",
+    "horses",
+    "tennis",
+    "indy",
+    "moto",
+    "olympic sports",
     "nbc-csn-bay-area",
     "nbc-csn-california",
     "nbc-csn-chicago",
     "nbc-csn-mid-atlantic",
     "nbc-csn-new-england",
-    "nbc-csn-philadelphia",
-    "nbc-sny"
+    "nbc-csn-philadelphia"
+
 ]
 
 # Create a filter list
@@ -77,7 +76,7 @@ LIVE = 'FF00B7EB'
 UPCOMING = 'FFFFB266'
 FREE_UPCOMING = 'FFCC66FF'
 
-VERIFY = False
+VERIFY = True
 # Add-on specific Adobepass variables
 SERVICE_VARS = {
     'public_key': 'nTWqX10Zj8H0q34OHAmCvbRABjpBk06w',

--- a/plugin.video.nbcsnliveextra/resources/settings.xml
+++ b/plugin.video.nbcsnliveextra/resources/settings.xml
@@ -16,29 +16,27 @@
     <setting type="lsep" label="Filter by Sport / Category"/>
     <!--<setting id="filter" type="select" label="410" default="Show All" values="Show All|NFL|Premier League|NASCAR|NHL|Golf|PGA|Notre Dame|College Football|F1|NBA|MLB|Rugby|Horse racing|Tennis|IndyCar|Pro Motocross|Olympic Sports|CSN Bay Area|CSN California|CSN Chicago|CSN Mid-Atlantic|CSN New England|CSN Philadelphia"  /> -->
     <setting id="show-all" type="bool" label="30410" default="true" />
-    <setting id="nbc-nfl" type="bool" label="30411" default="false" />
-    <setting id="nbc-premier-league" type="bool" label="30412" default="false" />
-    <setting id="nbc-nascar" type="bool" label="30413" default="false" />
-    <setting id="nbc-nhl" type="bool" label="30414" default="false" />
-    <setting id="nbc-golf" type="bool" label="30415" default="false" />
-    <setting id="nbc-pga" type="bool" label="30416" default="false" />
+    <setting id="nfl" type="bool" label="30411" default="false" />
+    <setting id="premier-league" type="bool" label="30412" default="false" />
+    <setting id="nascar" type="bool" label="30413" default="false" />
+    <setting id="nhl" type="bool" label="30414" default="false" />
+    <setting id="golf" type="bool" label="30415" default="false" />
+    <setting id="pga" type="bool" label="30416" default="false" />
     <setting id="nbc-nd" type="bool" label="30417" default="false" />
-    <setting id="nbc-college-football" type="bool" label="30418" default="false" />
-    <setting id="nbc-f1" type="bool" label="30419" default="false" />
-    <setting id="nbc-nba" type="bool" label="30420" default="false" />
-    <setting id="nbc-mlb" type="bool" label="30421" default="false" />
-    <setting id="nbc-rugby" type="bool" label="30422" default="false" />
-    <setting id="nbc-horses" type="bool" label="30423" default="false" />
-    <setting id="nbc-tennis" type="bool" label="30424" default="false" />
-    <setting id="nbc-indy" type="bool" label="30425" default="false" />
-    <setting id="nbc-moto" type="bool" label="30426" default="false" />
-    <setting id="nbc-olympic-sports" type="bool" label="30427" default="false" />
+    <setting id="college-football" type="bool" label="30418" default="false" />
+    <setting id="nba" type="bool" label="30420" default="false" />
+    <setting id="mlb" type="bool" label="30421" default="false" />
+    <setting id="rugby" type="bool" label="30422" default="false" />
+    <setting id="horses" type="bool" label="30423" default="false" />
+    <setting id="tennis" type="bool" label="30424" default="false" />
+    <setting id="indy" type="bool" label="30425" default="false" />
+    <setting id="moto" type="bool" label="30426" default="false" />
+    <setting id="olympic-sports" type="bool" label="30427" default="false" />
     <setting id="nbc-csn-bay-area" type="bool" label="30428" default="false" />
     <setting id="nbc-csn-california" type="bool" label="30429" default="false" />
     <setting id="nbc-csn-chicago" type="bool" label="30430" default="false" />
     <setting id="nbc-csn-mid-atlantic" type="bool" label="30431" default="false" />
     <setting id="nbc-csn-new-england" type="bool" label="30432" default="false" />
     <setting id="nbc-csn-philadelphia" type="bool" label="30433" default="false" />
-    <setting id="nbc-sny" type="bool" label="30434" default="false" />
  </category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NBC Sports Live Extra
  - Add-on ID: plugin.video.nbcsnliveextra
  - Version number: 2022.10.5+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nbcsnliveextra
  
NBC Sports Live Extra is a service that allows you to watch NBC Sports coverage of live events from NBC and NBCSports Network

### Description of changes:


        - Update and fix filter by Sport
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
