### PR TITLE
[plugin.video.svtplay@krypton] 5.1.17

### DIFF
--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.16">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.17">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="2.25.0" />
@@ -19,8 +19,7 @@
     <source>https://github.com/nilzen/xbmc-svtplay</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=67110</forum>
     <news>
-- New icon and background for addon
-- Fix for compatibility with Kodi 20 (nexus)
+- Minor bug fixes (thank you @tomplast)
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/plugin.video.svtplay/resources/lib/api/graphql.py
+++ b/plugin.video.svtplay/resources/lib/api/graphql.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import,unicode_literals
 import json
 import re
 import requests
+from resources.lib.helper import strip_html_tags
 from resources.lib import logging
 from resources.lib.listing.listitem import VideoItem, ShowItem
 
@@ -169,7 +170,12 @@ class GraphQL:
     json_data = self.__get(operation_name, query_hash, variables=variables)
     if not json_data:
       return None
+
+    if not json_data['searchPage']['flat']:
+        return []
+
     results = []
+
     for search_hit in json_data["searchPage"]["flat"]["hits"]:
       item = search_hit["teaser"]["item"]
       type_name = item["__typename"]
@@ -312,6 +318,11 @@ class GraphQL:
     return sorted(items, key=lambda item: item.title)
 
   def __create_item(self, title, type_name, item_id, geo_restricted, thumbnail="", info={}, fanart=""):
+    title = strip_html_tags(title)
+
+    for k in info:
+        info[k] = strip_html_tags(info[k])
+
     if self.__is_video(type_name):
       return VideoItem(title, item_id, thumbnail, geo_restricted, info=info, fanart=fanart)
     elif self.__is_show(type_name):

--- a/plugin.video.svtplay/resources/lib/api/svt.py
+++ b/plugin.video.svtplay/resources/lib/api/svt.py
@@ -100,14 +100,16 @@ def __get_video_version(versions):
 def episodeUrlToShowUrl(url):
   """
   Returns the show URL from episode url.
-  Example: "/video/22132986/abel-och-fant/abel-och-fant-sasong-2-kupa-pa-rymmen" > "abel-och-fant"
-
+  Example1: "/video/22132986/abel-och-fant/abel-och-fant-sasong-2-kupa-pa-rymmen" > "abel-och-fant"
+  Example2: "/bluey" > "bluey"
   Returns None for single video items (movies etc)
   """
   new_url = None
   stub_url = url.split("/")
   if len(stub_url) >= 5:
     new_url = stub_url[3]
+  elif len(stub_url) == 2:
+    new_url = stub_url[1]  
   return new_url
 
 def resolveShowJson(json_obj):

--- a/plugin.video.svtplay/resources/lib/helper.py
+++ b/plugin.video.svtplay/resources/lib/helper.py
@@ -36,3 +36,13 @@ def getInputFromKeyboard(heading):
   if keyboard.isConfirmed():
       text = keyboard.getText()
   return text
+
+def strip_html_tags(string):
+    if not string:
+        return string
+
+    try:
+        return re.sub('<[^<]+?>', '', string)
+    except Exception as e:
+        logging.error('An error occured while trying to strip tags from text: "{}". Exception: {}'.format(string, e))
+        return string


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SVT Play
  - Add-on ID: plugin.video.svtplay
  - Version number: 5.1.17
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/nilzen/xbmc-svtplay
  
With this addon you can stream content from SVT Play (svtplay.se).

### Description of changes:


- Minor bug fixes (thank you @tomplast)
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
