### PR TITLE
[plugin.video.vtm.go@leia] 1.4.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [v1.4.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.0) (2023-02-03)
+## [v1.4.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.1) (2023-02-08)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.0...v1.4.1)
+
+**Fixed bugs:**
+
+- Fix livestreams on Kodi 19 [\#354](https://github.com/add-ons/plugin.video.vtm.go/pull/354) ([mediaminister](https://github.com/mediaminister))
+
+## [v1.4.0](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.0) (2023-02-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.3.3...v1.4.0)
 

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.0" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,11 +22,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.4.0 (2023-02-03)
-- Update API to support new DRM.
-- Fix subtitles on Kodi 20.
-- Add EPG for VTM Non-Stop.
-- Remove VTM Kids (no longer available).</news>
+        <news>v1.4.1 (2023-02-09)
+- Fix Live TV on older Kodi versions.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -18,7 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 class VtmGoStream:
     """ VTM GO Stream API """
 
-    _API_KEY = 'r9EOnHOp1pPL5L4FuGzBPSIHwrQnPu5TBfW16y75'
+    _V5_API_KEY = '3vjmWnsxF7SUTeNCBZlnUQ4Z7GQV8f6miQ514l10'
+    _V6_API_KEY = 'r9EOnHOp1pPL5L4FuGzBPSIHwrQnPu5TBfW16y75'
 
     def __init__(self, tokens=None):
         """ Initialise object """
@@ -159,21 +160,34 @@ class VtmGoStream:
         """
         url = 'https://videoplayer-service.dpgmedia.net/config/%s/%s' % (strtype, stream_id)
         _LOGGER.debug('Getting video info from %s', url)
-        response = util.http_post(url,
-                                  params={
-                                      'startPosition': '0.0',
-                                      'autoPlay': 'true',
-                                  },
-                                  data={
-                                      'deviceType': 'android-tv',
-                                      'zone': 'vtmgo',
-                                  },
-                                  headers={
-                                      'Accept': 'application/json',
-                                      'x-api-key': self._API_KEY,
-                                      'Popcorn-SDK-Version': '6',
-                                      'Authorization': 'Bearer ' + player_token,
-                                  })
+        # Live channels: Fallback to old Popcorn SDK 5 for Kodi 19 and lower, because new livestream format is not supported
+        if kodiutils.kodi_version_major() <= 19 and strtype == 'channels':
+            response = util.http_get(url,
+                                     params={
+                                         'startPosition': '0.0',
+                                         'autoPlay': 'true',
+                                     },
+                                     headers={
+                                         'Accept': 'application/json',
+                                         'x-api-key': self._V5_API_KEY,
+                                         'Popcorn-SDK-Version': '5',
+                                     })
+        else:
+            response = util.http_post(url,
+                                      params={
+                                          'startPosition': '0.0',
+                                          'autoPlay': 'true',
+                                      },
+                                      data={
+                                          'deviceType': 'android-tv',
+                                          'zone': 'vtmgo',
+                                      },
+                                      headers={
+                                          'Accept': 'application/json',
+                                          'x-api-key': self._V6_API_KEY,
+                                          'Popcorn-SDK-Version': '6',
+                                          'Authorization': 'Bearer ' + player_token,
+                                      })
 
         info = json.loads(response.text)
         return info


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.4.1
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.4.1 (2023-02-09)
- Fix Live TV on older Kodi versions.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
