### PR TITLE
[plugin.video.svtplay@krypton] 5.1.15

### DIFF
--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.14">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.15">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="2.25.0" />
@@ -19,7 +19,8 @@
     <source>https://github.com/nilzen/xbmc-svtplay</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=67110</forum>
     <news>
-- Add fanart to popular, latest
+- Fix broken playback and listing for some items
+- Change item listing to "TITLE (SEASON)" for easier episode overview
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/plugin.video.svtplay/resources/lib/api/graphql.py
+++ b/plugin.video.svtplay/resources/lib/api/graphql.py
@@ -114,7 +114,7 @@ class GraphQL:
       for item in content["items"]:
         item = item["item"]
         season_title = ""
-        if content["type"] == "Season" and content["name"] and item["positionInSeason"]:
+        if content["type"] == "Season" and content["name"]:
           season_title = content["name"]
         title = item["name"]
         video_id = item["urls"]["svtplay"]
@@ -205,6 +205,23 @@ class GraphQL:
     return {
       "svtId" : json_data["listablesByEscenicId"][0]["svtId"],
       "blockedForChildren" : json_data["listablesByEscenicId"][0]["restrictions"]["blockedForChildren"]
+    }
+
+  def getVideoDataForVideoUrl(self, video_url):
+    """
+    Returns video data for any video url.
+
+    The returned data contains "svtId" and "blockedForChildren"
+    """
+    operation_name = "DetailsPageQuery"
+    query_hash = "5be42eb4028ed8f2680ce2302f6887df3fed2dcb6f61ac091ff5a37a3d0bf477"
+    variables = {"path":video_url}
+    json_data = self.__get(operation_name, query_hash, variables=variables)
+    if not json_data:
+      return None
+    return {
+      "svtId" : json_data["detailsPageByPath"]["video"]["svtId"],
+      "blockedForChildren": json_data["detailsPageByPath"]["moreDetails"]["restrictions"]["blockedForChildren"]
     }
 
   def getChannels(self):

--- a/plugin.video.svtplay/resources/lib/svtplay.py
+++ b/plugin.video.svtplay/resources/lib/svtplay.py
@@ -219,8 +219,7 @@ class SvtPlay:
         if channel_pattern.search(video_url):
             video_json = svt.getVideoJSON(video_url)
         else:
-            legacy_id = video_url.split("/")[2]
-            video_data = self.graphql.getVideoDataForLegacyId(legacy_id)
+            video_data = self.graphql.getVideoDataForVideoUrl(video_url)
             if self.settings.inappropriate_for_children and video_data["blockedForChildren"]:
                 raise BlockedForChildrenException()
             video_json = svt.getSvtVideoJson(video_data["svtId"])
@@ -270,7 +269,7 @@ class SvtPlay:
         fanart = play_item.fanart if play_item.item_type == PlayItem.VIDEO_ITEM else ""
         title = play_item.title
         if play_item.item_type == PlayItem.VIDEO_ITEM and play_item.season_title:
-            title = "{season} - {episode}".format(season=play_item.season_title, episode=play_item.title)
+            title = "{episode} ({season})".format(season=play_item.season_title, episode=play_item.title)
         self.__add_directory_item(title, params, play_item.thumbnail, folder, False, info, fanart)
 
     def __is_geo_restricted(self, play_item):
@@ -279,12 +278,12 @@ class SvtPlay:
     
     def __resolve_and_play_video(self, video_json):
         if video_json is None:
-            logging.log("ERROR: Could not get video JSON")
+            logging.error("Could not get video JSON")
             return
         try:
             show_obj = svt.resolveShowJson(video_json)
         except ValueError:
-            logging.log("Could not decode JSON for {}".format(video_json))
+            logging.error("Could not decode JSON for {}".format(video_json))
             return
         if show_obj["videoUrl"]:
             self.playback.play_video(show_obj["videoUrl"], show_obj.get("subtitleUrl", None), self.settings.show_subtitles)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SVT Play
  - Add-on ID: plugin.video.svtplay
  - Version number: 5.1.15
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/nilzen/xbmc-svtplay
  
With this addon you can stream content from SVT Play (svtplay.se).

### Description of changes:


- Fix broken playback and listing for some items
- Change item listing to "TITLE (SEASON)" for easier episode overview
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
