### PR TITLE
[plugin.video.vtm.go@leia] 1.3.3

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.3.3](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.3) (2023-01-04)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.2...v1.3.3)
+
+**Fixed bugs:**
+
+- Filter category names [\#335](https://github.com/add-ons/plugin.video.vtm.go/pull/335) ([michaelarnauts](https://github.com/michaelarnauts))
+
+**Merged pull requests:**
+
+- Update to version 13 API [\#343](https://github.com/add-ons/plugin.video.vtm.go/pull/343) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.3.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.3.2) (2022-06-06)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.1...v1.3.2)

--- a/plugin.video.vtm.go/README.md
+++ b/plugin.video.vtm.go/README.md
@@ -1,5 +1,5 @@
-[![GitHub release](https://img.shields.io/github/release/add-ons/plugin.video.vtm.go.svg)](https://github.com/add-ons/plugin.video.vtm.go/releases)
-[![Build Status](https://img.shields.io/github/workflow/status/add-ons/plugin.video.vtm.go/CI/master)](https://github.com/add-ons/plugin.video.vtm.go/actions?query=branch%3Amaster)
+[![GitHub release](https://img.shields.io/github/v/release/add-ons/plugin.video.vtm.go?display_name=tag)](https://github.com/add-ons/plugin.video.vtm.go/releases)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/add-ons/plugin.video.vtm.go/ci.yml?branch=master)](https://github.com/add-ons/plugin.video.vtm.go/actions?query=branch%3Amaster)
 [![Codecov status](https://img.shields.io/codecov/c/github/add-ons/plugin.video.vtm.go/master)](https://codecov.io/gh/add-ons/plugin.video.vtm.go/branch/master)
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Contributors](https://img.shields.io/github/contributors/add-ons/plugin.video.vtm.go.svg)](https://github.com/add-ons/plugin.video.vtm.go/graphs/contributors)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.2" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.3.3" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,9 +22,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	<news>v1.3.2 (2022-06-06)
-- Fix empty items due to corrupted cache.
-- Show better error message when you are geoblocked.</news>
+        <news>v1.3.3 (2023-01-04)
+- Fix add-on due to changed API.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.en_gb/strings.po
@@ -15,11 +15,11 @@ msgid "Browse through the movie-catalogue"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Series"
+msgid "Shorties"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Browse through the series-catalogue"
+msgid "Browse through the shorties-catalogue"
 msgstr ""
 
 msgctxt "#30007"

--- a/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.vtm.go/resources/language/resource.language.nl_nl/strings.po
@@ -17,12 +17,12 @@ msgid "Browse through the movie-catalogue"
 msgstr "Doorblader de filmcatalogus"
 
 msgctxt "#30005"
-msgid "Series"
-msgstr "Programma's"
+msgid "Shorties"
+msgstr "Shorties"
 
 msgctxt "#30006"
-msgid "Browse through the series-catalogue"
-msgstr "Doorblader de programmacatalogus"
+msgid "Browse through the shorties-catalogue"
+msgstr "Doorblader de shortiescatalogus"
 
 msgctxt "#30007"
 msgid "Channels"

--- a/plugin.video.vtm.go/resources/lib/addon.py
+++ b/plugin.video.vtm.go/resources/lib/addon.py
@@ -116,18 +116,18 @@ def show_mylist():
     Catalog().show_mylist()
 
 
-@routing.route('/catalog/mylist/add/<video_type>/<content_id>')
-def mylist_add(video_type, content_id):
+@routing.route('/catalog/mylist/add/<content_id>')
+def mylist_add(content_id):
     """ Add an item to "My List" """
     from resources.lib.modules.catalog import Catalog
-    Catalog().mylist_add(video_type, content_id)
+    Catalog().mylist_add(content_id)
 
 
-@routing.route('/catalog/mylist/del/<video_type>/<content_id>')
-def mylist_del(video_type, content_id):
+@routing.route('/catalog/mylist/del/<content_id>')
+def mylist_del(content_id):
     """ Remove an item from "My List" """
     from resources.lib.modules.catalog import Catalog
-    Catalog().mylist_del(video_type, content_id)
+    Catalog().mylist_del(content_id)
 
 
 @routing.route('/catalog/continuewatching')

--- a/plugin.video.vtm.go/resources/lib/modules/catalog.py
+++ b/plugin.video.vtm.go/resources/lib/modules/catalog.py
@@ -8,7 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
 from resources.lib.modules.menu import Menu
-from resources.lib.vtmgo import STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SERIES, Category
+from resources.lib.vtmgo import STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SHORTIES, Category
 from resources.lib.vtmgo.exceptions import UnavailableException
 from resources.lib.vtmgo.vtmgo import CACHE_PREVENT, ApiUpdateRequired, VtmGo
 from resources.lib.vtmgo.vtmgoauth import VtmGoAuth
@@ -144,8 +144,8 @@ class Catalog:
             else:
                 listing.append(Menu.generate_titleitem(item))
 
-        if storefront == STOREFRONT_SERIES:
-            label = 30005  # Series
+        if storefront == STOREFRONT_SHORTIES:
+            label = 30005  # Shorties
         elif storefront == STOREFRONT_MOVIES:
             label = 30003  # Movies
         else:
@@ -174,7 +174,7 @@ class Catalog:
         for item in result.content:
             listing.append(Menu.generate_titleitem(item))
 
-        if storefront == STOREFRONT_SERIES:
+        if storefront == STOREFRONT_SHORTIES:
             content = 'tvshows'
         elif storefront == STOREFRONT_MOVIES:
             content = 'movies'
@@ -203,20 +203,18 @@ class Catalog:
 
         kodiutils.show_listing(listing, 30017, content='files', sort=['unsorted', 'label', 'year', 'duration'])
 
-    def mylist_add(self, video_type, content_id):
+    def mylist_add(self, content_id):
         """ Add an item to "My List"
-        :type video_type: str
         :type content_id: str
          """
-        self._api.add_mylist(video_type, content_id)
+        self._api.add_mylist(content_id)
         kodiutils.end_of_directory()
 
-    def mylist_del(self, video_type, content_id):
+    def mylist_del(self, content_id):
         """ Remove an item from "My List"
-        :type video_type: str
         :type content_id: str
         """
-        self._api.del_mylist(video_type, content_id)
+        self._api.del_mylist(content_id)
         kodiutils.end_of_directory()
         kodiutils.container_refresh()
 

--- a/plugin.video.vtm.go/resources/lib/modules/menu.py
+++ b/plugin.video.vtm.go/resources/lib/modules/menu.py
@@ -7,8 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.modules import CHANNELS
-from resources.lib.vtmgo import STOREFRONT_KIDS, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SERIES, Episode, Movie, Program
-from resources.lib.vtmgo.vtmgo import CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM
+from resources.lib.vtmgo import STOREFRONT_KIDS, STOREFRONT_MAIN, STOREFRONT_MOVIES, STOREFRONT_SHORTIES, Episode, Movie, Program
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,8 +60,8 @@ class Menu:
         ))
 
         listing.append(kodiutils.TitleItem(
-            title=kodiutils.localize(30005),  # Series
-            path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_SERIES),
+            title=kodiutils.localize(30005),  # Shorties
+            path=kodiutils.url_for('show_recommendations', storefront=STOREFRONT_SHORTIES),
             art_dict=dict(
                 icon='DefaultTVShows.png',
                 fanart=kodiutils.get_addon_info('fanart'),
@@ -202,13 +201,13 @@ class Menu:
                 context_menu = [(
                     kodiutils.localize(30101),  # Remove from My List
                     'Container.Update(%s)' %
-                    kodiutils.url_for('mylist_del', video_type=CONTENT_TYPE_MOVIE, content_id=item.movie_id)
+                    kodiutils.url_for('mylist_del', content_id=item.movie_id)
                 )]
             else:
                 context_menu = [(
                     kodiutils.localize(30100),  # Add to My List
                     'Container.Update(%s)' %
-                    kodiutils.url_for('mylist_add', video_type=CONTENT_TYPE_MOVIE, content_id=item.movie_id)
+                    kodiutils.url_for('mylist_add', content_id=item.movie_id)
                 )]
 
             info_dict.update({
@@ -243,13 +242,13 @@ class Menu:
                 context_menu = [(
                     kodiutils.localize(30101),  # Remove from My List
                     'Container.Update(%s)' %
-                    kodiutils.url_for('mylist_del', video_type=CONTENT_TYPE_PROGRAM, content_id=item.program_id)
+                    kodiutils.url_for('mylist_del', content_id=item.program_id)
                 )]
             else:
                 context_menu = [(
                     kodiutils.localize(30100),  # Add to My List
                     'Container.Update(%s)' %
-                    kodiutils.url_for('mylist_add', video_type=CONTENT_TYPE_PROGRAM, content_id=item.program_id)
+                    kodiutils.url_for('mylist_add', content_id=item.program_id)
                 )]
 
             info_dict.update({

--- a/plugin.video.vtm.go/resources/lib/modules/proxy.py
+++ b/plugin.video.vtm.go/resources/lib/modules/proxy.py
@@ -78,7 +78,7 @@ class Proxy(BaseHTTPRequestHandler):
             params = parse_qs(urlparse(self.path).query)
             url = params.get('path')[0]
             _LOGGER.debug('Proxying to %s', url)
-            response = requests.get(url=url)
+            response = requests.get(url=url, timeout=30)
 
             # Return response code
             self.send_response(response.status_code)

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -9,7 +9,7 @@ API_ANDROID_ENDPOINT = 'https://lfvp-android-api.dpgmedia.net'
 # These seem to be hardcoded
 STOREFRONT_MAIN = 'main'
 STOREFRONT_MOVIES = 'movies'
-STOREFRONT_SERIES = 'series'
+STOREFRONT_SHORTIES = 'shorties'
 STOREFRONT_KIDS = 'kids'
 
 

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -17,11 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTMGO/12.12 (be.vmma.vtm.zenderapp; build:16424; Android 24) okhttp/4.9.3',
-    'x-app-version': '12',
+    'User-Agent': 'VTM_GO/13.8 (be.vmma.vtm.zenderapp; build:17133; Android TV 28) okhttp/4.10.0',
+    'x-app-version': '13',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
-    'x-persgroep-os-version': '24',
+    'x-persgroep-os-version': '28',
 }
 
 PROXIES = kodiutils.get_proxies()

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgoauth.py
@@ -118,7 +118,7 @@ class VtmGoAuth:
         self._account.refresh_token = auth_info.get('refresh_token')
 
         # Fetch an actual token we can use
-        response = util.http_post('https://lfvp-api.dpgmedia.net/vtmgo/tokens', data={
+        response = util.http_post('https://lfvp-api.dpgmedia.net/VTM_GO/tokens', data={
             'device': {
                 'id': str(uuid.uuid4()),
                 'name': 'VTM Go Addon on Kodi',
@@ -142,7 +142,7 @@ class VtmGoAuth:
             return self._account
 
         # We can refresh our old token so it's valid again
-        response = util.http_post('https://lfvp-api.dpgmedia.net/vtmgo/tokens/refresh', data={
+        response = util.http_post('https://lfvp-api.dpgmedia.net/VTM_GO/tokens/refresh', data={
             'lfvpToken': self._account.access_token,
         })
 
@@ -158,9 +158,9 @@ class VtmGoAuth:
 
         return self._account
 
-    def get_profiles(self, products='VTM_GO,VTM_GO_KIDS'):
+    def get_profiles(self):
         """ Returns the available profiles """
-        response = util.http_get(API_ENDPOINT + '/profiles', {'products': products}, token=self._account.access_token)
+        response = util.http_get(API_ENDPOINT + '/VTM_GO/profiles', token=self._account.access_token)
         result = json.loads(response.text)
 
         profiles = [
@@ -173,7 +173,7 @@ class VtmGoAuth:
                 color=profile.get('color', {}).get('start'),
                 color2=profile.get('color', {}).get('end'),
             )
-            for profile in result
+            for profile in result.get('profiles')
         ]
 
         return profiles


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.3.3
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.3.3 (2023-01-04)
- Fix add-on due to changed API.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
