### PR TITLE
[plugin.video.tvvlaanderen@leia] 1.0.6

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.0.6](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.6) (2023-02-09)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.5...v1.0.6)
+
+**Implemented enhancements:**
+
+- Add support for playing from the VOD Catalog [\#52](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/52) ([michaelarnauts](https://github.com/michaelarnauts))
+- Add support for Canal Digitaal \(NL\) [\#50](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/50) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.0.5](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.5) (2022-01-22)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.4...v1.0.5)

--- a/plugin.video.tvvlaanderen/README.md
+++ b/plugin.video.tvvlaanderen/README.md
@@ -18,6 +18,7 @@ De volgende features worden ondersteund:
 * Live TV
 * Restart TV, bekijk het huidige programma vanaf het begin (niet voor alle zenders)
 * Replay TV, bekijk een programma tot 7 dagen terug (niet voor alle zenders)
+* Catalog, bekijk films en series als die beschikbaar zijn in je abonnement
 * Doorzoeken van alle programma's
 * Integratie met [IPTV Manager](https://github.com/add-ons/service.iptv.manager)
 

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.5" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.6" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="2.26.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,10 +22,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.5 (2022-01-22)
-- Fix incorrect time in EPG view.
-- Fix hiding of adult channels in EPG view.
-- Add translations.</news>
+        <news>v1.0.6 (2023-02-09)
+- Add support for VOD.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.de_de/strings.po
@@ -1,12 +1,13 @@
+#
 msgid ""
 msgstr ""
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-### MENUS
+# MENUS
 msgctxt "#30007"
 msgid "Channels"
 msgstr "Kanäle"
@@ -23,8 +24,23 @@ msgctxt "#30010"
 msgid "Search through the catalogue"
 msgstr "Durchsuche Katalog"
 
+msgctxt "#30011"
+msgid "Catalog"
+msgstr ""
 
-### SUBMENUS
+msgctxt "#30012"
+msgid "Browse the Video on Demand catalog"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Show catalogs"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Browse by catalogs"
+msgstr ""
+
+# SUBMENUS
 msgctxt "#30051"
 msgid "Watch live [B]{channel}[/B]"
 msgstr "Schaue live [B]{channel}[/B]"
@@ -49,8 +65,7 @@ msgctxt "#30056"
 msgid "Browse the replay catalog for [B]{channel}[/B]"
 msgstr "Zeige Replay Katalog für [B]{channel}[/B]"
 
-
-### CODE
+# CODE
 msgctxt "#30203"
 msgid "Your credentials are not valid!"
 msgstr "Die Login-Daten sind nicht korrekt!"
@@ -84,15 +99,22 @@ msgid "[B]less then 1 hour[/B] remaining"
 msgstr "[B]weniger als 1 Stunde[/B] verfügbar"
 
 msgctxt "#30213"
-msgid "[B]Now:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Jetzt:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Now:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Jetzt:[/B] {start} - {end}\n"
+"» {title}"
 
 msgctxt "#30214"
-msgid "[B]Next:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Danach:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Next:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Danach:[/B] {start} - {end}\n"
+"» {title}"
 
-
-### Dates
+# Dates
 msgctxt "#30301"
 msgid "Yesterday"
 msgstr "Gestern"
@@ -105,8 +127,7 @@ msgctxt "#30303"
 msgid "Tomorrow"
 msgstr "Morgen"
 
-
-### MESSAGES
+# MESSAGES
 msgctxt "#30701"
 msgid "To watch a video, you need to enter your credentials. Do you want to enter them now?"
 msgstr "Um dieses Service zu nutzen, musst du deine Login-Daten eingeben. Möchtest du das jetzt tun?"
@@ -119,8 +140,11 @@ msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
 msgstr "Das video ist gerade nicht verfügbar und kann nicht abgespielt werden."
 
+msgctxt "#30713"
+msgid "The video is not available in you subscription."
+msgstr ""
 
-### SETTINGS
+# SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
 msgstr "Login-Daten"

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.en_gb/strings.po
@@ -22,6 +22,22 @@ msgctxt "#30010"
 msgid "Search through the catalogue"
 msgstr ""
 
+msgctxt "#30011"
+msgid "Catalog"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Browse the Video on Demand catalog"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Show catalogs"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Browse by catalogs"
+msgstr ""
+
 
 ### SUBMENUS
 msgctxt "#30051"
@@ -116,6 +132,10 @@ msgstr ""
 
 msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
+msgstr ""
+
+msgctxt "#30713"
+msgid "The video is not available in you subscription."
 msgstr ""
 
 

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.nl_nl/strings.po
@@ -1,12 +1,13 @@
+#
 msgid ""
 msgstr ""
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-### MENUS
+# MENUS
 msgctxt "#30007"
 msgid "Channels"
 msgstr "Kanalen"
@@ -23,8 +24,23 @@ msgctxt "#30010"
 msgid "Search through the catalogue"
 msgstr "Doorzoek de catalogus"
 
+msgctxt "#30011"
+msgid "Catalog"
+msgstr "Catalogus"
 
-### SUBMENUS
+msgctxt "#30012"
+msgid "Browse the Video on Demand catalog"
+msgstr "Blader door de Video on Demand catalogus"
+
+msgctxt "#30013"
+msgid "Show catalogs"
+msgstr "Toon catalogi"
+
+msgctxt "#30014"
+msgid "Browse by catalogs"
+msgstr "Blader door de catalogi"
+
+# SUBMENUS
 msgctxt "#30051"
 msgid "Watch live [B]{channel}[/B]"
 msgstr "Kijk live [B]{channel}[/B]"
@@ -49,8 +65,7 @@ msgctxt "#30056"
 msgid "Browse the replay catalog for [B]{channel}[/B]"
 msgstr "Doorblader de replay catalogus voor [B]{channel}[/B]"
 
-
-### CODE
+# CODE
 msgctxt "#30203"
 msgid "Your credentials are not valid!"
 msgstr "De inloggegevens zijn onjuist!"
@@ -84,15 +99,22 @@ msgid "[B]less then 1 hour[/B] remaining"
 msgstr "beschikbaar voor [B]minder dan 1 uur[/B]"
 
 msgctxt "#30213"
-msgid "[B]Now:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Nu:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Now:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Nu:[/B] {start} - {end}\n"
+"» {title}"
 
 msgctxt "#30214"
-msgid "[B]Next:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Straks:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Next:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Straks:[/B] {start} - {end}\n"
+"» {title}"
 
-
-### Dates
+# Dates
 msgctxt "#30301"
 msgid "Yesterday"
 msgstr "Gisteren"
@@ -105,8 +127,7 @@ msgctxt "#30303"
 msgid "Tomorrow"
 msgstr "Morgen"
 
-
-### MESSAGES
+# MESSAGES
 msgctxt "#30701"
 msgid "To watch a video, you need to enter your credentials. Do you want to enter them now?"
 msgstr "Om een video te bekijken moet je je inloggegevens ingeven. Wil je dit nu doen?"
@@ -119,8 +140,11 @@ msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
 msgstr "Deze video is niet beschikbaar en kan nu niet worden afgespeeld."
 
+msgctxt "#30713"
+msgid "The video is not available in you subscription."
+msgstr "Deze video is niet beschikbaar in je abonnement."
 
-### SETTINGS
+# SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
 msgstr "Inloggegevens"

--- a/plugin.video.tvvlaanderen/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.tvvlaanderen/resources/language/resource.language.ro_ro/strings.po
@@ -1,11 +1,12 @@
+#
 msgid ""
 msgstr ""
+"Language: ro\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-### MENUS
+# MENUS
 msgctxt "#30007"
 msgid "Channels"
 msgstr "Canale"
@@ -22,8 +23,23 @@ msgctxt "#30010"
 msgid "Search through the catalogue"
 msgstr "Căutare în bibliotecă"
 
+msgctxt "#30011"
+msgid "Catalog"
+msgstr ""
 
-### SUBMENUS
+msgctxt "#30012"
+msgid "Browse the Video on Demand catalog"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Show catalogs"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Browse by catalogs"
+msgstr ""
+
+# SUBMENUS
 msgctxt "#30051"
 msgid "Watch live [B]{channel}[/B]"
 msgstr "Urmărește în direct [B]{channel}[/B]"
@@ -48,8 +64,7 @@ msgctxt "#30056"
 msgid "Browse the replay catalog for [B]{channel}[/B]"
 msgstr "Răsfoiește biblioteca replay pentru [B]{channel}[/B]"
 
-
-### CODE
+# CODE
 msgctxt "#30203"
 msgid "Your credentials are not valid!"
 msgstr "Datele dvs de logare nu sunt corecte!"
@@ -83,15 +98,22 @@ msgid "[B]less then 1 hour[/B] remaining"
 msgstr "[B]mai puțin de 1 oră[/B] rămasă"
 
 msgctxt "#30213"
-msgid "[B]Now:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Acum:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Now:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Acum:[/B] {start} - {end}\n"
+"» {title}"
 
 msgctxt "#30214"
-msgid "[B]Next:[/B] {start} - {end}\n» {title}"
-msgstr "[B]Urmează:[/B] {start} - {end}\n» {title}"
+msgid ""
+"[B]Next:[/B] {start} - {end}\n"
+"» {title}"
+msgstr ""
+"[B]Urmează:[/B] {start} - {end}\n"
+"» {title}"
 
-
-### Dates
+# Dates
 msgctxt "#30301"
 msgid "Yesterday"
 msgstr "Ieri"
@@ -104,8 +126,7 @@ msgctxt "#30303"
 msgid "Tomorrow"
 msgstr "Mâine"
 
-
-### MESSAGES
+# MESSAGES
 msgctxt "#30701"
 msgid "To watch a video, you need to enter your credentials. Do you want to enter them now?"
 msgstr "Pentru a viziona conținutul, trebuie să vă autentificați. Vă autentificați acum?"
@@ -118,8 +139,11 @@ msgctxt "#30712"
 msgid "The video is unavailable and can't be played right now."
 msgstr "Video-ul este indisponibil și nu poate fi redat momentan."
 
+msgctxt "#30713"
+msgid "The video is not available in you subscription."
+msgstr ""
 
-### SETTINGS
+# SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
 msgstr "Autentificare"

--- a/plugin.video.tvvlaanderen/resources/lib/addon.py
+++ b/plugin.video.tvvlaanderen/resources/lib/addon.py
@@ -99,9 +99,44 @@ def show_channel_replay_series(series_id):
     Channels().show_channel_replay_series(series_id)
 
 
+@routing.route('/catalog')
+def show_catalog():
+    """ Shows the Catalog menu """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_overview()
+
+
+@routing.route('/catalog/catalogs')
+def show_catalog_catalogs():
+    """ Shows the Catalog menu """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_overview(True)
+
+
+@routing.route('/catalog/catalog/<catalog>')
+def show_catalog_by_catalog(catalog):
+    """ Show the Catalog menu of a specific catalog """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_by_catalog(catalog)
+
+
+@routing.route('/catalog/query/<query>')
+def show_catalog_by_query(query):
+    """ Show the Catalog content by running a query """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_by_query(query)
+
+
+@routing.route('/catalog/series/<asset>')
+def show_catalog_series(asset):
+    """ Show the seasons of a series """
+    from resources.lib.modules.catalog import Catalog
+    Catalog().show_series(asset)
+
+
 @routing.route('/play/asset/<asset_id>')
 def play_asset(asset_id):
-    """ PLay a Program """
+    """ Play a Program """
     from resources.lib.modules.player import Player
     Player().play_asset(asset_id)
 

--- a/plugin.video.tvvlaanderen/resources/lib/modules/catalog.py
+++ b/plugin.video.tvvlaanderen/resources/lib/modules/catalog.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+""" Catalog module """
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+
+from resources.lib import kodiutils
+from resources.lib.kodiutils import TitleItem
+from resources.lib.modules.menu import Menu
+from resources.lib.solocoo import VodEpisode, VodMovie, VodSeries
+from resources.lib.solocoo.asset import AssetApi
+from resources.lib.solocoo.auth import AuthApi
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Catalog:
+    """ Menu code related to the Catalog. """
+
+    def __init__(self):
+        """ Initialise object. """
+        auth = AuthApi(username=kodiutils.get_setting('username'),
+                       password=kodiutils.get_setting('password'),
+                       tenant=kodiutils.get_setting('tenant'),
+                       token_path=kodiutils.get_tokens_path())
+        self._api = AssetApi(auth)
+
+    def show_overview(self, catalogs=False):
+        """ Shows an overview. """
+        listing = []
+
+        if catalogs:
+            # Show all catalogs
+            catalogs = self._api.get_collection_catalogs()
+            for catalog in catalogs:
+                title_item = TitleItem(
+                    title=catalog.title,
+                    path=kodiutils.url_for('show_catalog_by_catalog', catalog=catalog.uid),
+                    art_dict={
+                        'icon': catalog.cover,
+                        'thumb': catalog.cover,
+                    },
+                )
+                listing.append(title_item)
+
+        else:
+            # Show catalogs
+            title_item = TitleItem(
+                title=kodiutils.localize(30013),  # Show catalogs
+                path=kodiutils.url_for('show_catalog_catalogs'),
+                art_dict=dict(
+                    icon='DefaultAddonPVRClient.png',
+                ),
+                info_dict=dict(
+                    plot=kodiutils.localize(30014),
+                )
+            )
+            listing.append(title_item)
+
+            # Show genres
+            genres = self._api.get_collection_genres()
+            for genre in genres:
+                title_item = TitleItem(
+                    title=genre.title,
+                    path=kodiutils.url_for('show_catalog_by_query', query=genre.query),
+                )
+
+                listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30011, content='files')
+
+    def show_by_catalog(self, catalog):
+        """ Show an overview by catalog. """
+        listing = []
+
+        genres = self._api.get_collection_genres(catalog)
+        for genre in genres:
+            title_item = TitleItem(
+                title=genre.title,
+                path=kodiutils.url_for('show_catalog_by_query', query=genre.query),
+            )
+
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30011, content='files')
+
+    def show_by_query(self, query):
+        """ Show an overview with a query. """
+        listing = []
+
+        assets = self._api.query_assets(query)
+        for asset in assets:
+            if isinstance(asset, VodMovie):
+                listing.append(Menu.generate_titleitem_vod_movie(asset))
+
+            if isinstance(asset, VodSeries):
+                listing.append(Menu.generate_titleitem_vod_series(asset))
+
+            if isinstance(asset, VodEpisode):
+                listing.append(Menu.generate_titleitem_vod_episode(asset))
+
+        kodiutils.show_listing(listing, 30011, content='files')
+
+    def show_series(self, asset):
+        """ Show an overview of the seasons of a series. """
+        listing = []
+
+        seasons = self._api.get_collection_seasons(asset)
+        for season in seasons:
+            listing.append(Menu.generate_titleitem_vod_season(season))
+
+        kodiutils.show_listing(listing, 30011, content='seasons')

--- a/plugin.video.tvvlaanderen/resources/lib/modules/iptvmanager.py
+++ b/plugin.video.tvvlaanderen/resources/lib/modules/iptvmanager.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 from resources.lib import kodiutils
 from resources.lib.modules import SETTINGS_ADULT_HIDE
 from resources.lib.solocoo import Credit
+from resources.lib.solocoo.asset import AssetApi
 from resources.lib.solocoo.auth import AuthApi
-from resources.lib.solocoo.channel import ChannelApi
 from resources.lib.solocoo.epg import EpgApi
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class IPTVManager:
     @via_socket
     def send_channels(self):
         """ Return JSON-STREAMS formatted information to IPTV Manager. """
-        channel_api = ChannelApi(self._auth)
+        channel_api = AssetApi(self._auth)
 
         streams = []
 
@@ -66,7 +66,7 @@ class IPTVManager:
     @via_socket
     def send_epg(self):
         """ Return JSON-EPG formatted information to IPTV Manager. """
-        channel_api = ChannelApi(self._auth)
+        channel_api = AssetApi(self._auth)
         epg_api = EpgApi(self._auth)
 
         epg = defaultdict(list)

--- a/plugin.video.tvvlaanderen/resources/lib/modules/search.py
+++ b/plugin.video.tvvlaanderen/resources/lib/modules/search.py
@@ -7,7 +7,7 @@ import logging
 
 from resources.lib import kodiutils
 from resources.lib.modules.menu import Menu
-from resources.lib.solocoo import Channel, Program
+from resources.lib.solocoo import Channel, Epg, EpgSeries
 from resources.lib.solocoo.auth import AuthApi
 from resources.lib.solocoo.search import SearchApi
 
@@ -43,13 +43,13 @@ class Search:
         # Generate the results
         listing = []
         for item in items:
-            if isinstance(item, Program):
-                if item.series_id:
-                    listing.append(Menu.generate_titleitem_series(item))
-                else:
-                    listing.append(Menu.generate_titleitem_program(item))
+            if isinstance(item, Epg):
+                listing.append(Menu.generate_titleitem_epg(item))
 
-            if isinstance(item, Channel) and item.available is not False:
+            elif isinstance(item, EpgSeries):
+                listing.append(Menu.generate_titleitem_epg_series(item))
+
+            elif isinstance(item, Channel) and item.available is not False:
                 listing.append(Menu.generate_titleitem_channel(item))
 
         # Sort like we get our results back.

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/__init__.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/__init__.py
@@ -10,8 +10,8 @@ class Channel:
 
     def __init__(self, uid, station_id, title, icon, preview, number, epg_now=None, epg_next=None, replay=False, radio=False, available=None, pin=None):
         """
-        :param Program epg_now:     The currently playing program on this channel.
-        :param Program epg_next:    The next playing program on this channel.
+        :param Epg epg_now:     The currently playing program on this channel.
+        :param Epg epg_next:    The next playing program on this channel.
         """
         self.uid = uid
         self.station_id = station_id
@@ -49,7 +49,7 @@ class StreamInfo:
         return "%r" % self.__dict__
 
 
-class Program:
+class Epg:
     """ Program object """
 
     def __init__(self, uid, title, description, cover, preview, start, end, duration, channel_id, formats, genres, replay,
@@ -80,9 +80,29 @@ class Program:
         self.season = season
         self.episode = episode
 
-        self.credit = credit
+        self.credit = credit or []
 
         self.available = available
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class EpgSeries:
+    """ EpgSeries object """
+
+    def __init__(self, uid, title, description, cover, preview, channel_id, formats, genres, age):
+        self.uid = uid
+        self.title = title
+        self.description = description
+        self.cover = cover
+        self.preview = preview
+
+        self.age = age
+        self.channel_id = channel_id
+
+        self.formats = formats
+        self.genres = genres
 
     def __repr__(self):
         return "%r" % self.__dict__
@@ -102,3 +122,135 @@ class Credit:
         self.role = role
         self.person = person
         self.character = character
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodCatalog:
+    """ Catalog object for VOD """
+
+    def __init__(self, uid, title, cover):
+        self.uid = uid
+        self.title = title
+        self.cover = cover
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodGenre:
+    """ Genre object for VOD """
+
+    GENRE_MAP = {
+        "sg.ui.genre.actionadventure": "Action & Adventure",
+        "sg.ui.genre.carsmotors": "Cars & Motors",
+        "sg.ui.genre.factualentertainment": "Factual Entertainment",
+        "sg.ui.genre.naturalhistory": "Natural History",
+    }
+
+    def __init__(self, uid, title, query):
+        self.uid = uid
+        self.title = title
+        self.query = query
+
+    @classmethod
+    def map_label(cls, label):
+        """ Map the label to a Genre """
+        genre = cls.GENRE_MAP.get(label)
+        if genre is not None:
+            return genre
+
+        # Fallback to something based on the id
+        return label.split('.')[-1].title()
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodMovie:
+    """ Movie object for VOD """
+
+    def __init__(self, uid, title, year, duration, age, cover, preview, credit=None, trailer=None, available=None):
+        """
+
+        :type credit: list[Credit]
+        """
+        self.uid = uid
+        self.title = title
+        self.year = year
+        self.duration = duration
+        self.age = age
+        self.cover = cover
+        self.preview = preview
+
+        self.credit = credit or []
+        self.trailer = trailer
+        self.available = available
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodSeries:
+    """ Series object for VOD """
+
+    def __init__(self, uid, title, year, age, cover, preview, credit=None, available=None):
+        """
+
+        :type credit: list[Credit]
+        """
+        self.uid = uid
+        self.title = title
+        self.year = year
+        self.age = age
+        self.cover = cover
+        self.preview = preview
+
+        self.credit = credit or []
+        self.available = available
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodSeason:
+    """ Season object for VOD """
+
+    def __init__(self, uid, title, query):
+        """
+
+        :type credit: list[Credit]
+        """
+        self.uid = uid
+        self.title = title
+        self.query = query
+
+    def __repr__(self):
+        return "%r" % self.__dict__
+
+
+class VodEpisode:
+    """ Episode object for VOD """
+
+    def __init__(self, uid, title, year, duration, age, cover, preview, series_id, season, episode, credit=None):
+        """
+
+        :type credit: list[Credit]
+        """
+        self.uid = uid
+        self.title = title
+        self.year = year
+        self.duration = duration
+        self.age = age
+        self.cover = cover
+        self.preview = preview
+
+        self.series_id = series_id
+        self.season = season
+        self.episode = episode
+
+        self.credit = credit or []
+
+    def __repr__(self):
+        return "%r" % self.__dict__

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/auth.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/auth.py
@@ -143,7 +143,7 @@ class AuthApi:
             return self._account
 
         if not self._account.challenge_id or not self._account.challenge_secret:
-            # We don't have an challenge_id or challenge_secret, so we need to request one
+            # We don't have a challenge_id or challenge_secret, so we need to request one
             # This challenge can be kept for a longer time
             self._account.challenge_id, self._account.challenge_secret = self._do_challenge(
                 self._account.device_name,
@@ -342,10 +342,12 @@ class AuthApi:
                                    deviceModel=device_name,
                                    deviceType="PC",
                                    deviceSerial=device_serial,
-                                   osVersion="Linux undefined",
-                                   appVersion="84.0",
-                                   memberId="0",
+                                   osVersion="Linux",
+                                   appVersion="97.0.4692.71",
                                    brand=self._tenant.get('app'),
+                                   memberId='0',
+                                   featureLevel='1',
+                                   environment='p',
                                ))
         return json.loads(reply.text).get('token')
 

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/epg.py
@@ -11,7 +11,7 @@ import dateutil.parser
 import dateutil.tz
 
 from resources.lib.solocoo import SOLOCOO_API, util
-from resources.lib.solocoo.util import parse_program, parse_program_capi
+from resources.lib.solocoo.util import parse_epg, parse_epg_capi
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class EpgApi:
         :param str|datetime date_to:    The date of the guide we want to fetch.
 
         :returns:                       A parsed dict with EPG data.
-        :rtype: dict[str, list[resources.lib.solocoo.util.Program]]
+        :rtype: dict[str, list[resources.lib.solocoo.Epg]]
         """
         # Allow to specify one channel, and we map it to a list
         if not isinstance(channels, list):
@@ -60,7 +60,7 @@ class EpgApi:
         if date_to is not None:
             date_to = self._parse_date(date_to)
         else:
-            date_to = (date_from + timedelta(days=1))
+            date_to = date_from + timedelta(days=1)
 
         programs = {}
 
@@ -77,8 +77,8 @@ class EpgApi:
                                   token_bearer=self._tokens.jwt_token)
             data = json.loads(reply.text)
 
-            # Parse to a dict (channel: list[Program])
-            programs.update({channel: [parse_program(program, offers) for program in programs]
+            # Parse to a dict (channel: list[Epg])
+            programs.update({channel: [parse_epg(program, offers) for program in programs]
                              for channel, programs in data.get('epg', []).items()})
 
         return programs
@@ -91,7 +91,7 @@ class EpgApi:
         :param str|datetime date_to:    The date of the guide we want to fetch.
 
         :returns:                       A parsed dict with EPG data.
-        :rtype: dict[str, list[resources.lib.solocoo.util.Program]]
+        :rtype: dict[str, list[resources.lib.solocoo.Epg]]
         """
         # Allow to specify one channel, and we map it to a list
         if not isinstance(channels, list):
@@ -110,7 +110,7 @@ class EpgApi:
         if date_to is not None:
             date_to = self._parse_date(date_to)
         else:
-            date_to = (date_from + timedelta(days=1))
+            date_to = date_from + timedelta(days=1)
         date_to_posix = str(int((date_to - epoch).total_seconds())) + '000'
 
         programs = {}
@@ -140,8 +140,8 @@ class EpgApi:
 
             data = json.loads(reply.text)
 
-            # Parse to a dict (channel: list[Program])
-            programs.update({channel: [parse_program_capi(program, self._tenant) for program in programs]
+            # Parse to a dict (channel: list[Epg])
+            programs.update({channel: [parse_epg_capi(program, self._tenant) for program in programs]
                              for channel, programs in data[1].items()})
 
         return programs

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/search.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/search.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 from resources.lib.solocoo import SOLOCOO_API, util
-from resources.lib.solocoo.channel import ASSET_TYPE_CHANNEL
+from resources.lib.solocoo.asset import ASSET_TYPE_CHANNEL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class SearchApi:
         :param str query:               The query to search for.
 
         :returns:                        A list of results.
-        :rtype: list[resources.lib.solocoo.util.Channel|resources.lib.solocoo.util.Program]
+        :rtype: list[resources.lib.solocoo.Channel|resources.lib.solocoo.Epg]
         """
         if not query:
             return []
@@ -52,7 +52,7 @@ class SearchApi:
 
         # Parse replay
         replay = next((c for c in data.get('collection') if c.get('label') == 'sg.ui.search.replay'), {})
-        results.extend([util.parse_program(asset, offers)
+        results.extend([util.parse_epg(asset, offers)
                         for asset in replay.get('assets', [])])
 
         return results


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.6
  - Kodi/repository version: leia

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen

Deze add-on geeft toegang tot de live TV kanalen en de video-on-demand content dat beschikbaar is via je TV Vlaanderen abonnement.

### What's new

v1.0.6 (2023-02-09)
- Add support for VOD.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
