### PR TITLE
[plugin.video.composite_for_plex@leia] 1.4.4

### DIFF
--- a/plugin.video.composite_for_plex/addon.xml
+++ b/plugin.video.composite_for_plex/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.composite_for_plex" name="Composite" version="1.4.3" provider-name="anxdpanic">
+<addon id="plugin.video.composite_for_plex" name="Composite" version="1.4.4" provider-name="anxdpanic">
     <requires>
         <import addon="xbmc.python" version="2.26.0"/>
         <import addon="script.module.kodi-six" version="0.0.2"/>
@@ -42,6 +42,7 @@
             <fanart>resources/media/fanart.png</fanart>
         </assets>
         <news>
+[fix] fix TV series not showing with library integration |contrib: mash2k3|
 [lang] update translations from Weblate
         </news>
         <platform>all</platform>

--- a/plugin.video.composite_for_plex/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.composite_for_plex/resources/language/resource.language.it_it/strings.po
@@ -7,15 +7,15 @@ msgstr ""
 "Project-Id-Version: Composite\n"
 "Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: 2014-10-26 17:05+0000\n"
-"PO-Revision-Date: 2022-09-23 03:14+0000\n"
-"Last-Translator: Massimo Pissarello <mapi68@gmail.com>\n"
+"PO-Revision-Date: 2022-11-22 17:15+0000\n"
+"Last-Translator: Christian Gade <gade@kodi.tv>\n"
 "Language-Team: Italian <https://kodi.weblate.cloud/projects/kodi-add-ons-video/plugin-video-composite_for_plex/it_it/>\n"
 "Language: it_it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14.1\n"
+"X-Generator: Weblate 4.14.2\n"
 
 msgctxt "Addon Description"
 msgid "Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay"
@@ -27,35 +27,35 @@ msgstr "Composite NON è un componente aggiuntivo Plex ufficiale e non è suppor
 
 msgctxt "#30000"
 msgid "Confirm file delete?"
-msgstr "Confermi l'eliminazione del file?"
+msgstr "Confermare l'eliminazione del file?"
 
 msgctxt "#30001"
 msgid "Delete this item? This action will delete media and associated data files."
-msgstr "Elimino questo elemento? Quest'azione cancellerà il media e i file di dati associati."
+msgstr "Eliminare questo elemento? Questa azione eliminerà i file multimediali e di dati associati."
 
 msgctxt "#30002"
 msgid "Plex Online"
-msgstr "Plex Online"
+msgstr "Plex in linea"
 
 msgctxt "#30003"
 msgid "About to install"
-msgstr "Sto per installare"
+msgstr "In procinto di installare"
 
 msgctxt "#30004"
 msgid "This plugin is already installed"
-msgstr "Questo plugin è già stato installato"
+msgstr "Questo plugin è già installato"
 
 msgctxt "#30005"
 msgid "Switch Failed"
-msgstr "Il cambio è fallito"
+msgstr "Cambio fallito"
 
 msgctxt "#30006"
 msgid "Sign Out"
-msgstr "Esci"
+msgstr "Disconnessione"
 
 msgctxt "#30007"
 msgid "To sign out you must be logged in as an admin user. Switch user and try again"
-msgstr "Per uscire devi essere loggato come utente amministrativo. Per favore cambia utente e prova di nuovo"
+msgstr "Per uscire devi essere loggato come utente amministratore. Cambia utente e riprova"
 
 msgctxt "#30008"
 msgid "myPlex"
@@ -63,76 +63,76 @@ msgstr "myPlex"
 
 msgctxt "#30009"
 msgid "You are currently signed into myPlex. Are you sure you want to sign out?"
-msgstr "Hai eseguito l'accesso in myPlex. Sei sicuro di voler uscire?"
+msgstr "Sei attualmente connesso a myPlex. Sei sicuro di voler uscire?"
 
 #  30010
 msgctxt "#30011"
 msgid "You are not currently logged into myPlex. Continue to sign in, or cancel to return"
-msgstr "Non sei attualmente loggato in myPlex. Per favore continua il login, oppure annulla per tornare indietro"
+msgstr "Non sei attualmente connesso a myPlex. Continua per accedere o annulla per tornare indietro"
 
 msgctxt "#30012"
 msgid "To access these screens you must be logged in as an admin user. Switch user and try again"
-msgstr "Per accedere a queste schermate devi essere loggato come utente amministrativo. Per favore cambia utente e prova di nuovo"
+msgstr "Per accedere a queste schermate devi essere loggato come utente amministratore. Cambia utente e riprova"
 
 msgctxt "#30013"
 msgid "All"
-msgstr "Tutte"
+msgstr "Tutti"
 
 msgctxt "#30014"
 msgid "Unwatched"
-msgstr "Non Viste"
+msgstr "Non visti"
 
 msgctxt "#30015"
 msgid "Recently Aired"
-msgstr "Trasmesse di Recente"
+msgstr "In onda recentemente"
 
 msgctxt "#30016"
 msgid "Recently Added"
-msgstr "Aggiunte di Recente"
+msgstr "Aggiunti recentemente"
 
 msgctxt "#30017"
 msgid "Recently Viewed Episodes"
-msgstr "Episodi Visti di Recente"
+msgstr "Episodi visti recentemente"
 
 msgctxt "#30018"
 msgid "Recently Viewed Shows"
-msgstr "Serie TV Viste di Recente"
+msgstr "Programmi visti recentemente"
 
 msgctxt "#30019"
 msgid "On Deck"
-msgstr "In Primo Piano"
+msgstr "In primo piano"
 
 msgctxt "#30020"
 msgid "By Collection"
-msgstr "Per Collezione"
+msgstr "Per raccolta"
 
 msgctxt "#30021"
 msgid "By First Letter"
-msgstr "Per Prima Lettera"
+msgstr "Per prima lettera"
 
 msgctxt "#30022"
 msgid "By Genre"
-msgstr "Per Genere"
+msgstr "Per genere"
 
 msgctxt "#30023"
 msgid "By Year"
-msgstr "Per Anno"
+msgstr "Per anno"
 
 msgctxt "#30024"
 msgid "By Content Rating"
-msgstr "Per Classificazione"
+msgstr "Per valutazione contenuti"
 
 msgctxt "#30025"
 msgid "By Folder"
-msgstr "Per Cartella"
+msgstr "Per cartella"
 
 msgctxt "#30026"
 msgid "Search Shows..."
-msgstr "Cerca Serie TV..."
+msgstr "Cerca programmi..."
 
 msgctxt "#30027"
 msgid "Search Episodes..."
-msgstr "Cerca Episodi..."
+msgstr "Cerca episodi..."
 
 msgctxt "#30028"
 msgid "All"
@@ -140,39 +140,39 @@ msgstr "Tutti"
 
 msgctxt "#30029"
 msgid "By Album"
-msgstr "Per Album"
+msgstr "Per album"
 
 msgctxt "#30030"
 msgid "By Genre"
-msgstr "Per Genere"
+msgstr "Per genere"
 
 msgctxt "#30031"
 msgid "By Year"
-msgstr "Per Anno"
+msgstr "Per anno"
 
 msgctxt "#30032"
 msgid "By Collection"
-msgstr "Per Collezione"
+msgstr "Per raccolta"
 
 msgctxt "#30033"
 msgid "Recently Added"
-msgstr "Aggiunti di Recente"
+msgstr "Aggiunti recentemente"
 
 msgctxt "#30034"
 msgid "By Folder"
-msgstr "Per Cartella"
+msgstr "Per cartella"
 
 msgctxt "#30035"
 msgid "Search Artists..."
-msgstr "Cerca Artisti..."
+msgstr "Cerca artisti..."
 
 msgctxt "#30036"
 msgid "Search Albums..."
-msgstr "Cerca Album..."
+msgstr "Cerca album..."
 
 msgctxt "#30037"
 msgid "Search Tracks..."
-msgstr "Cerca Tracce..."
+msgstr "Cerca tracce..."
 
 msgctxt "#30038"
 msgid "All"
@@ -180,71 +180,71 @@ msgstr "Tutti"
 
 msgctxt "#30039"
 msgid "Unwatched"
-msgstr "Da Vedere"
+msgstr "Non visti"
 
 msgctxt "#30040"
 msgid "Recently Released"
-msgstr "Usciti di Recente"
+msgstr "Rilasciati recentemente"
 
 msgctxt "#30041"
 msgid "Recently Added"
-msgstr "Aggiunti di Recente"
+msgstr "Aggiunti recentemente"
 
 msgctxt "#30042"
 msgid "Recently Viewed"
-msgstr "Visti di Recente"
+msgstr "Visti recentemente"
 
 msgctxt "#30043"
 msgid "On Deck"
-msgstr "In Primo Piano"
+msgstr "In primo piano"
 
 msgctxt "#30044"
 msgid "By Collection"
-msgstr "Per Collezione"
+msgstr "Per raccolta"
 
 msgctxt "#30045"
 msgid "By Genre"
-msgstr "Per Genere"
+msgstr "Per genere"
 
 msgctxt "#30046"
 msgid "By Year"
-msgstr "Per Anno"
+msgstr "Per anno"
 
 msgctxt "#30047"
 msgid "By Decade"
-msgstr "Per Decade"
+msgstr "Per decade"
 
 msgctxt "#30048"
 msgid "By Director"
-msgstr "Per Regista"
+msgstr "Per regista"
 
 msgctxt "#30049"
 msgid "By Starring Actor"
-msgstr "Per Attore Principale"
+msgstr "Per attore principale"
 
 msgctxt "#30050"
 msgid "By Country"
-msgstr "Per Paese"
+msgstr "Per paese"
 
 msgctxt "#30051"
 msgid "By Content Rating"
-msgstr "Per Classificazione"
+msgstr "Per valutazione contenuti"
 
 msgctxt "#30052"
 msgid "By Rating"
-msgstr "Per Voto"
+msgstr "Per valutazione"
 
 msgctxt "#30053"
 msgid "By Resolution"
-msgstr "Per Risoluzione"
+msgstr "Per risoluzione"
 
 msgctxt "#30054"
 msgid "By First Letter"
-msgstr "Per Prima Lettera"
+msgstr "Per prima lettera"
 
 msgctxt "#30055"
 msgid "By Folder"
-msgstr "Per Cartella"
+msgstr "Per cartella"
 
 msgctxt "#30056"
 msgid "Search..."
@@ -252,23 +252,23 @@ msgstr "Cerca..."
 
 msgctxt "#30057"
 msgid "All"
-msgstr "Tutte"
+msgstr "Tutti"
 
 msgctxt "#30058"
 msgid "By Year"
-msgstr "Per Anno"
+msgstr "Per anno"
 
 msgctxt "#30059"
 msgid "Recently Added"
-msgstr "Aggiunte di Recente"
+msgstr "Aggiunti recentemente"
 
 msgctxt "#30060"
 msgid "Camera Make"
-msgstr "Marca Fotocamera"
+msgstr "Marca fotocamera"
 
 msgctxt "#30061"
 msgid "Camera Model"
-msgstr "Modello Fotocamera"
+msgstr "Modello fotocamera"
 
 msgctxt "#30062"
 msgid "Aperture"
@@ -276,7 +276,7 @@ msgstr "Apertura"
 
 msgctxt "#30063"
 msgid "Shutter Speed"
-msgstr "Velocità Otturatore"
+msgstr "Velocità otturatore"
 
 msgctxt "#30064"
 msgid "ISO"
@@ -288,15 +288,15 @@ msgstr "Lenti"
 
 msgctxt "#30066"
 msgid "Unable to see any media servers"
-msgstr "Non è possible vedere nessun media server"
+msgstr "Impossibile vedere alcun server multimediale"
 
 msgctxt "#30067"
 msgid "Unable to contact server:"
-msgstr "Non è possibile contattare il server:"
+msgstr "Non riesco a contattare il server:"
 
 msgctxt "#30068"
 msgid "Library refresh started"
-msgstr "iniziato aggiornamento libreria"
+msgstr "L'aggiornamento della libreria è iniziato"
 
 msgctxt "#30069"
 msgid "myPlex not configured"
@@ -324,11 +324,11 @@ msgstr "Seleziona server master"
 
 msgctxt "#30075"
 msgid "Known server list"
-msgstr "Lista server conosciuta"
+msgstr "Elenco server conosciuti"
 
 msgctxt "#30076"
 msgid "Switch User"
-msgstr "Cambia Utente"
+msgstr "Cambia utente"
 
 msgctxt "#30077"
 msgid "Enter PIN"
@@ -348,15 +348,15 @@ msgstr "Coda myPlex"
 
 msgctxt "#30081"
 msgid "Sign In"
-msgstr "Login"
+msgstr "Registrati"
 
 msgctxt "#30082"
 msgid "Display Servers"
-msgstr "Visualizza i Server"
+msgstr "Visualizza server"
 
 msgctxt "#30083"
 msgid "Refresh Data"
-msgstr "Aggiorna i dati"
+msgstr "Aggiorna dati"
 
 msgctxt "#30084"
 msgid "Channels"
@@ -368,7 +368,7 @@ msgstr "Playlist"
 
 msgctxt "#30086"
 msgid "Play Transcoded"
-msgstr "Riproduci con transcodifica"
+msgstr "Riproduci transcodificato"
 
 msgctxt "#30087"
 msgid "All episodes"
@@ -380,16 +380,16 @@ msgstr "Stagione"
 
 msgctxt "#30089"
 msgid "Search for"
-msgstr "Ricerca per"
+msgstr "Cerca per"
 
 msgctxt "#30090"
 msgid "Unplayed"
-msgstr ""
+msgstr "Non riprodotti"
 
 # ##### SETTINGS
 msgctxt "#30500"
 msgid "Primary Server Address"
-msgstr "Indirizzo Server Primario"
+msgstr "Indirizzo server primario"
 
 msgctxt "#30501"
 msgid "Stream from PMS"
@@ -405,7 +405,7 @@ msgstr "Abilita i filtri aggiuntivi nei menu"
 
 msgctxt "#30504"
 msgid "Server Discovery"
-msgstr "Ricerca Server"
+msgstr "Ricerca server"
 
 msgctxt "#30505"
 msgid "PMS Username: "
@@ -417,7 +417,7 @@ msgstr "Password PMS: "
 
 msgctxt "#30507"
 msgid "Always Transcode"
-msgstr "Transcodifica Sempre"
+msgstr "Transcodifica sempre"
 
 msgctxt "#30508"
 msgid "Transcode format "
@@ -425,11 +425,11 @@ msgstr "Formato di transcodifica "
 
 msgctxt "#30509"
 msgid "Recent & OnDeck items"
-msgstr "Elementi Recenti e In Primo Piano"
+msgstr "Elementi recenti e in primo piano"
 
 msgctxt "#30510"
 msgid "Debug log"
-msgstr "Log di Debug"
+msgstr "Registro di debug"
 
 msgctxt "#30511"
 msgid "Auto"
@@ -445,11 +445,11 @@ msgstr "smb"
 
 msgctxt "#30514"
 msgid "Debug level"
-msgstr ""
+msgstr "Livello di debug"
 
 msgctxt "#30515"
 msgid "Use transcoding proxy"
-msgstr "Utilizza un proxy per la transcodifica"
+msgstr "Utilizza proxy per la transcodifica"
 
 msgctxt "#30516"
 msgid "Server"
@@ -473,11 +473,11 @@ msgstr "Aspetto"
 
 msgctxt "#30521"
 msgid "Skin Home Shelf"
-msgstr "Scaffale"
+msgstr "Skin scaffale domestico"
 
 msgctxt "#30522"
 msgid "Advanced"
-msgstr "Avanzato"
+msgstr "Avanzate"
 
 msgctxt "#30523"
 msgid "Use Wake On LAN"
@@ -501,11 +501,11 @@ msgstr "Autenticazione richiesta?"
 
 msgctxt "#30528"
 msgid "Load External Subtitles?"
-msgstr "Carica i sottotitoli esterni?"
+msgstr "Caricare i sottotitoli esterni?"
 
 msgctxt "#30529"
 msgid "Always display subtitles?"
-msgstr "Visualizza sempre i sottotitoli?"
+msgstr "Mostrare sempre i sottotitoli?"
 
 msgctxt "#30530"
 msgid "Port Number"
@@ -513,23 +513,23 @@ msgstr "Numero porta"
 
 msgctxt "#30531"
 msgid "Use PMS localisation settings"
-msgstr ""
+msgstr "Utilizza le impostazioni di localizzazione PMS"
 
 msgctxt "#30532"
 msgid "Manual"
-msgstr ""
+msgstr "Manuale"
 
 msgctxt "#30533"
 msgid "Always"
-msgstr ""
+msgstr "Sempre"
 
 msgctxt "#30534"
 msgid "Audio stream selection"
-msgstr ""
+msgstr "Selezione del flusso audio"
 
 msgctxt "#30535"
 msgid "Subtitle stream selection"
-msgstr ""
+msgstr "Selezione del flusso sottotitoli"
 
 msgctxt "#30536"
 msgid "Kodi Control"
@@ -537,7 +537,7 @@ msgstr "Controllo Kodi"
 
 msgctxt "#30537"
 msgid "External"
-msgstr ""
+msgstr "Esterno"
 
 msgctxt "#30538"
 msgid "Audio and subtitle selector"
@@ -553,7 +553,7 @@ msgstr "Qualità"
 
 msgctxt "#30541"
 msgid "Proxy Port"
-msgstr ""
+msgstr "Porta proxy"
 
 msgctxt "#30542"
 msgid "Plex Channel View"
@@ -561,40 +561,40 @@ msgstr "Vista Canale Plex"
 
 msgctxt "#30543"
 msgid "Flatten TV Shows"
-msgstr "Spiana le Serie TV"
+msgstr "Spiana i Programmi TV"
 
 msgctxt "#30544"
 msgid "Server MAC address"
-msgstr ""
+msgstr "Indirizzo MAC del server"
 
 msgctxt "#30545"
 msgid "Plex Style Watched flags"
-msgstr ""
+msgstr "Flag già visto in stile Plex"
 
 msgctxt "#30546"
 msgid "Windows Media Server?"
-msgstr ""
+msgstr "Windows Media Server?"
 
 msgctxt "#30547"
 msgid "Use WOL?"
-msgstr ""
+msgstr "Utilizzare WOL?"
 
 # 30548
 msgctxt "#30549"
 msgid "Skip Genre/director/writer"
-msgstr "Evita i metadata Genere/Regista/Scrittore"
+msgstr "Salta genere/regista/sceneggiatore"
 
 msgctxt "#30550"
 msgid "Skip images (thumbs, fanart)"
-msgstr "Evita le immagini (miniature, fanart)"
+msgstr "Salta immagini (miniature, fanart)"
 
 msgctxt "#30551"
 msgid "Skip Media Flags"
-msgstr "Evita i Media Flags"
+msgstr "Salta flag multimediali"
 
 msgctxt "#30552"
 msgid "Skip Context Menus"
-msgstr "Evita i menu contestuali"
+msgstr "Salta menu contestuali"
 
 msgctxt "#30553"
 msgid "Off"
@@ -602,19 +602,19 @@ msgstr "Spento"
 
 msgctxt "#30554"
 msgid "Bonjour"
-msgstr ""
+msgstr "Bonjour"
 
 msgctxt "#30556"
 msgid "Play TV Theme Music"
-msgstr ""
+msgstr "Riproduci musica a tema TV"
 
 msgctxt "#30557"
 msgid "Select audio output"
-msgstr "Seleziona l'audio di uscita"
+msgstr "Seleziona uscita audio"
 
 msgctxt "#30558"
 msgid "If only one season"
-msgstr "Se c'è solo una stagione"
+msgstr "Se solo una stagione"
 
 msgctxt "#30559"
 msgid "All seasons"
@@ -622,11 +622,11 @@ msgstr "Tutte le stagioni"
 
 msgctxt "#30560"
 msgid "Force DVD playback"
-msgstr "Forza la riproduzione DVD"
+msgstr "Forza riproduzione DVD"
 
 msgctxt "#30561"
 msgid "Override SMB location"
-msgstr "Correggi la posizione SMB"
+msgstr "Sostituisci posizione SMB"
 
 msgctxt "#30562"
 msgid "NAS IP Address"
@@ -646,7 +646,7 @@ msgstr "Password NAS"
 
 msgctxt "#30566"
 msgid "NAS Root Folder"
-msgstr "Cartella Principale NAS"
+msgstr "Cartella principale NAS"
 
 msgctxt "#30567"
 msgid "Plex Control"
@@ -654,39 +654,39 @@ msgstr "Controllo Plex"
 
 msgctxt "#30568"
 msgid "Subtitle Size"
-msgstr "Dimensione Sottotitolo"
+msgstr "Dimensione sottotitoli"
 
 msgctxt "#30569"
 msgid "Audio Boost"
-msgstr "Aumento Livello Audio"
+msgstr "Aumenta audio"
 
 msgctxt "#30570"
 msgid "Auto (GDM)"
-msgstr ""
+msgstr "Auto (GDM)"
 
 msgctxt "#30571"
 msgid "Current Master Server"
-msgstr "Master Server Corrente"
+msgstr "Server principale attuale"
 
 msgctxt "#30572"
 msgid "Current Master Server"
-msgstr ""
+msgstr "Server principale attuale"
 
 msgctxt "#30573"
 msgid "Recently Added"
-msgstr "Aggiunti di Recente"
+msgstr "Aggiunti recentemente"
 
 msgctxt "#30574"
 msgid "On Deck"
-msgstr "In Primo Piano"
+msgstr "In primo piano"
 
 msgctxt "#30575"
 msgid "Force Skin Views"
-msgstr "Forza la vista della skin"
+msgstr "Forza visualizzazioni skin"
 
 msgctxt "#30576"
 msgid "Skin Name"
-msgstr "Nome Skin"
+msgstr "Nome skin"
 
 msgctxt "#30577"
 msgid "Movie View"
@@ -694,7 +694,7 @@ msgstr "Vista Film"
 
 msgctxt "#30578"
 msgid "TV View"
-msgstr "Vista Serie TV"
+msgstr "Vista TV"
 
 msgctxt "#30579"
 msgid "Season View"
@@ -710,27 +710,27 @@ msgstr "Vista Musica"
 
 msgctxt "#30582"
 msgid "Enable Movie Shelf"
-msgstr "Abilita lo Scaffale per i Film"
+msgstr "Abilita scaffale per i Film"
 
 msgctxt "#30583"
 msgid "Enable TV Shelf"
-msgstr "Abilita lo Scaffale per le Serie TV"
+msgstr "Abilita scaffale per la TV"
 
 msgctxt "#30584"
 msgid "Enable Music Shelf"
-msgstr "Abilita lo Scaffale per la Musica"
+msgstr "Abilita scaffale per la Musica"
 
 msgctxt "#30585"
 msgid "Enable Channel Shelf"
-msgstr "Abilita lo Scaffale per i Canali"
+msgstr "Abilita scaffale per i Canali"
 
 msgctxt "#30586"
 msgid "Content filter"
-msgstr "Filtro Contenuti"
+msgstr "Filtro contenuti"
 
 msgctxt "#30587"
 msgid "Map unknown content as:"
-msgstr "Mappa il contenuto sconosciuto come:"
+msgstr "Mappa contenuti sconosciuti come:"
 
 msgctxt "#30588"
 msgid "RA Library filter"
@@ -754,7 +754,7 @@ msgstr "Utilizza il menù per le sezioni condivise"
 
 msgctxt "#30593"
 msgid "Cache Data"
-msgstr ""
+msgstr "Cache dati"
 
 msgctxt "#30594"
 msgid "Manual"
@@ -770,19 +770,19 @@ msgstr "Utilizza le fanart a piena risoluzione"
 
 msgctxt "#30597"
 msgid "Hide watched recently added items"
-msgstr "Nascondi gli elementi visti e aggiunti di recente"
+msgstr "Nascondi gli elementi già visti e aggiunti di recente"
 
 msgctxt "#30598"
 msgid "Info"
-msgstr ""
+msgstr "Informazioni"
 
 msgctxt "#30599"
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 msgctxt "#30600"
 msgid "Debug+"
-msgstr ""
+msgstr "Debug+"
 
 msgctxt "#30601"
 msgid "Transcoder"
@@ -794,11 +794,11 @@ msgstr "Nome"
 
 msgctxt "#30603"
 msgid "Disable 'All Episodes'"
-msgstr "Disabilita 'Tutti gli Episodi'"
+msgstr "Disabilita 'Tutti gli episodi'"
 
 msgctxt "#30604"
 msgid "Enable Kodi view cache"
-msgstr "Abilita la cache di Kodi"
+msgstr "Abilita la cache di visualizzazione di Kodi"
 
 msgctxt "#30605"
 msgid "Manage myPlex"
@@ -810,15 +810,15 @@ msgstr "Preferisci la grafica delle Stagioni"
 
 msgctxt "#30607"
 msgid "Hide Unique Information in log"
-msgstr "Nascondi le informazioni uniche nel log"
+msgstr "Nascondi informazioni univoche nel log"
 
 msgctxt "#30608"
 msgid "Use Kodi client name?"
-msgstr "Uso il nome del client Kodi?"
+msgstr "Utilizzo il nome del client Kodi?"
 
 msgctxt "#30609"
 msgid "Switch off playback monitor"
-msgstr "Spegni il monitoraggio per la riproduzione"
+msgstr "Spegnere il monitor di riproduzione"
 
 msgctxt "#30610"
 msgid "Use HTTPS"
@@ -1017,11 +1017,11 @@ msgstr ""
 
 msgctxt "#30661"
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgctxt "#30662"
 msgid "Server Cache TTL (minutes)"
-msgstr ""
+msgstr "Server Cache TTL (minuti)"
 
 msgctxt "#30663"
 msgid "Server detection notification"
@@ -1081,7 +1081,7 @@ msgstr "Seleziona playlist"
 
 msgctxt "#30677"
 msgid "Add to playlist"
-msgstr ""
+msgstr "Aggiungi a playlist"
 
 msgctxt "#30678"
 msgid "Added %s to the %s playlist"
@@ -1109,7 +1109,7 @@ msgstr ""
 
 msgctxt "#30684"
 msgid "Up Next"
-msgstr ""
+msgstr "Avanti il prossimo"
 
 msgctxt "#30685"
 msgid "Enable Up Next"
@@ -1149,11 +1149,11 @@ msgstr ""
 
 msgctxt "#30694"
 msgid "Clear Caches"
-msgstr ""
+msgstr "Cancella cache"
 
 msgctxt "#30695"
 msgid "Data Cache TTL (minutes)"
-msgstr ""
+msgstr "Cache dati TTL (minuti)"
 
 msgctxt "#30696"
 msgid "Clear data cache on refresh"
@@ -1185,7 +1185,7 @@ msgstr ""
 
 msgctxt "#30703"
 msgid "Data Cache"
-msgstr ""
+msgstr "Cache dati"
 
 msgctxt "#30704"
 msgid "Companion receiver is unable to start due to a port conflict"
@@ -1229,7 +1229,7 @@ msgstr "Password"
 
 msgctxt "#30714"
 msgid "Main Menu"
-msgstr ""
+msgstr "Menu principale"
 
 msgctxt "#30715"
 msgid "Show [B]myPlex Queue[/B] menu"
@@ -1269,7 +1269,7 @@ msgstr ""
 
 msgctxt "#30724"
 msgid "Delete playlist"
-msgstr ""
+msgstr "Elimina playlist"
 
 msgctxt "#30725"
 msgid "Confirm playlist delete?"
@@ -1289,11 +1289,11 @@ msgstr ""
 
 msgctxt "#30729"
 msgid "Plex"
-msgstr ""
+msgstr "Plex"
 
 msgctxt "#30730"
 msgid "Kodi"
-msgstr ""
+msgstr "Kodi"
 
 msgctxt "#30731"
 msgid "Manage Servers"
@@ -1445,7 +1445,7 @@ msgstr ""
 
 msgctxt "#30768"
 msgid "Play"
-msgstr ""
+msgstr "Riproduci"
 
 msgctxt "#30769"
 msgid "Item Count"
@@ -1577,7 +1577,7 @@ msgstr ""
 
 msgctxt "#30801"
 msgid "Detect Servers"
-msgstr ""
+msgstr "Rileva server"
 
 #~ msgctxt "#30572"
 #~ msgid "Shelf Items"

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/dialogs/composite_playlist.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/addon/dialogs/composite_playlist.py
@@ -636,7 +636,7 @@ class RadioButton(pyxbmct.CompareMixin, xbmcgui.ControlRadioButton):
             'noFocusOffTexture': os.path.join(pyxbmct.skin.images,
                                               'RadioButton', 'radiobutton-nofocus.png')
         })
-        return super(RadioButton, cls).__new__(cls, -10, -10, 1, 1, *args, **kwargs)
+        return super(RadioButton, cls).__new__(cls, -10, -10, 1, 1, *args, **kwargs)  # pylint: disable=too-many-function-args
 
 
 if CONFIG['kodi_version'] >= 19:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/listener.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/companion/listener.py
@@ -44,7 +44,7 @@ class PlexCompanionHandler(BaseHTTPRequestHandler):
         self.client_details = self.settings.companion_receiver()
         BaseHTTPRequestHandler.__init__(self, *args, **kwargs)
 
-    def log_message(self, format, *args):  # pylint: disable=redefined-builtin, unused-argument, no-self-use
+    def log_message(self, format, *args):  # pylint: disable=redefined-builtin, unused-argument
         # I have my own logging, suppressing BaseHTTPRequestHandler's
         # LOG.debug(format % args)
         return True

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/plex/plex.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/plex/plex.py
@@ -137,7 +137,8 @@ class Plex:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         if temp_token:
             response = requests.get('%s/users/account?X-Plex-Token=%s' %
                                     (self.myplex_server, temp_token),
-                                    headers=self.plex_identification_header())
+                                    headers=self.plex_identification_header(),
+                                    timeout=120)
             response.encoding = 'utf-8'
 
             LOG.debug('Status Code: %s' % response.status_code)
@@ -617,7 +618,8 @@ class Plex:  # pylint: disable=too-many-public-methods, too-many-instance-attrib
         }
 
         response = requests.post('%s/users/sign_in.xml' % self.myplex_server,
-                                 headers=dict(self.plex_identification_header(), **myplex_headers))
+                                 headers=dict(self.plex_identification_header(), **myplex_headers),
+                                 timeout=120)
         response.encoding = 'utf-8'
 
         if response.status_code == 201:

--- a/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/kodi_library.py
+++ b/plugin.video.composite_for_plex/resources/lib/composite_addon/routes/kodi_library.py
@@ -48,7 +48,7 @@ def run(context):
         LOG.debug('refresh info for %s' % context.params.get('url'))
         context.plex_network = plex.Plex(context.settings, load=True)
         server = context.plex_network.get_server_from_url(context.params.get('url'))
-        _list_content(context, server, context.params.get('url'))
+        _list_content(context, server, context.params.get('url'), content_type)
         xbmcplugin.endOfDirectory(get_handle(), cacheToDisc=False)
 
     else:
@@ -78,7 +78,8 @@ def run(context):
                         set_content(get_handle(), content_type)
                         _list_content(context, server,
                                       server.join_url(server.get_url_location(),
-                                                      section.get_path(), 'all'))
+                                                      section.get_path(), 'all'),
+                                      content_type)
 
         xbmcplugin.endOfDirectory(get_handle(), cacheToDisc=False)
 
@@ -93,24 +94,24 @@ def _get_content_type(path_mode):
     return content_type
 
 
-def _list_content(context, server, url):
+def _list_content(context, server, url, content_type):
     tree = server.processed_xml(url)
     if tree is None:
         return
 
     items = []
     append_item = items.append
+    content_iter = 'Video'
+
+    if 'movies' in content_type:
+        content_iter = 'Video'
+    if 'tvshows' in content_type:
+        content_iter = 'Directory'
 
     if PY3:
-        branches = tree.iter('Video')
+        branches = tree.iter(content_iter)
     else:
-        branches = tree.getiterator('Video')
-
-    if not branches:
-        if PY3:
-            branches = tree.iter('Directory')
-        else:
-            branches = tree.getiterator('Directory')
+        branches = tree.getiterator(content_iter)
 
     for content in branches:
         item = Item(server, url, tree, content)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Composite
  - Add-on ID: plugin.video.composite_for_plex
  - Version number: 1.4.4
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/anxdpanic/plugin.video.composite_for_plex
  
Browse and play video, music and photo media files managed by Plex Media Server.[CR][CR]Fork of PleXBMC by Hippojay

### Description of changes:


[fix] fix TV series not showing with library integration |contrib: mash2k3|
[lang] update translations from Weblate
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
