### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.19+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,11 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.19 (2022-10-16)
+- Fix categories and channels menu listings (@mediaminister)
+- Fix resumepoints and Up Next integration (@mediaminister)
+- Fix playing from VRT MAX url API interface (@mediaminister)
+
 ### v2.5.18 (2022-10-07)
 - Fix menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.18+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.19+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,11 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.19 (2022-10-16)
+- Fix categories and channels menu listings
+- Fix resumepoints and Up Next integration
+- Fix playing from VRT MAX url API interface
+
 v2.5.18 (2022-10-07)
 - Fix menu listings
 

--- a/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.en_gb/strings.po
@@ -519,6 +519,10 @@ msgctxt "#30454"
 msgid "from livestream cache"
 msgstr ""
 
+msgctxt "#30455"
+msgid "Delete from this list"
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30700"

--- a/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vrt.nu/resources/language/resource.language.nl_nl/strings.po
@@ -519,6 +519,10 @@ msgctxt "#30454"
 msgid "from livestream cache"
 msgstr "uit de livestream-cache"
 
+msgctxt "#30455"
+msgid "Delete from this list"
+msgstr "Verwijder uit deze lijst"
+
 
 ### SETTINGS
 msgctxt "#30700"

--- a/plugin.video.vrt.nu/resources/lib/addon.py
+++ b/plugin.video.vrt.nu/resources/lib/addon.py
@@ -129,6 +129,13 @@ def resumepoints_continue(end_cursor=''):
     VRTPlayer().show_continue_menu(end_cursor=end_cursor)
 
 
+@plugin.route('/resumepoints/continue/delete/<episode_id>')
+def resumepoints_continue_delete(episode_id):
+    """The API interface to delete episodes from continue watching listing"""
+    from resumepoints import ResumePoints
+    ResumePoints().delete_continue(episode_id)
+
+
 @plugin.route('/resumepoints/refresh')
 def resumepoints_refresh():
     """The API interface to refresh the resumepoints cache"""
@@ -265,10 +272,18 @@ def remove_search(keywords):
 
 @plugin.route('/play/id/<video_id>')
 @plugin.route('/play/id/<video_id>/<publication_id>')
-def play_id(video_id, publication_id=None):
+@plugin.route('/play/id/<video_id>/<publication_id>/<episode_id>')
+def play_id(video_id, publication_id=None, episode_id=None):  # pylint: disable=unused-argument
     """The API interface to play a video by video_id and/or publication_id"""
     from vrtplayer import VRTPlayer
     VRTPlayer().play(dict(video_id=video_id, publication_id=publication_id))
+
+
+@plugin.route('/play/url/<path:video_url>')
+def play_url(video_url):
+    """The API interface to play a video by using a VRT MAX URL"""
+    from vrtplayer import VRTPlayer
+    VRTPlayer().play(dict(video_url=video_url))
 
 
 @plugin.route('/play/latest/<program_name>')

--- a/plugin.video.vrt.nu/resources/lib/graphql_data.py
+++ b/plugin.video.vrt.nu/resources/lib/graphql_data.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Implements VRT MAX GraphQL API functionality"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+
+EPISODE_TILE = """
+    fragment episodeTile on EpisodeTile {
+      __typename
+      id
+      title
+      episode {
+        __typename
+        id
+        name
+        available
+        whatsonId
+        title
+        description
+        subtitle
+        permalink
+        logo
+        brand
+        brandLogos {
+          type
+          mono
+          primary
+        }
+        image {
+          alt
+          templateUrl
+        }
+
+        ageRaw
+        ageValue
+
+        durationRaw
+        durationValue
+        durationSeconds
+
+        episodeNumberRaw
+        episodeNumberValue
+        episodeNumberShortValue
+
+        onTimeRaw
+        onTimeValue
+        onTimeShortValue
+
+        offTimeRaw
+        offTimeValue
+        offTimeShortValue
+
+        productPlacementValue
+        productPlacementShortValue
+
+        regionRaw
+        regionValue
+        program {
+          title
+          id
+          link
+          programType
+          description
+          shortDescription
+          subtitle
+          announcementType
+          announcementValue
+          whatsonId
+          image {
+            alt
+            templateUrl
+          }
+          posterImage {
+            alt
+            templateUrl
+          }
+        }
+        season {
+          id
+          titleRaw
+          titleValue
+          titleShortValue
+        }
+        analytics {
+          airDate
+          categories
+          contentBrand
+          episode
+          mediaSubtype
+          mediaType
+          name
+          pageName
+          season
+          show
+        }
+        primaryMeta {
+          longValue
+          shortValue
+          type
+          value
+          __typename
+        }
+        secondaryMeta {
+          longValue
+          shortValue
+          type
+          value
+          __typename
+        }
+        watchAction {
+          avodUrl
+          completed
+          resumePoint
+          resumePointTotal
+          resumePointProgress
+          resumePointTitle
+          episodeId
+          videoId
+          publicationId
+          streamId
+        }
+        favoriteAction {
+          favorite
+          id
+          title
+        }
+      }
+    }
+"""

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -108,6 +108,20 @@ class StreamService:
         # Prepare api_data for livestreams by video_id, e.g. vualto_strubru, vualto_mnm, ketnet_jr
         elif video_id and not video_url:
             api_data = ApiData(self._CLIENT, self._VUALTO_API_URL, video_id, '', True)
+        elif video_url:
+            model_url = video_url.strip('/') + '.model.json'
+            data_json = get_url_json(model_url)
+            # Get streamId
+            stream_id = None
+            for action in data_json.get('details').get('actions'):
+                if action.get('type') == 'watch-episode':
+                    if action.get('videoType') == 'live':
+                        is_live_stream = True
+                        stream_id = action.get('streamId')
+                    else:
+                        is_live_stream = False
+                        stream_id = action.get('episodePublicationId') + quote('$') + action.get('episodeVideoId')
+            api_data = ApiData(self._CLIENT, self._VUALTO_API_URL, stream_id, '', is_live_stream)
         return api_data
 
     def _get_stream_json(self, api_data, roaming=False):

--- a/plugin.video.vrt.nu/resources/lib/vrtplayer.py
+++ b/plugin.video.vrt.nu/resources/lib/vrtplayer.py
@@ -3,7 +3,8 @@
 """Implements a VRTPlayer class"""
 
 from __future__ import absolute_import, division, unicode_literals
-from api import get_continue_episodes, get_featured, get_programs, get_episodes, get_favorite_programs, get_recent_episodes, get_offline_programs
+from api import (get_continue_episodes, get_featured, get_programs, get_episodes, get_favorite_programs, get_recent_episodes,
+                 get_offline_programs, get_single_episode)
 from apihelper import ApiHelper
 from favorites import Favorites
 from helperobjects import TitleItem
@@ -317,7 +318,8 @@ class VRTPlayer:
 
     def play_upnext(self, episode_id):
         """Play the next episode of a program by episode_id"""
-        video = self._apihelper.get_single_episode(episode_id=episode_id)
+        title_item = get_single_episode(episode_id=episode_id)
+        video = dict(listitem=title_item, video_id=title_item.path.split('/')[5], publication_id=title_item.path.split('/')[6])
         if not video:
             log_error('Play Up Next with episodeId {episode_id} failed', episode_id=episode_id)
             ok_dialog(message=localize(30954))


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.19+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from Eén, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.19 (2022-10-16)
- Fix categories and channels menu listings
- Fix resumepoints and Up Next integration
- Fix playing from VRT MAX url API interface

v2.5.18 (2022-10-07)
- Fix menu listings

v2.5.17 (2022-09-21)
- Fix watching VRT MAX abroad
- Fix 'My Programs' menu
- Fix login issue on Raspberry Pi

v2.5.16 (2022-09-13)
- Fix 'My Programs' menu
- Hide resumepoints error messages
- Implement new login api

v2.5.15 (2022-08-31)
- Fix add-on crash

v2.5.14 (2022-08-29)
- VRT MAX rebranding

v2.5.13 (2022-08-05)
- Support 1080p video on demand

v2.5.12 (2022-05-25)
- Fix playing from TV guide
- Fix listing programs with a single char in their name

v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels

v2.5.9 (2022-04-20)
- Fix broken menu listings

v2.5.8 (2022-04-14)
- Fix watching VRT NU abroad
- Fix webscraping video attributes

v2.5.7 (2022-01-31)
- Fix watch later
- Fix favorites

v2.5.6 (2021-12-22)
- Fix watching VRT NU abroad
- Fix resumepoints
- Update featured menu

v2.5.5 (2021-09-09)
- Fix broken menu listings

v2.5.4 (2021-07-21)
- Fix login
- Use Widevine DRM by default

v2.5.2 (2021-05-13)
- Fix watching age restricted content

v2.5.2 (2021-04-21)
- Fix broken menu listings

v2.5.1 (2021-04-07)
- Fix season labels

v2.5.0 (2021-03-29)
- Add new categories to featured menu
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
