### PR TITLE
[plugin.video.srfplaytv@matrix] 2.2.3

### DIFF
--- a/plugin.video.srfplaytv/README.md
+++ b/plugin.video.srfplaytv/README.md
@@ -29,6 +29,11 @@ Get the [SRF Play TV media library](https://www.srf.ch/play/tv) on your TV (or a
 
    Keep in mind that you won't get any automatic updates if you choose this method.
 
+## Reporting issues
+
+Please use [this](https://github.com/goggle/script.module.srgssr/issues) issue tracker to report issues.
+
+
 ## Support this plugin
 How you can help improving this plugin:
  - For bugs and feature requests use the [issue tracker](https://github.com/goggle/plugin.video.srfplaytv/issues) on the github page.

--- a/plugin.video.srfplaytv/addon.xml
+++ b/plugin.video.srfplaytv/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.srfplaytv" name="SRF Play TV" version="2.2.2" provider-name="Alexander Seiler">
+<addon id="plugin.video.srfplaytv" name="SRF Play TV" version="2.2.3" provider-name="Alexander Seiler">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
-    <import addon="script.module.srgssr" version="2.2.2"/>
+    <import addon="script.module.srgssr" version="2.2.3"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>
@@ -26,7 +26,10 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=331129</forum>
     <website>https://www.srf.ch/play/tv</website>
     <source>https://github.com/goggle/plugin.video.srfplaytv</source>
-    <news>v2.2.2 (2023-01-29)
+    <news>v2.2.3 (2023-03-09)
+  - Display date and time for scheduled live streams.
+
+v2.2.2 (2023-01-29)
   - Fix homepage and topics menu
 
 v2.2.1 (2022-10-25)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SRF Play TV
  - Add-on ID: plugin.video.srfplaytv
  - Version number: 2.2.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/goggle/plugin.video.srfplaytv
  
SRF Play TV allows you to watch the content from the video library of Swiss Radio and Television (SRF).

### Description of changes:

v2.2.3 (2023-03-09)
  - Display date and time for scheduled live streams.

v2.2.2 (2023-01-29)
  - Fix homepage and topics menu

v2.2.1 (2022-10-25)
  - Fix shows by date

v2.2.0 (2022-06-24)
  - Support WIDEVINE encrypted DASH streams

v2.1.0 (2022-06-01)
  - Add support for content presented on homepage.
  - Add support for topics.
  - Add support for playback of livestreams.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
