### PR TITLE
[plugin.video.youtube@nexus] 7.0.1

### DIFF
--- a/plugin.video.youtube/addon.xml
+++ b/plugin.video.youtube/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.0" provider-name="anxdpanic, bromix">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.1" provider-name="anxdpanic, bromix">
     <requires>
         <import addon="xbmc.python" version="3.0.1"/>
         <import addon="script.module.requests" version="2.12.4"/>
@@ -14,9 +14,7 @@
     <extension point="xbmc.python.module" library="resources/lib/"/>
     <extension point="xbmc.addon.metadata">
         <news>
-[rem] removed support for versions of Kodi pre-Nexus v20
-[rem] removed support for python 2
-[rem] removed dependency on six
+[fix] video duration not showing in lists
 [upd] Translations updated from Kodi Weblate
         </news>
         <assets>

--- a/plugin.video.youtube/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/plugin.video.youtube/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -87,7 +87,6 @@ def to_play_item(context, play_item):
         # This should work for all versions of XBMC/KODI.
         if 'duration' in _info_labels:
             duration = _info_labels['duration']
-            del _info_labels['duration']
             info_tag.add_stream_info('video', {'duration': duration})
 
         info_tag.set_info(_info_labels)
@@ -139,7 +138,6 @@ def to_video_item(context, video_item):
     # This should work for all versions of XBMC/KODI.
     if 'duration' in _info_labels:
         duration = _info_labels['duration']
-        del _info_labels['duration']
         info_tag.add_stream_info('video', {'duration': duration})
 
     info_tag.set_info(_info_labels)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: YouTube
  - Add-on ID: plugin.video.youtube
  - Version number: 7.0.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/anxdpanic/plugin.video.youtube
  
YouTube is one of the biggest video-sharing websites of the world.

### Description of changes:


[fix] video duration not showing in lists
[upd] Translations updated from Kodi Weblate
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
