### PR TITLE
[plugin.audio.podcasts] 2.2.3

### DIFF
--- a/plugin.audio.podcasts/addon.xml
+++ b/plugin.audio.podcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.2.2" provider-name="Heckie">
+<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.2.3" provider-name="Heckie">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.requests" version="2.25.1" />

--- a/plugin.audio.podcasts/resources/lib/rssaddon/abstract_rss_addon.py
+++ b/plugin.audio.podcasts/resources/lib/rssaddon/abstract_rss_addon.py
@@ -289,6 +289,7 @@ class AbstractRssAddon:
                 }
                 self.add_list_item(entry, path)
 
+            li = None
             for i, item in enumerate(items):
                 if i >= offset and (not limit or i < offset + limit):
                     li = self._create_list_item(item)


### PR DESCRIPTION
### Description
Fixed issue [UnboundLocalError: local variable 'li' referenced before assignment #18](https://github.com/Heckie75/kodi-addon-podcast/issues/18) that was raised in case that rss feed doesn't have any items.

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0