### PR TITLE
[plugin.video.videomediaset@krypton] 2.1.0

### DIFF
--- a/plugin.video.videomediaset/addon.xml
+++ b/plugin.video.videomediaset/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.videomediaset" name="Mediaset Play Infinity" provider-name="phate89, aracnoz" version="2.0.7">
+<addon id="plugin.video.videomediaset" name="Mediaset Infinity" provider-name="phate89, aracnoz" version="2.1.0">
     <requires>
         <import addon="xbmc.python" version="2.25.0" />
-        <import addon="script.module.phate89" version="1.2.1"/>
+        <import addon="script.module.phate89" version="1.2.2"/>
         <import addon="script.module.inputstreamhelper" version="0.0.1"/>
     </requires>
     <extension library="default.py" point="xbmc.python.pluginsource">
@@ -19,8 +19,11 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=292876</forum>
         <source>https://github.com/phate89/plugin.video.videomediaset</source>
         <reuselanguageinvoker>true</reuselanguageinvoker>
-        <news>2.0.7
-- fix mistake in code refactoring
+        <news>2.1.0
+- fixed movie category listing
+- fixed mediaset branding name
+- updated lib helper to fix nexus 20 problems (thx nixxo and CristianSumma)
+- fixed random videos erroring out (thx madpilot78)
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.videomediaset/changelog.txt
+++ b/plugin.video.videomediaset/changelog.txt
@@ -1,3 +1,12 @@
+[B]2.1.0[/B]
+- fixed movie category listing
+- fixed mediaset branding name
+- updated lib helper to fix nexus 20 problems (thx nixxo and CristianSumma)
+- fixed random videos erroring out (thx madpilot78)
+
+[B]2.0.8[/B]
+- added option to order like mediaset website
+
 [B]2.0.7[/B]
 - fix mistake in code refactoring
 

--- a/plugin.video.videomediaset/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.videomediaset/resources/language/resource.language.en_gb/strings.po
@@ -42,6 +42,10 @@ msgctxt "#32006"
 msgid "Installa widevine per i contenuti protetti"
 msgstr "Install widevine CDM for protected content"
 
+msgctxt "#32007"
+msgid "Ordina usando l'ordinamento mediaset (da più nuovo a più vecchio)"
+msgstr "Order using mediaset ordering (from newer to older)"
+
 msgctxt "#32101"
 msgid "Tutto A-Z"
 msgstr "All A-Z"

--- a/plugin.video.videomediaset/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.videomediaset/resources/language/resource.language.it_it/strings.po
@@ -42,6 +42,10 @@ msgctxt "#32006"
 msgid "Installa widevine per i contenuti protetti"
 msgstr "Installa widevine per i contenuti protetti"
 
+msgctxt "#32007"
+msgid "Ordina usando l'ordinamento mediaset (da più nuovo a più vecchio)"
+msgstr "Ordina usando l'ordinamento mediaset (da più nuovo a più vecchio)"
+
 msgctxt "#32101"
 msgid "Tutto A-Z"
 msgstr "Tutto A-Z"

--- a/plugin.video.videomediaset/resources/lib/mediaset.py
+++ b/plugin.video.videomediaset/resources/lib/mediaset.py
@@ -428,7 +428,7 @@ class Mediaset(rutils.RUtils):
                     '&assetTypes=HD,browser,widevine,geoIT|geoNo:HD,browser,geoIT|geoNo:HD,'
                     'geoIT|geoNo:SD,''browser,widevine,geoIT|geoNo:SD,browser,geoIT|geoNo:SD,'
                     'geoIT|geoNo')
-        text = self.getText(u)
+        text = self.getText(u).encode('utf-8')
         res = {'url': '', 'pid': '', 'type': '', 'security': False}
         root = ET.fromstring(text)
         for vid in root.findall('.//{http://www.w3.org/2005/SMIL21/Language}switch'):

--- a/plugin.video.videomediaset/resources/main.py
+++ b/plugin.video.videomediaset/resources/main.py
@@ -279,8 +279,12 @@ class KodiMediaset(object):
         kodiutils.endScript()
 
     def elenco_video_list(self, subBrandId, start):
+        if (kodiutils.getSettingAsBool('sortmediaset')):
+            sort = 'mediasetprogram$publishInfo_lastPublished|desc'
+        else:
+            sort = 'mediasetprogram$publishInfo_lastPublished'
         els = self.med.OttieniVideoSezione(
-            subBrandId, sort='mediasetprogram$publishInfo_lastPublished', erange=self.__imposta_range(start))
+            subBrandId, sort=sort, erange=self.__imposta_range(start))
         self.__analizza_elenco(els, True)
         if len(els) == self.iperpage:
             kodiutils.addListItem(kodiutils.LANGUAGE(32130),
@@ -349,7 +353,7 @@ class KodiMediaset(object):
                                                                      prog["mediasetlisting$epgTitle"])),
                                        'infos': _gather_info(prog),
                                        'arts': _gather_art(prog),
-                                       'restartAllowed': prog['mediasetlisting$restartAllowed']}
+                                       'restartAllowed': prog.get('mediasetlisting$restartAllowed', False)}
         els = self.med.OttieniCanaliLive(sort='ShortTitle')
         for prog in els:
             if (prog['callSign'] in chans and 'tuningInstruction' in prog and
@@ -382,7 +386,9 @@ class KodiMediaset(object):
 
     def __ottieni_vid_restart(self, guid):
         res = self.med.OttieniLiveStream(guid)
-        if ('currentListing' in res[0] and
+        if (res is not None and
+                res[0] is not None and
+                'currentListing' in res[0] and
                 res[0]['currentListing']['mediasetlisting$restartAllowed']):
             url = res[0]['currentListing']['restartUrl']
             return url.rpartition('/')[-1]

--- a/plugin.video.videomediaset/resources/settings.xml
+++ b/plugin.video.videomediaset/resources/settings.xml
@@ -4,6 +4,7 @@
         <setting label="32002" type="text" id="password" option="hidden" default=""/>
         <setting label="32003" type="number" id="itemsperpage" default="500"/>
         <setting label="32004" type="bool" id="fullguide" default="false"/>
+        <setting label="32007" type="bool" id="sortmediaset" default="false"/>
         <setting label="32005" type="bool" id="splitlive" default="false"/>
         <setting label="32006" type="action" action="RunScript(script.module.inputstreamhelper,widevine_install)" visible="!system.platform.android"/>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Mediaset Infinity
  - Add-on ID: plugin.video.videomediaset
  - Version number: 2.1.0
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/phate89/plugin.video.videomediaset
  
All your favorite shows are available to you the day after the airing Tv. Last night you missed your favorite TV drama? No problem, you can finally see her comfortably on KODI whenever you want.

### Requires https://github.com/xbmc/repo-scripts/pull/2397

### Description of changes:

2.1.0
- fixed movie category listing
- fixed mediaset branding name
- updated lib helper to fix nexus 20 problems (thx nixxo and CristianSumma)
- fixed random videos erroring out (thx madpilot78)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
