### PR TITLE
[plugin.video.swiplaytv@matrix] 2.2.3

### DIFF
--- a/plugin.video.swiplaytv/README.md
+++ b/plugin.video.swiplaytv/README.md
@@ -25,7 +25,12 @@ Get the [Swissinfo video library](https://play.swissinfo.ch/play/tv/) on your TV
    - [script.module.srgssr](https://github.com/goggle/script.module.srgssr)
    - [script.module.youtube_channels](https://github.com/goggle/script.module.youtube_channels)
 
-   Keep in mind that you won't get any automatic updates if you choose this method
+   Keep in mind that you won't get any automatic updates if you choose this method.
+
+## Reporting issues
+
+Please use [this](https://github.com/goggle/script.module.srgssr/issues) issue tracker to report issues.
+
 
 ## Support this plugin
 How you can help improving this plugin:

--- a/plugin.video.swiplaytv/addon.xml
+++ b/plugin.video.swiplaytv/addon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.swiplaytv" name="SWI Play TV" version="2.2.2" provider-name="Alexander Seiler">
+<addon id="plugin.video.swiplaytv" name="SWI Play TV" version="2.2.3" provider-name="Alexander Seiler">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
-    <import addon="script.module.srgssr" version="2.2.2"/>
+    <import addon="script.module.srgssr" version="2.2.3"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>video</provides>
@@ -26,7 +26,10 @@
     <forum>https://github.com/goggle/plugin.video.swiplaytv/discussions</forum>
     <website>https://play.swissinfo.ch/play/tv/</website>
     <source>https://github.com/goggle/plugin.video.swiplaytv</source>
-    <news>v2.2.2 (2023-01-29)
+    <news>v2.2.3 (2023-03-09)
+  - Display date and time for scheduled live streams.
+
+v2.2.2 (2023-01-29)
   - Fix homepage and topics menu
 
 v2.2.0 (2022-06-24)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SWI Play TV
  - Add-on ID: plugin.video.swiplaytv
  - Version number: 2.2.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/goggle/plugin.video.swiplaytv
  
Access the video library of Swissinfo, a multilingual news and information platform produces by the Swiss Broadcasting Coroporation (SRG SSR)

### Description of changes:

v2.2.3 (2023-03-09)
  - Display date and time for scheduled live streams.

v2.2.2 (2023-01-29)
  - Fix homepage and topics menu

v2.2.0 (2022-06-24)
  - Support WIDEVINE encrypted DASH streams.

v2.1.0 (2022-06-01)
  - Initial release
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
