### PR TITLE
[plugin.video.mlbtv@krypton] 2022.10.9

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.9.5" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2022.10.9" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="2.25.0"/>
         <import addon="script.module.pytz" />
@@ -24,6 +24,12 @@
         <news>
             - auto skip: added option to skip to specific batter(s) or pitcher(s)
             - fixed game changer display time bug for start time TBD games
+            - option to skip only commercial breaks
+            - tweaked idle time / specific player skipping
+            - added international blackout labels for postseason games
+            - removed unnecessary Big Inning checks
+            - removed non-playable WBC qualifier games from list
+            - added skip adjust start and end settings (recommend 7 and 5 for postseason so far)
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -281,11 +281,11 @@ msgid "Skip nothing"
 msgstr ""
 
 msgctxt "#30405"
-msgid "Skip breaks plus idle time"
+msgid "Skip all breaks plus idle time between pitches"
 msgstr ""
 
 msgctxt "#30406"
-msgid "Skip breaks, idle time, and non-action pitches"
+msgid "Skip all breaks and non-action pitches"
 msgstr ""
 
 msgctxt "#30407"
@@ -293,7 +293,7 @@ msgid "Inning"
 msgstr ""
 
 msgctxt "#30408"
-msgid "Skip breaks"
+msgid "Skip all breaks"
 msgstr ""
 
 msgctxt "#30409"
@@ -351,4 +351,17 @@ msgstr ""
 msgctxt "#30422"
 msgid "Select batter(s) or pitcher(s) (one at a time, click Cancel when done)"
 msgstr ""
+
+msgctxt "#30423"
+msgid "Skip commercial breaks"
+msgstr ""
+
+msgctxt "#30424"
+msgid "Skip adjust start (seconds)"
+msgstr ""
+
+msgctxt "#30425"
+msgid "Skip adjust end (seconds)"
+msgstr ""
+
 

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -32,6 +32,8 @@
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
+    <setting id="skip_adjust_start" type="labelenum" label="30424" default="0" values="-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7" />
+    <setting id="skip_adjust_end" type="labelenum" label="30425" default="0" values="-7|-6|-5|-4|-3|-2|-1|0|1|2|3|4|5|6|7" />
     <setting id="auto_play_fav" type="bool" label="30412" default="false" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
     <setting id="game_changer_delay" type="labelenum" label="30420" default="0" values="0|10|20" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2022.10.9
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - auto skip: added option to skip to specific batter(s) or pitcher(s)
            - fixed game changer display time bug for start time TBD games
            - option to skip only commercial breaks
            - tweaked idle time / specific player skipping
            - added international blackout labels for postseason games
            - removed unnecessary Big Inning checks
            - removed non-playable WBC qualifier games from list
            - added skip adjust start and end settings (recommend 7 and 5 for postseason so far)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
