### PR TITLE
[plugin.video.rtpplay@matrix] 6.0.4

### DIFF
--- a/plugin.video.rtpplay/addon.xml
+++ b/plugin.video.rtpplay/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.3" provider-name="enen92, guipenedo">
+<addon id="plugin.video.rtpplay" name="RTP Play" version="6.0.4" provider-name="enen92, guipenedo">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.0"/>
@@ -22,9 +22,8 @@
         <email>enen92@kodi.tv</email>
         <source>https://github.com/enen92/plugin.video.rtpplay</source>
         <news>
-            Version 6.0.3 (15/08/2022)
-                - Add support for inputstream.adaptive
-                - Minor fixes
+            Version 6.0.4 (4/12/2022)
+                - Give priority to smil links
         </news>
         <disclaimer lang="en_GB">The plugin is unofficial and not endorsed by RTP. Expect it to break. </disclaimer>
         <disclaimer lang="pt_PT">Este plugin não é oficial nem desenvolvido pela RTP. </disclaimer>

--- a/plugin.video.rtpplay/resources/lib/kodiutils.py
+++ b/plugin.video.rtpplay/resources/lib/kodiutils.py
@@ -84,7 +84,9 @@ def format_date(date):
 
 
 def get_stream_url(source):
-    if "hls_url_new" in source:
+    if "stream" in source and "clean" in source["stream"] and "smil" in source["stream"]["clean"]:
+        return source["stream"]["clean"]["smil"]
+    elif "hls_url_new" in source:
         return source["hls_url_new"]
     elif "hls_url" in source:
         return source["hls_url"]


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: RTP Play
  - Add-on ID: plugin.video.rtpplay
  - Version number: 6.0.4
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/enen92/plugin.video.rtpplay
  
Play live and on-demand broadcasts from RTP Play

### Description of changes:


            Version 6.0.4 (4/12/2022)
                - Give priority to smil links
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
