### PR TITLE
[plugin.video.viervijfzes@leia] 0.4.9

### DIFF
--- a/plugin.video.viervijfzes/CHANGELOG.md
+++ b/plugin.video.viervijfzes/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.4.9](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.9) (2023-01-04)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.8...v0.4.9)
+
+**Fixed bugs:**
+
+- Add support for unprotected MPEG-DASH streams [\#111](https://github.com/add-ons/plugin.video.viervijfzes/pull/111) ([mediaminister](https://github.com/mediaminister))
+- Fix clips [\#108](https://github.com/add-ons/plugin.video.viervijfzes/pull/108) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v0.4.8](https://github.com/add-ons/plugin.video.viervijfzes/tree/v0.4.8) (2022-07-07)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.viervijfzes/compare/v0.4.7...v0.4.8)

--- a/plugin.video.viervijfzes/README.md
+++ b/plugin.video.viervijfzes/README.md
@@ -1,5 +1,5 @@
-[![GitHub release](https://img.shields.io/github/release/add-ons/plugin.video.viervijfzes.svg?include_prereleases)](https://github.com/add-ons/plugin.video.viervijfzes/releases)
-[![Build Status](https://img.shields.io/github/workflow/status/add-ons/plugin.video.viervijfzes/CI/master)](https://github.com/add-ons/plugin.video.viervijfzes/actions?query=branch%3Amaster)
+[![GitHub release](https://img.shields.io/github/v/release/add-ons/plugin.video.viervijfzes?display_name=tag)](https://github.com/add-ons/plugin.video.viervijfzes/releases)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/add-ons/plugin.video.viervijfzes/ci.yml?branch=master)](https://github.com/add-ons/plugin.video.viervijfzes/actions?query=branch%3Amaster)
 [![Codecov status](https://img.shields.io/codecov/c/github/add-ons/plugin.video.viervijfzes/master)](https://codecov.io/gh/add-ons/plugin.video.viervijfzes/branch/master)
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Contributors](https://img.shields.io/github/contributors/add-ons/plugin.video.viervijfzes.svg)](https://github.com/add-ons/plugin.video.viervijfzes/graphs/contributors)

--- a/plugin.video.viervijfzes/addon.xml
+++ b/plugin.video.viervijfzes/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.8" provider-name="Michaël Arnauts">
+<addon id="plugin.video.viervijfzes" name="GoPlay" version="0.4.9" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -21,8 +21,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by SBS Belgium and is provided 'as is' without any warranty of any kind. The Play4, Play5 and Play6 logos are property of SBS Belgium.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	    <news>v0.4.8 (2022-07-07)
-- Fix Addon due to API changes.</news>
+        <news>v0.4.9 (2023-01-04)
+- Add support for unprotected HD MPEG-DASH streams.</news>
         <source>https://github.com/add-ons/plugin.video.viervijfzes</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.viervijfzes/resources/lib/service.py
+++ b/plugin.video.viervijfzes/resources/lib/service.py
@@ -125,7 +125,7 @@ class KodiPlayer(Player):
         if not self.av_started:
             # Check stream path
             import requests
-            response = requests.get(self.stream_path)
+            response = requests.get(self.stream_path, timeout=5)
             if response.status_code == 403:
                 message_id = 30720
             else:

--- a/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
+++ b/plugin.video.viervijfzes/resources/lib/viervijfzes/content.py
@@ -309,7 +309,7 @@ class ContentApi:
             result = regex_video_data.search(page)
             if result:
                 video_id = json.loads(unescape(result.group(1)))['id']
-                video_json_data = self._get_url('%s/api/video/%s' % (self.SITE_URL, video_id))
+                video_json_data = self._get_url('%s/web/v1/videos/short-form/%s' % (self.API_GOPLAY, video_id))
                 video_json = json.loads(video_json_data)
                 return dict(video=video_json)
 
@@ -336,7 +336,7 @@ class ContentApi:
 
         if 'video' in data and data['video']:
             # We have found detailed episode information
-            episode = self._parse_episode_data(data['video'])
+            episode = self._parse_clip_data(data['video'])
             return episode
 
         if 'program' in data and 'episode' in data and data['program'] and data['episode']:
@@ -361,23 +361,33 @@ class ContentApi:
             raise UnavailableException
 
         if 'videoDash' in data:
-            # DRM protected stream
-            # See https://docs.unified-streaming.com/documentation/drm/buydrm.html#setting-up-the-client
-            drm_key = data['drmKey']['S']
 
-            _LOGGER.debug('Fetching Authentication XML with drm_key %s', drm_key)
-            response_drm = self._get_url(self.API_GOPLAY + '/video/xml/%s' % drm_key, authentication=self._auth.get_token())
-            data_drm = json.loads(response_drm)
+            if 'drmKey' in data:
+                # DRM protected stream
+                # See https://docs.unified-streaming.com/documentation/drm/buydrm.html#setting-up-the-client
+                drm_key = data['drmKey']['S']
 
+                _LOGGER.debug('Fetching Authentication XML with drm_key %s', drm_key)
+                response_drm = self._get_url(self.API_GOPLAY + '/video/xml/%s' % drm_key, authentication=self._auth.get_token())
+                data_drm = json.loads(response_drm)
+
+                # DRM protected DASH stream
+                return ResolvedStream(
+                    uuid=uuid,
+                    url=data['videoDash']['S'],
+                    stream_type=STREAM_DASH,
+                    license_url='https://wv-keyos.licensekeyserver.com/',
+                    auth=data_drm.get('auth'),
+                )
+
+            # Unprotected DASH stream
             return ResolvedStream(
                 uuid=uuid,
                 url=data['videoDash']['S'],
                 stream_type=STREAM_DASH,
-                license_url='https://wv-keyos.licensekeyserver.com/',
-                auth=data_drm.get('auth'),
             )
 
-        # Normal HLS stream
+        # Unprotected HLS stream
         return ResolvedStream(
             uuid=uuid,
             url=data['video']['S'],
@@ -693,6 +703,19 @@ class ContentApi:
             expiry=datetime.fromtimestamp(int(data.get('unpublishDate'))) if data.get('unpublishDate') else None,
             rating=data.get('parentalRating'),
             stream=data.get('path'),
+        )
+        return episode
+
+    @staticmethod
+    def _parse_clip_data(data):
+        """ Parse the Clip JSON.
+        :type data: dict
+        :rtype Episode
+        """
+        episode = Episode(
+            uuid=data.get('videoUuid'),
+            program_title=data.get('title'),
+            title=data.get('title'),
         )
         return episode
 


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: GoPlay
  - Add-on ID: plugin.video.viervijfzes
  - Version number: 0.4.9
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.viervijfzes

Deze add-on geeft toegang tot de programma's die aangeboden worden op de websites van Play4, Play5 en Play6.

### What's new

v0.4.9 (2023-01-04)
- Add support for unprotected HD MPEG-DASH streams.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
