### PR TITLE
[plugin.video.sandmann] v2.2.2

### DIFF
--- a/plugin.video.sandmann/addon.xml
+++ b/plugin.video.sandmann/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.sandmann" name="Sandmann" version="2.2.1" provider-name="sorax">
+<addon id="plugin.video.sandmann" name="Sandmann" version="2.2.2" provider-name="sorax">
   <requires>
     <import addon="xbmc.python" version="3.0.0"></import>
   </requires>
@@ -22,8 +22,8 @@
       <icon>resources/assets/icon.png</icon>
       <fanart>resources/assets/fanart.jpg</fanart>
     </assets>
-    <news>v2.2.1:
-      - add date info
+    <news>v2.2.2:
+      - move refresh-item on top of list
     </news>
   </extension>
 </addon>

--- a/plugin.video.sandmann/changelog.txt
+++ b/plugin.video.sandmann/changelog.txt
@@ -1,3 +1,5 @@
+version 2.2.2:
+ * move refresh-item on top of list
 version 2.2.1:
  * add date info
 version 2.2.0:

--- a/plugin.video.sandmann/libs/sandmann.py
+++ b/plugin.video.sandmann/libs/sandmann.py
@@ -48,6 +48,10 @@ source = addon.getSettingInt("source2")
 
 
 def sandmann():
+    if update == 1:
+        li_refresh = xbmcgui.ListItem(label=addon.getLocalizedString(30020))
+        xbmcplugin.addDirectoryItem(addon_handle, base_path, li_refresh, True)
+
     episodes_url = sources["rbb"]
     if source == 1:
         episodes_url = sources["mdr"]
@@ -64,10 +68,6 @@ def sandmann():
             item_list.append((episode["stream"], getListItem(episode), False))
 
     xbmcplugin.addDirectoryItems(addon_handle, item_list, len(item_list))
-
-    if update == 1:
-        li_refresh = xbmcgui.ListItem(label=addon.getLocalizedString(30020))
-        xbmcplugin.addDirectoryItem(addon_handle, base_path, li_refresh, True)
 
     xbmcplugin.endOfDirectory(addon_handle)
 


### PR DESCRIPTION
### Description
 * move refresh-item on top of list (so users don't have to scroll so much)

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
