### PR TITLE
[plugin.video.arteplussept@matrix] 1.1.9

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,11 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.1.9 (2023-4-18)
+- Improve security and performance by caching token to limit authentication requests
+- Fallback on clip, when stream is not available anymore. Same feature as on Arte mobile. For favorite content.
+- Clean-up and lint code
+- Add CI with Pylint and Kodi addon submitter
+
 v1.1.8 (2023-2-17)
 - Improve synchronization of playback progress with Arte TV
     - Synchronize progress every minute

--- a/plugin.video.arteplussept/addon.py
+++ b/plugin.video.arteplussept/addon.py
@@ -1,4 +1,4 @@
-
+"""Main module for Kodi add-on plugin.video.arteplussept"""
 # coding=utf-8
 # -*- coding: utf-8 -*-
 #
@@ -22,7 +22,9 @@
 #
 # https://xbmcswift2.readthedocs.io/en/latest/api.html
 # https://github.com/XBMC-Addons/script.module.xbmcswift2
+# pylint: disable=import-error
 from xbmcswift2 import Plugin
+# pylint: disable=import-error
 from xbmcswift2 import xbmc
 from resources.lib import view
 from resources.lib.player import Player
@@ -32,109 +34,77 @@ from resources.lib.settings import Settings
 # plugin stuff
 plugin = Plugin()
 
-
-class PluginInformation:
-    name = plugin.name
-    version = plugin.addon.getAddonInfo('version')
-
-
 settings = Settings(plugin)
 
 
 @plugin.route('/', name='index')
 def index():
-    # return view.build_categories(plugin, plugin.get_storage('cached_categories', TTL=60), settings)
-    return view.build_home_page(plugin, plugin.get_storage('cached_categories', TTL=60), settings)
+    """Display home menu"""
+    return view.build_home_page(plugin.get_storage('cached_categories', TTL=60), settings)
 
 
 @plugin.route('/api_category/<category_code>', name='api_category')
 def api_category(category_code):
+    """Display the menu for a category that needs an api call"""
     return view.build_api_category(category_code, settings)
 
 
 @plugin.route('/cached_category/<category_code>', name='cached_category')
 def cached_category(category_code):
+    """Display the menu for a category that is stored
+    in cache from previous api call like home page"""
     return view.get_cached_category(category_code, plugin.get_storage('cached_categories', TTL=60))
-
-
-# @plugin.route('/creative', name='creative')
-# def creative():
-#     return []
-
-
-@plugin.route('/magazines', name='magazines')
-def magazines():
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_magazines(settings))
 
 
 @plugin.route('/favorites', name='favorites')
 def favorites():
+    """Display the menu for user favorites"""
     plugin.set_content('tvshows')
     return plugin.finish(view.build_favorites(plugin, settings))
 
 @plugin.route('/add_favorite/<program_id>/<label>', name='add_favorite')
 def add_favorite(program_id, label):
+    """Add content program_id to user favorites.
+    Notify about completion status with label,
+    useful when several operations are requested in parallel."""
     view.add_favorite(plugin, settings.username, settings.password, program_id, label)
 
 @plugin.route('/remove_favorite/<program_id>/<label>', name='remove_favorite')
 def remove_favorite(program_id, label):
+    """Remove content program_id from user favorites
+    Notify about completion status with label,
+    useful when several operations are requested in parallel."""
     view.remove_favorite(plugin, settings.username, settings.password, program_id, label)
 
 
 @plugin.route('/last_viewed', name='last_viewed')
 def last_viewed():
+    """Display the menu of user history"""
     plugin.set_content('tvshows')
     return plugin.finish(view.build_last_viewed(plugin, settings))
 
 @plugin.route('/purge_last_viewed', name='purge_last_viewed')
 def purge_last_viewed():
+    """Flush user history and notify about completion status"""
     view.purge_last_viewed(plugin, settings.username, settings.password)
-
-
-@plugin.route('/newest', name='newest')
-def newest():
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_newest(settings))
-
-
-@plugin.route('/most_viewed', name='most_viewed')
-def most_viewed():
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_most_viewed(settings))
-
-
-@plugin.route('/last_chance', name='last_chance')
-def last_chance():
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_last_chance(settings))
-
-
-@plugin.route('/sub_category/<sub_category_code>', name='sub_category_by_code')
-def sub_category_by_code(sub_category_code):
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_sub_category_by_code(sub_category_code, settings))
-
-
-@plugin.route('/sub_category/<category_code>/<sub_category_title>', name='sub_category_by_title')
-def sub_category_by_title(category_code, sub_category_title):
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_sub_category_by_title(category_code, sub_category_title, settings))
 
 
 @plugin.route('/collection/<kind>/<program_id>', name='collection')
 def collection(kind, program_id):
+    """Display menu for collection of content"""
     plugin.set_content('tvshows')
     return plugin.finish(view.build_mixed_collection(kind, program_id, settings))
 
 
 @plugin.route('/streams/<program_id>', name='streams')
 def streams(program_id):
+    """Play a multi language content."""
     return plugin.finish(view.build_video_streams(program_id, settings))
 
-@plugin.route('/play_live/<streamUrl>', name='play_live')
-def play_live(streamUrl):
-    return plugin.set_resolved_url({'path': streamUrl})
+@plugin.route('/play_live/<stream_url>', name='play_live')
+def play_live(stream_url):
+    """Play live content."""
+    return plugin.set_resolved_url({'path': stream_url})
 
 # Cannot read video new arte tv program API. Blocked by FFMPEG issue #10149
 # @plugin.route('/play_artetv/<program_id>', name='play_artetv')
@@ -148,9 +118,13 @@ def play_live(streamUrl):
 @plugin.route('/play/<kind>/<program_id>', name='play')
 @plugin.route('/play/<kind>/<program_id>/<audio_slot>', name='play_specific')
 def play(kind, program_id, audio_slot='1'):
+    """Play content identified with program_id.
+    kind is a value of TODO (e.g. TRAILER, COLLECTION, LINK, ...)
+    audio_slot is a numeric
+    """
     synched_player = Player(plugin, settings, program_id)
     item = view.build_stream_url(plugin, kind, program_id, int(audio_slot), settings)
-    r = plugin.set_resolved_url(item)
+    result = plugin.set_resolved_url(item)
     # wait 1s first to give a chance for playback to start
     # otherwise synched_player won't be able to listen
     xbmc.sleep(500)
@@ -165,16 +139,12 @@ def play(kind, program_id, audio_slot='1'):
         xbmc.sleep(1000)
     synched_player.synch_progress()
     del synched_player
-    return r
+    return result
 
-
-@plugin.route('/weekly', name='weekly')
-def weekly():
-    plugin.set_content('tvshows')
-    return plugin.finish(view.build_weekly(settings))
 
 @plugin.route('/search', name='search')
-def weekly():
+def search():
+    """Display the keyboard to search for content. Then, display the menu of search results"""
     plugin.set_content('tvshows')
     return plugin.finish(view.search(plugin, settings))
 

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.8" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.9" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -57,6 +57,10 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         <source>https://github.com/known-as-bmf/plugin.video.arteplussept</source>
         <news>
         Highlights since 1.1.2
+        - Improve security and performance by caching token to limit authentication requests
+        - Fallback on clip, when stream is not available anymore.
+        - Clean-up and lint code
+        - Add CI with Pylint and Kodi addon submitter
         - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
         - Move from HBB TV to Arte TV API.
         - Fixed playback progress / resume point retrieved from Arte TV
@@ -64,8 +68,6 @@ https://github.com/known-as-bmf/plugin.video.arteplussept
         - Manage favorites in Arte profile from context menu
         - Added Search in root menu
         - Added Live stream in root menu
-        - Added Polish translation
-        - Added My list and My history content from Arte TV profile
         - Added purge of my history
         </news>
         <assets>

--- a/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
@@ -38,33 +38,6 @@ msgctxt "#30055"
 msgid "Password"
 msgstr "Passwort"
 
-msgctxt "#30005"
-msgid "Most recent"
-msgstr "Neuste"
-
-msgctxt "#30006"
-msgid "Most viewed"
-msgstr "Am meisten gesehen"
-
-msgctxt "#30007"
-msgid "Last chance"
-msgstr "Letzte chance"
-
-msgctxt "#30008"
-msgid "Magazines A-Z"
-msgstr "Sendungen A-Z"
-
-msgctxt "#30009"
-msgid "This week"
-msgstr "Diese Woche"
-
-msgctxt "#30010"
-msgid "My list"
-msgstr "Meine Liste"
-
-msgctxt "#30011"
-msgid "My history"
-msgstr "Mein Videoverlauf"
 
 msgctxt "#30012"
 msgid "Search"

--- a/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
@@ -38,33 +38,6 @@ msgctxt "#30055"
 msgid "Password"
 msgstr ""
 
-msgctxt "#30005"
-msgid "Most recent"
-msgstr ""
-
-msgctxt "#30006"
-msgid "Most viewed"
-msgstr ""
-
-msgctxt "#30007"
-msgid "Last chance"
-msgstr ""
-
-msgctxt "#30008"
-msgid "Magazines A-Z"
-msgstr ""
-
-msgctxt "#30009"
-msgid "This week"
-msgstr ""
-
-msgctxt "#30010"
-msgid "My list"
-msgstr ""
-
-msgctxt "#30011"
-msgid "My history"
-msgstr ""
 
 msgctxt "#30012"
 msgid "Search"

--- a/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
@@ -38,33 +38,6 @@ msgctxt "#30055"
 msgid "Password"
 msgstr "Mot de passe"
 
-msgctxt "#30005"
-msgid "Most recent"
-msgstr "Les plus récentes"
-
-msgctxt "#30006"
-msgid "Most viewed"
-msgstr "Les plus vues"
-
-msgctxt "#30007"
-msgid "Last chance"
-msgstr "Dernière chance"
-
-msgctxt "#30008"
-msgid "Magazines A-Z"
-msgstr "Émissions A-Z"
-
-msgctxt "#30009"
-msgid "This week"
-msgstr "Cette semaine"
-
-msgctxt "#30010"
-msgid "My list"
-msgstr "Mes favoris"
-
-msgctxt "#30011"
-msgid "My history"
-msgstr "Mon historique"
 
 msgctxt "#30012"
 msgid "Search"

--- a/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
@@ -38,33 +38,6 @@ msgctxt "#30055"
 msgid "Password"
 msgstr "Password"
 
-msgctxt "#30005"
-msgid "Most recent"
-msgstr "I più recenti"
-
-msgctxt "#30006"
-msgid "Most viewed"
-msgstr "I più visti"
-
-msgctxt "#30007"
-msgid "Last chance"
-msgstr "Ultima opportunità!"
-
-msgctxt "#30008"
-msgid "Magazines A-Z"
-msgstr "Spettacoli A-Z"
-
-msgctxt "#30009"
-msgid "This week"
-msgstr "Questa settimana"
-
-msgctxt "#30010"
-msgid "My list"
-msgstr "La mia lista"
-
-msgctxt "#30011"
-msgid "My history"
-msgstr "Cronologia"
 
 msgctxt "#30012"
 msgid "Search"

--- a/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
@@ -38,33 +38,6 @@ msgctxt "#30055"
 msgid "Password"
 msgstr "Hasło"
 
-msgctxt "#30005"
-msgid "Most recent"
-msgstr "Najnowsze"
-
-msgctxt "#30006"
-msgid "Most viewed"
-msgstr "Najczęściej oglądane"
-
-msgctxt "#30007"
-msgid "Last chance"
-msgstr "Opuszczajace oferte"
-
-msgctxt "#30008"
-msgid "Magazines A-Z"
-msgstr "Reportaże"
-
-msgctxt "#30009"
-msgid "This week"
-msgstr "W tym tygodniu"
-
-msgctxt "#30010"
-msgid "My list"
-msgstr "Moja lista"
-
-msgctxt "#30011"
-msgid "My history"
-msgstr "Ostatnio ogladane"
 
 msgctxt "#30012"
 msgid "Search"

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -1,33 +1,32 @@
-from addon import PluginInformation
+"""Arte TV and HBB TV API communications - REST and authentication calls"""
 from collections import OrderedDict
+# pylint: disable=import-error
 import requests
+# pylint: disable=import-error
 from xbmcswift2 import xbmc
 from . import hof
 
 
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
-_base_api_url = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
-_base_headers = {
-    'user-agent': PluginInformation.name + '/' + PluginInformation.version
+_HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
+_HBBTV_HEADERS = {
+    'user-agent': 'plugin.video.arteplussept/1.1.9'
 }
-_endpoints = {
-    'categories': '/EMAC/teasers/{type}/v2/{lang}',
+_HBBTV_ENDPOINTS = {
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
-    'subcategory': '/OPA/v3/videos/subcategory/{sub_category_code}/page/1/limit/100/{lang}',
-    # 'magazines': '/OPA/v3/magazines/{lang}', # moved to arte tv api
     'collection': '/EMAC/teasers/collection/v2/{collection_id}/{lang}',
     # program details
     'video': '/OPA/v3/videos/{program_id}/{lang}',
     # program streams
-    'streams': '/OPA/v3/streams/{program_id}/{kind}/{lang}',
-    'daily': '/OPA/v3/programs/{date}/{lang}'
+    'streams': '/OPA/v3/streams/{program_id}/{kind}/{lang}'
 }
 
 
 # Arte TV API - Used on Arte TV website
-_artetv_url = 'https://api.arte.tv/api'
-_artetv_rproxy_url = 'https://arte.tv/api/rproxy'
-_artetv_endpoints = {
+_ARTETV_URL = 'https://api.arte.tv/api'
+ARTETV_RPROXY_URL = 'https://arte.tv/api/rproxy'
+_ARTETV_AUTH_URL = 'https://auth.arte.tv/ssologin'
+ARTETV_ENDPOINTS = {
     # POST
     'token': '/sso/v3/token',
     # needs token in authorization header
@@ -47,7 +46,6 @@ _artetv_endpoints = {
     # PATCH empty payload
     # needs token in authorization header
     'purge_last_viewed': '/sso/v3/lastvieweds/purge',
-    'magazines': '/sso/v3/magazines/{lang}?page={page}&limit={limit}',
     # program_id can be 103520-000-A or LIVE
     'program': '/player/v2/config/{lang}/{program_id}',
     # rproxy
@@ -56,129 +54,132 @@ _artetv_endpoints = {
     # not yet impl.
     # rproxy date=2023-01-17
     # 'guide_tv': '/emac/v3/{lang}/{client}/pages/TV_GUIDE/?day={DATE}',
+    # auth api
+    'custom_token': '/setCustomToken',
+    # auth api
+    'login': '/login',
 }
-_artetv_headers = {
+ARTETV_HEADERS = {
+    'user-agent': 'plugin.video.arteplussept/1.1.9',
     # required to use token endpoint
     'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg',
     # required for Arte TV API. values like web, app, tv, orange, free
+    # prefer client tv over web so that Arte adapt content to tv limiting links for instance
     'client': 'tv',
     'accept': 'application/json'
 }
 
-# Retrieve favorites from a personal account.
 def get_favorites(plugin, lang, usr, pwd):
-    url = _artetv_url + _artetv_endpoints['get_favorites'].format(lang=lang, page='1', limit='50')
+    """Retrieve favorites from a personal account."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['get_favorites'].format(lang=lang, page='1', limit='50')
     return _load_json_personal_content(plugin, url, usr, pwd)
 
 def add_favorite(plugin, usr, pwd, program_id):
-    url = _artetv_url + _artetv_endpoints['add_favorite']
-    headers = _add_auth_token(plugin, usr, pwd, _artetv_headers)
+    """Add content program_id to user favorites.
+    :return: HTTP status code."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['add_favorite']
+    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
     data = {'programId': program_id}
-    r = requests.put(url, data=data, headers=headers)
-    return r.status_code
+    reply = requests.put(url, data=data, headers=headers, timeout=10)
+    return reply.status_code
 
 def remove_favorite(plugin, usr, pwd, program_id):
-    url = _artetv_url + _artetv_endpoints['remove_favorite'].format(program_id=program_id)
-    headers = _add_auth_token(plugin, usr, pwd, _artetv_headers)
-    r = requests.delete(url, headers=headers)
-    return r.status_code
+    """Remove content program_id from user favorites.
+    :return: HTTP status code."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['remove_favorite'].format(program_id=program_id)
+    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    reply = requests.delete(url, headers=headers, timeout=10)
+    return reply.status_code
 
-# Retrieve content recently watched by a user.
 def get_last_viewed(plugin, lang, usr, pwd):
-    url = _artetv_url + _artetv_endpoints['get_last_viewed'].format(lang=lang, page='1', limit='50')
+    """Retrieve content recently watched by a user."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['get_last_viewed'].format(lang=lang, page='1', limit='50')
     return _load_json_personal_content(plugin, url, usr, pwd)
 
 def sync_last_viewed(plugin, usr, pwd, program_id, time):
-    url = _artetv_url + _artetv_endpoints['sync_last_viewed']
-    headers = _add_auth_token(plugin, usr, pwd, _artetv_headers)
+    """Synchronize in arte profile the progress time of content being played.
+    :return: HTTP status code."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['sync_last_viewed']
+    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
     data = {'programId': program_id, 'timecode': time}
-    r = requests.put(url, data=data, headers=headers)
-    return r.status_code
+    reply = requests.put(url, data=data, headers=headers, timeout=10)
+    return reply.status_code
 
 def purge_last_viewed(plugin, usr, pwd):
-    url = _artetv_url + _artetv_endpoints['purge_last_viewed']
-    headers = _add_auth_token(plugin, usr, pwd, _artetv_headers)
-    r = requests.patch(url, data={}, headers=headers)
-    return r.status_code
+    """Flush user history"""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['purge_last_viewed']
+    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    reply = requests.patch(url, data={}, headers=headers, timeout=10)
+    return reply.status_code
 
 def program_video(lang, program_id):
-    url = _artetv_url + _artetv_endpoints['program'].format(lang=lang, program_id=program_id)
+    """Get the info of content program_id from Arte TV API."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['program'].format(lang=lang, program_id=program_id)
     return _load_json_full_url(url, None).get('data', {})
 
 
-def categories(lang):
-    url = _endpoints['categories'].format(type='categories', lang=lang)
-    return _load_json(url).get('categories', {})
-
-
-def home_category(name, lang):
-    url = _endpoints['categories'].format(type='home', lang=lang)
-    return _load_json(url).get('teasers', {}).get(name, [])
-
-
 def category(category_code, lang):
-    url = _endpoints['category'].format(category_code=category_code, lang=lang)
+    """Get the info of category with category_code."""
+    url = _HBBTV_ENDPOINTS['category'].format(category_code=category_code, lang=lang)
     return _load_json(url).get('category', {})
 
 
-def subcategory(sub_category_code, lang):
-    url = _endpoints['subcategory'].format(
-        sub_category_code=sub_category_code, lang=lang)
-    return _load_json(url).get('videos', {})
-
-
 def collection(kind, collection_id, lang):
-    url = _endpoints['collection'].format(
+    """Get the info of collection collection_id"""
+    url = _HBBTV_ENDPOINTS['collection'].format(
         kind=kind, collection_id=collection_id, lang=lang)
-    subCollections = _load_json(url).get('subCollections', [])
-    return hof.flat_map(lambda subCollections: subCollections.get('videos', []), subCollections)
+    sub_collections = _load_json(url).get('subCollections', [])
+    return hof.flat_map(
+        lambda sub_collections: sub_collections.get('videos', []),
+        sub_collections)
 
 
 def video(program_id, lang):
-    url = _endpoints['video'].format(
+    """Get the info of content program_id from HBB TV API."""
+    url = _HBBTV_ENDPOINTS['video'].format(
         program_id=program_id, lang=lang)
     return _load_json(url).get('videos', [])[0]
 
 
 def streams(kind, program_id, lang):
-    url = _endpoints['streams'].format(
+    """Get the stream info of content program_id."""
+    url = _HBBTV_ENDPOINTS['streams'].format(
         kind=kind, program_id=program_id, lang=lang)
     return _load_json(url).get('videoStreams', [])
 
+def page_content(lang):
+    """Get content to be display in a page. It can be a page for a category or the home page."""
+    url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['page'].format(
+        lang=lang, category='HOME', client='tv')
+    return _load_json_full_url(url, ARTETV_HEADERS).get('value', [])
 
-def magazines(lang):
-    url = _artetv_url + _artetv_endpoints['magazines'].format(
-        lang=lang, page='1', limit='50')
-    return _load_json_full_url(url, _artetv_headers).get('data')
-
-
-def daily(date, lang):
-    url = _endpoints['daily'].format(date=date, lang=lang)
-    return _load_json(url).get('programs', [])
-
-# Get content to be display in a page. It can be a page for a category or the home page.
-def page(lang):
-    url = _artetv_rproxy_url + _artetv_endpoints['page'].format(lang=lang, category='HOME', client='tv')
-    return _load_json_full_url(url, _artetv_headers).get('value', [])
-
-# /emac/v4/{lang}/{client}/pages/SEARCH/?page={page}&query={query}
 def search(lang, query, page='1'):
-    url = _artetv_rproxy_url + _artetv_endpoints['page'].format(lang=lang, category='SEARCH', client='tv')
+    """Search for content in Arte TV API.
+    /emac/v4/{lang}/{client}/pages/SEARCH/?page={page}&query={query}
+    """
+    url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['page'].format(
+        lang=lang, category='SEARCH', client='tv')
     params = {'page' : page, 'query' : query}
-    return _load_json_full_url(url, _artetv_headers, params).get('value', []).get('zones', [None])[0]
+    return _load_json_full_url(url, ARTETV_HEADERS, params).get('value', []).get('zones', [None])[0]
 
-# Deprecated since 2022. Prefer building url on client side
-def _load_json(path, headers=_base_headers):
-    url = _base_api_url + path
+def _load_json(path, headers=None):
+    """Deprecated since 2022. Prefer building url on client side"""
+    if headers is None:
+        headers = _HBBTV_HEADERS
+    url = _HBBTV_URL + path
     return _load_json_full_url(url, headers)
 
-def _load_json_full_url(url, headers=_base_headers, params=None):
+def _load_json_full_url(url, headers=None, params=None):
+    if headers is None:
+        headers = _HBBTV_HEADERS
     # https://requests.readthedocs.io/en/latest/
-    r = requests.get(url, headers=headers, params=params)
-    return r.json(object_pairs_hook=OrderedDict)
+    reply = requests.get(url, headers=headers, params=params, timeout=10)
+    return reply.json(object_pairs_hook=OrderedDict)
 
-# Get a bearer token and add it in headers before sending the request
-def _load_json_personal_content(plugin, url, usr, pwd, hdrs=_artetv_headers):
+def _load_json_personal_content(plugin, url, usr, pwd, hdrs=None):
+    """Get a bearer token and add it in headers before sending the request"""
+    if hdrs is None:
+        hdrs = ARTETV_HEADERS
     headers = _add_auth_token(plugin, usr, pwd, hdrs)
     if not headers:
         return None
@@ -186,41 +187,139 @@ def _load_json_personal_content(plugin, url, usr, pwd, hdrs=_artetv_headers):
 
 # Get a bearer token and add it as HTTP header authorization
 def _add_auth_token(plugin, usr, pwd, hdrs):
-    tkn = token(plugin, usr, pwd)
+    tkn = get_and_persist_token(plugin, usr, pwd)
     if not tkn:
         return None
     headers = hdrs.copy()
     headers['authorization'] = tkn['token_type'] + ' ' + tkn['access_token']
+    # web client needed to reuse token. Otherwise API rejects with
+    # {"error":"invalid_client","error_description":"Client not authorized"}
+    headers['client'] = 'web'
     return headers
 
-# Log in user thanks to his/her settings and get a bearer token
-# return None if:
-#   - any parameter is empty
-#     - silenty if both parameters are empty
-#     - with a notification if one is not empty
-#   - connection to arte tv failed
-def token(plugin, username='', password='', headers=_artetv_headers):
+
+def get_and_persist_token(plugin, username='', password='', headers=None):
+    """Log in user thanks to his/her settings and get a bearer token.
+    Return None if:
+        - any parameter is empty
+        - silenty if both parameters are empty
+        - with a notification if one is not empty
+        - connection to arte tv failed"""
+    if headers is None:
+        headers = ARTETV_HEADERS
     # unable to authenticate if either username or password are empty
     if not username and not password:
         plugin.notify(msg=plugin.addon.getLocalizedString(30022), image='info')
         return None
     # inform that settings are incomplete
     if not username or not password:
-        msg = plugin.addon.getLocalizedString(30020) + ' : ' + plugin.addon.getLocalizedString(30021)
+        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30021)}"
         plugin.notify(msg=msg, image='warning')
         return None
 
-    url = _artetv_url + _artetv_endpoints['token']
-    token_data = {'anonymous_token': None, 'grant_type': 'password', 'username': username, 'password': password}
-    # set to web, because with tv get error client_invalid, error Client not authorized
+    cached_token = plugin.get_storage('token', TTL=24*60)
+    token_idx = f"{username}_{hash(password)}"
+    if token_idx in cached_token:
+        tkn_data = cached_token[token_idx]
+        xbmc.log(f"\"{username}\" already authenticated to Arte TV : {tkn_data['access_token']}")
+        return tkn_data
+
+    # set client to web, because with tv get error client_invalid, error Client not authorized
     headers['client'] = 'web'
+
+    tokens = authenticate_in_arte(plugin, username, password, headers)
+    # exit if authentication failed
+    if not tokens:
+        return None
+
+    # try to persist token in arte to be allowed to reuse; otherwise token is one-shot
+    if persist_token_in_arte(plugin, tokens, headers):
+        # token persisted remotly are stored in kodi cache to be reused
+        cached_token[token_idx] = tokens
+        xbmc.log(f"\"{username}\" is successfully authenticated to Arte TV")
+        xbmc.log(f"Token persisted for a day \"{tokens['access_token']}\"")
+    # return persisted or unpersisted token anyway
+    return tokens
+
+
+def authenticate_in_arte(plugin, username='', password='', headers=None):
+    """Return None if authentication failed and display an error notification
+    Return arte reply with access and refresh tokens if authentication was successfull
+    (i.e. status 200, no exception)"""
+    if headers is None:
+        headers = ARTETV_HEADERS
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['token']
+    token_data = {
+        'anonymous_token': None,
+        'grant_type': 'password',
+        'username': username,
+        'password': password
+    }
+    xbmc.log(f"Try authenticating \"{username}\" to Arte TV")
+    error = None
+    reply = None
     try:
         # https://requests.readthedocs.io/en/latest/
-        r = requests.post(url, data=token_data, headers=headers)
+        reply = requests.post(url, data=token_data, headers=headers, timeout=10)
     except requests.exceptions.ConnectionError as err:
         # unable to auth. e.g.
-        # HTTPSConnectionPool(host='api.arte.tv', port=443): Max retries exceeded with url: /api/sso/v3/token
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
-        xbmc.log('Unable to authenticate to Arte TV : {err_str}'.format(err_str=err))
+        # HTTPSConnectionPool(host='api.arte.tv', port=443):
+        # Max retries exceeded with url: /api/sso/v3/token
+        error = err
+    if error or not reply or reply.status_code != 200:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='error')
+        err_dtls = str(error) if error else (reply.text if reply is not None else '')
+        xbmc.log(f"Unable to authenticate to Arte TV : {err_dtls}")
         return None
-    return r.json(object_pairs_hook=OrderedDict)
+    return reply.json(object_pairs_hook=OrderedDict)
+
+def persist_token_in_arte(plugin, tokens, headers):
+    """Calls the sequence of 2 services to be able to reuse authentication token
+    Return True, if token is persisted, False otherwise.
+    Notify the user with a warning if persistance failed.
+    """
+    # constants taken from my reverse engineering
+    api_key = '97598990-f0af-427b-893e-9da348d9f5a6'
+    cookies = {
+        'TCPID' : '123261154911117061452',
+        # pylint: disable=line-too-long
+        'TC_PRIVACY' : '1%40031%7C29%7C3445%40%40%401677322453596%2C1677322453596%2C1711018453596%40',
+        'TC_PRIVACY_CENTER' : None
+    }
+
+    # step 1/2 : get additional cookies for step 2.
+    url = _ARTETV_AUTH_URL + ARTETV_ENDPOINTS['custom_token']
+    params = {
+        'shouldValidateAnonymous' : False,
+        'token' : tokens['access_token'],
+        'apikey' : api_key,
+        'isrememberme' : True
+    }
+    error = None
+    cstm_tkn = None
+    try:
+        cstm_tkn = requests.get(url,params=params, headers=headers, cookies=cookies, timeout=10)
+    except requests.exceptions.ConnectionError as err:
+        error = err
+    if error or not cstm_tkn or cstm_tkn.status_code != 200:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
+        err_dtls = str(error) if error else (cstm_tkn.text if cstm_tkn is not None else '')
+        xbmc.log(f"Unable to persist Arte TV token {tokens['access_token']}. Step 1/2: {err_dtls}")
+        return False
+
+    # step 2/2 : persist / remember token so that it can be reused
+    url = _ARTETV_AUTH_URL + ARTETV_ENDPOINTS['login']
+    params = {'shouldValidateAnonymous' : 'false', 'apikey' : api_key}
+    cookies = hof.merge_dicts(cookies, cstm_tkn.cookies)
+    login = None
+    try:
+        login = requests.get(url,params=params, headers=headers, cookies=cookies, timeout=10)
+    except requests.exceptions.ConnectionError as err:
+        error = err
+    if error or not login or login.status_code != 200:
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
+        err_dtls = str(error) if error else (login.text if login is not None else '')
+        xbmc.log(f"Unable to persist Arte TV token {tokens['access_token']}. Step 2/2: {err_dtls}")
+        return False
+
+    return True

--- a/plugin.video.arteplussept/resources/lib/hof.py
+++ b/plugin.video.arteplussept/resources/lib/hof.py
@@ -1,74 +1,53 @@
-import functools
+"""Utility methods for lists and dictionaries"""
 
-def find(findFn, l):
+def find(find_fctn, lst):
     """
-      Will return the first item matching the findFn
-      findFn: A function taking one param: value. MUST return a boolean
-      l: The list to search
+      Return the first item matching the findfctn
+      :param fn find_fctn: A function taking one param: value. MUST return a boolean
+      :param list lst: The list to search
     """
-    for item in l:
-        if findFn(item):
+    for item in lst:
+        if find_fctn(item):
             return item
     return None
 
 
-def find_dict(findFn, d):
+def find_dict(find_fctn, dictionary):
     """
-      Will return the first value matching the findFn
-      findFn: A function taking two params: value, key. MUST return a boolean
-      d: The dict to search
+      Return the first value matching the findfctn
+      :param fn find_fctn: A function taking two params: value, key. MUST return a boolean
+      :param dict dictionary: The dict to search
     """
-    for k, v in d.items():
-        if findFn(v, k):
-            return v
+    for key, value in dictionary.items():
+        if find_fctn(value, key):
+            return value
     return None
 
 
-def map_dict(mapFn, d):
+def map_dict(map_fctn, dictionary):
     """
-      mapFn: A function taking two params: value, key
-      d: The dict to map
+      :param fn map_fctn: A function taking two params: value, key
+      :param dict dictionary: The dict to map
     """
-    return {k: mapFn(v, k) for k, v in d.items()}
+    return {k: map_fctn(v, k) for k, v in dictionary.items()}
 
 
-def filter_dict(filterFn, d):
+def filter_dict(filter_fctn, dictionary):
     """
-      filterFn: A function taking two params: value, key. MUST return a boolean
-      d: The dict to filter
+      :param fn filter_fctn: A function taking two params: value, key. MUST return a boolean
+      :param dict dictionary: The dict to filter
     """
-    return {k: v for k, v in d.items() if filterFn(v, k)}
-
-
-def reject_dict(filterFn, d):
-    """
-      filterFn: A function taking two params: value, key. MUST return a boolean
-      d: The dict to filter
-    """
-    def invert(*args, **kwargs):
-        return not filterFn(*args, **kwargs)
-    return filter_dict(invert, d)
-
-
-def get_property(d, path, default=None):
-    def walk(sub_d, segment):
-        if sub_d is None:
-            return None
-        return sub_d.get(segment)
-    segments = path.split('.')
-    return functools.reduce(walk, segments, d) or default
-
+    return {key: value for key, value in dictionary.items() if filter_fctn(value, key)}
 
 def merge_dicts(*args):
+    """
+      Merge dictionaries in a single one. Precedence on lastest dictionaries in args
+    """
     result = {}
-    for d in args:
-        result.update(d)
+    for dictionary in args:
+        result.update(dictionary)
     return result
 
-
-def flatten(l):
-    return [item for sublist in l for item in sublist]
-
-
-def flat_map(f, lst):
-    return [item for list_item in lst for item in f(list_item)]
+def flat_map(fctn, lst):
+    """Return the results of applying fctn on sub elements of lst."""
+    return [item for list_item in lst for item in fctn(list_item)]

--- a/plugin.video.arteplussept/resources/lib/mapper.py
+++ b/plugin.video.arteplussept/resources/lib/mapper.py
@@ -1,56 +1,25 @@
-from addon import plugin
+"""Map JSON API outputs into playable content and meanus for Kodi"""
+# pylint: disable=import-error
 from xbmcswift2 import xbmc
+# pylint: disable=import-error
 from xbmcswift2 import actions
+# pylint: disable=cyclic-import
+from addon import plugin
 from . import hof
 from . import utils
 
-def map_categories(api_categories, show_video_streams, cached_categories):
-    categories = []
-    for item in api_categories:
-        # categories have code MOST_VIEWED, when content is returned in teasers
-        # and not available in sub API call
-        if item.get('code') == "MOST_VIEWED":
-            cat_code = "MOST_VIEWED_{id}".format(id=(len(cached_categories) or 0))
-            item['code'] = cat_code
-            if item.get('teasers'):
-                # build cached categories
-                cached_categories[cat_code] = [map_generic_item(teaser, show_video_streams)
-                        for teaser in item.get('teasers')]
-                categories.append(map_categories_item(item, 'cached_category'))
-            else:
-                xbmc.log("Category \"{cat_title}\" will be ignored, because it contains no teaser".format(cat_title=item.get('title')))
-        else:
-            categories.append(map_categories_item(item, 'api_category'))
-    return categories
 
-def map_categories_item(item, category_rule, category_code=None):
-    if not category_code:
-        category_code = item.get('code')
-    return {
-        'label': utils.colorize(item.get('title'), item.get('color')),
-        'path': plugin.url_for(category_rule, category_code=category_code)
-    }
-
-
-# def create_creative_item():
-#     return {
-#         'label': 'Creative I18N',
-#         'path': plugin.url_for('creative')
-#     }
-
-
-def create_favorites_item(label=None):
-    if not label:
-        label = plugin.addon.getLocalizedString(30010)
+def create_favorites_item(label):
+    """Return menu entry to access user favorites"""
     return {
         'label': label,
         'path': plugin.url_for('favorites')
     }
 
 
-def create_last_viewed_item(label=None):
-    if not label:
-        label = plugin.addon.getLocalizedString(30011)
+def create_last_viewed_item(label):
+    """Return menu entry to access user history
+    with an additional command to flush user history"""
     return {
         'label': label,
         'path': plugin.url_for('last_viewed'),
@@ -62,51 +31,20 @@ def create_last_viewed_item(label=None):
 
 
 def create_search_item():
+    """Return menu entry to search content"""
     return {
         'label': plugin.addon.getLocalizedString(30012),
         'path': plugin.url_for('search')
     }
 
 
-def create_magazines_item():
-    return {
-        'label': plugin.addon.getLocalizedString(30008),
-        'path': plugin.url_for('magazines')
-    }
-
-
-def create_week_item():
-    return {
-        'label': plugin.addon.getLocalizedString(30009),
-        'path': plugin.url_for('weekly')
-    }
-
-
-def create_newest_item():
-    return {
-        'label': plugin.addon.getLocalizedString(30005),
-        'path': plugin.url_for('newest')
-    }
-
-
-def create_most_viewed_item():
-    return {
-        'label': plugin.addon.getLocalizedString(30006),
-        'path': plugin.url_for('most_viewed')
-    }
-
-
-def create_last_chance_item():
-    return {
-        'label': plugin.addon.getLocalizedString(30007),
-        'path': plugin.url_for('last_chance')
-    }
-
-
 def map_category_item(item, category_code):
+    """Return menu entry to access a category content"""
     title = item.get('title')
-    path = plugin.url_for('sub_category_by_title',
-                          category_code=category_code, sub_category_title=utils.encode_string(title))
+    path = plugin.url_for(
+        'sub_category_by_title',
+        category_code=category_code,
+        sub_category_title=utils.encode_string(title))
 
     return {
         'label': title,
@@ -115,28 +53,33 @@ def map_category_item(item, category_code):
 
 
 def map_generic_item(item, show_video_streams):
+    """Return entry menu for video or playlist"""
     program_id = item.get('programId')
 
-    is_playlist = utils.is_playlist(program_id)
-    if not is_playlist:
-        return map_video(item, show_video_streams)
+    if utils.is_playlist(program_id):
+        item = map_playlist(item)
     else:
-        return map_playlist(item)
+        item = map_video(item, show_video_streams)
+    return item
 
 
-# Create a video menu item from a json returned by Arte HBBTV API
 def map_video(item, show_video_streams):
+    """Create a video menu item from a json returned by Arte HBBTV API"""
     program_id = item.get('programId')
     label = utils.format_title_and_subtitle(item.get('title'), item.get('subtitle'))
     kind = item.get('kind')
     duration = item.get('durationSeconds')
     airdate = item.get('broadcastBegin')
     if airdate is not None:
-        airdate = str(utils.parse_date(airdate))
+        airdate = str(utils.parse_date_hbbtv(airdate))
+    if show_video_streams:
+        path = plugin.url_for('streams', program_id=program_id)
+    else:
+        path = plugin.url_for('play', kind=kind, program_id=program_id)
 
     return {
         'label': label,
-        'path': plugin.url_for('streams', program_id=program_id) if show_video_streams else plugin.url_for('play', kind=kind, program_id=program_id),
+        'path': path,
         'thumbnail': item.get('imageUrl'),
         'is_playable': not show_video_streams,
         'info_type': 'video',
@@ -158,66 +101,25 @@ def map_video(item, show_video_streams):
         },
         'context_menu': [
             (plugin.addon.getLocalizedString(30023),
-                actions.background(plugin.url_for('add_favorite', program_id=program_id, label=label))),
+                actions.background(plugin.url_for(
+                    'add_favorite', program_id=program_id, label=label))),
             (plugin.addon.getLocalizedString(30024),
-                actions.background(plugin.url_for('remove_favorite', program_id=program_id, label=label))),
+                actions.background(plugin.url_for(
+                    'remove_favorite', program_id=program_id, label=label))),
         ],
     }
 
-# Create a video menu item from a json returned by Arte TV API
-# Source data example, unable to find public documentation
-# {
-#   "type": "teaser",
-#   "id": "079395-000-A_fr",
-#   "kind": "SHOW",
-# OR
-#   "kind":{"code":"SHOW","label":"Programme","isCollection":false}
-#   "programId": "079395-000-A",
-#   "language": "fr",
-#   "url": "https://www.arte.tv/fr/videos/079395-000-A/maitriser-l-energie-des-etoiles-la-revolution-de-demain/",
-#   "title": "Maîtriser l'énergie des étoiles, la révolution de demain",
-#   "subtitle": null,
-#   "images": [
-#     {
-#       "url": "https://api-cdn.arte.tv/img/v2/image/te28ppavJQNmHtpNndKqUG/1920x1080?type=TEXT", "format": "landscape", "width": 1920, "height": 1080,
-#       "alternateResolutions": [
-#         { "url": "https://api-cdn.arte.tv/img/v2/image/te28ppavJQNmHtpNndKqUG/1920x1080?type=TEXT", "width": 1920, "height": 1080, "imageSize": "1920x1080" }
-#       ]
-#     }
-#   ],
-#   "markings": [],
-#   "geoblocking": null,
-#   "warning": null,
-#   "description": "La technique de la fusion nucléaire revient régulièrement sur le devant de la scène. Face au défi de la transition énergétique, elle pourrait représenter une puissante alternative,aussi puissante que l'énergie du soleil dont elle entend s'inspirer. Sans déchets radioactifs, sans extractions polluantes, durable, elle est encore à ce stade un chantier pour la science et un gouffre financier. Explications.",
-#   "shortDescription": "La technique de la fusion nucléaire revient régulièrement sur le devant de la scène. Face au défi de la transition énergétique, elle pourrait représenter une puissante alternative,aussi puissante que l'énergie du soleil dont elle entend s'inspirer. Sans déchets radioactifs, sans extractions polluantes, durable, elle est encore à ce stade un chantier pour la science et un gouffre financier. Explications.",
-#   "beginsAt": "2022-07-01T03:00:00Z",
-#   "expireAt": "2023-06-30T03:00:00Z",
-#   "availability": { "type": "VOD", "start": "2022-07-01T03:00:00Z", "end": "2023-06-30T03:00:00Z", "hasVideoStreams": true, "broadcastBegin": null, "displayDate": "2022-07-01T03:00:00Z" },
-#   "duration": 52,
-#   "durationSeconds": 3114,
-#   "video_url": "/api/1/player/079395-000-A",
-#   "player": {
-#     "config": "https://api.arte.tv/api/player/v2/config/fr/079395-000-A"
-#   },
-#   "playable": true,
-#   "stickers": [
-#     { "code": "PLAYABLE", "label": "PLAYABLE"}
-#   ],
-#   "durationLabel": null,
-#   "available": true,
-#   "trackingPixel": "https://www.arte.tv/ct/?language=fr&support=web&pageid={HOME}&zonename=myarte_favorites&zoneid=myarte_favorites&teasertitle=Maitriser-l-energie-des-etoiles-la-revolution-de-demain&teaserid=079395-000-A&programid=079395-000-A&position=17",
-#   "lastviewed": { "is": true, "timecode": 0, "progress": 1 },
-#   "favorite": { "is": true }
-# }
-# Destination object : https://romanvm.github.io/Kodistubs/_autosummary/xbmcgui.html#xbmcgui.ListItem.setInfo
 def map_artetv_video(item):
+    """Return video menu item to show content from Arte TV API
+    :rtype dict[str, Any] | None: To be used in
+    https://romanvm.github.io/Kodistubs/_autosummary/xbmcgui.html#xbmcgui.ListItem.setInfo"""
     program_id = item.get('programId')
     label = utils.format_title_and_subtitle(item.get('title'), item.get('subtitle'))
     kind = item.get('kind')
     duration = item.get('durationSeconds')
     airdate = item.get('beginsAt') # broadcastBegin
     if airdate is not None:
-        airdate = str(utils.parse_artetv_date(airdate))
+        airdate = str(utils.parse_date_artetv(airdate))
 
     fanart_url = ""
     thumbnail_url = ""
@@ -244,7 +146,7 @@ def map_artetv_video(item):
 
     is_playlist = utils.is_playlist(program_id)
     path = plugin.url_for('collection' if is_playlist else 'play', kind=kind, program_id=program_id)
-    
+
     return {
         'label': label,
         'path': path,
@@ -274,14 +176,17 @@ def map_artetv_video(item):
         },
         'context_menu': [
             (plugin.addon.getLocalizedString(30023),
-                actions.background(plugin.url_for('add_favorite', program_id=program_id, label=label))),
+                actions.background(plugin.url_for(
+                    'add_favorite', program_id=program_id, label=label))),
             (plugin.addon.getLocalizedString(30024),
-                actions.background(plugin.url_for('remove_favorite', program_id=program_id, label=label))),
+                actions.background(plugin.url_for(
+                    'remove_favorite', program_id=program_id, label=label))),
         ],
     }
 
 
 def map_live_video(item, quality, audio_slot):
+    """Return menu entry to watch live content from Arte TV API"""
     # program_id = item.get('id')
     attr = item.get('attributes')
     meta = attr.get('metadata')
@@ -304,7 +209,7 @@ def map_live_video(item, quality, audio_slot):
 
     return {
         'label': utils.format_live_title_and_subtitle(meta.get('title'), meta.get('subtitle')),
-        'path': plugin.url_for('play_live', streamUrl=stream_url),
+        'path': plugin.url_for('play_live', stream_url=stream_url),
         # playing the stream from program id makes the live starts from the beginning of the video
         # while it starts the video like the live tv, with the above
         #  'path': plugin.url_for('play', kind='SHOW', program_id=programId.replace('_fr', '')),
@@ -332,6 +237,7 @@ def map_live_video(item, quality, audio_slot):
 
 
 def map_playlist(item):
+    """Map JSON item to menu entry to access playlist content"""
     program_id = item.get('programId')
     kind = item.get('kind')
 
@@ -347,15 +253,15 @@ def map_playlist(item):
 
 
 def map_streams(item, streams, quality):
+    """Map JSON item and list of audio streams into a menu."""
     program_id = item.get('programId')
     kind = item.get('kind')
 
     video_item = map_video(item, False)
 
-    # TODO: filter streams by quality
     filtered_streams = None
-    for q in [quality] + [i for i in ['SQ', 'EQ', 'HQ', 'MQ'] if i is not quality]:
-        filtered_streams = [s for s in streams if s.get('quality') == q]
+    for qlt in [quality] + [i for i in ['SQ', 'EQ', 'HQ', 'MQ'] if i is not quality]:
+        filtered_streams = [s for s in streams if s.get('quality') == qlt]
         if len(filtered_streams) > 0:
             break
 
@@ -380,9 +286,12 @@ def map_streams(item, streams, quality):
 
 
 def map_playable(streams, quality, audio_slot, match):
+    """Select the stream best matching quality and audio slot criteria in streams
+    and map to a menu entry"""
     stream = None
-    for q in [quality] + [i for i in ['SQ', 'EQ', 'HQ', 'MQ'] if i is not quality]:
-        stream = hof.find(lambda s: match(s, q, audio_slot), streams)
+    for qlt in [quality] + [i for i in ['SQ', 'EQ', 'HQ', 'MQ'] if i is not quality]:
+        # pylint: disable=cell-var-from-loop
+        stream = hof.find(lambda s: match(s, qlt, audio_slot), streams)
         if stream:
             break
 
@@ -394,17 +303,20 @@ def map_playable(streams, quality, audio_slot, match):
         'path': stream.get('url'),
     }
 
-
 def match_hbbtv(item, quality, audio_slot):
+    """Return True if item from HHB TV API matches quality and audio_slot constraints,
+    False otherwise"""
     return item.get('quality') == quality and item.get('audioSlot') == audio_slot
 
 def match_artetv(item, quality, audio_slot):
+    """Return True if item from Arte TV API matches quality and audio_slot constraints,
+    False otherwise"""
     return item.get('mainQuality').get('code') == quality and str(item.get('slot')) == audio_slot
 
 
-# Arte TV API page is split into zones. Map a 'zone' to menu item(s).
-# Populate cached_categories for zones with videos available in child 'content'
 def map_zone_to_item(zone, cached_categories):
+    """Arte TV API page is split into zones. Map a 'zone' to menu item(s).
+    Populate cached_categories for zones with videos available in child 'content'"""
     menu_item = None
     title = zone.get('title')
     if zone.get('id') == '9fc57105-847b-49c5-9b4a-f46863754059':
@@ -420,15 +332,29 @@ def map_zone_to_item(zone, cached_categories):
     elif zone.get('link'):
         menu_item = map_categories_item(zone, 'api_category', zone.get('link').get('page'))
     else:
-        xbmc.log("Zone \"{zone_title}\" will be ignored. No link. No content. id unknown.".format(zone_title=title))
+        xbmc.log(f"Zone \"{title}\" will be ignored. No link. No content. id unknown.")
 
     return menu_item
 
 
 def map_cached_categories(zone):
+    """Map JSON node zone from Arte TV API to a list of menu items."""
     cached_category = []
     for item in zone.get('content').get('data'):
         menu_video = map_artetv_video(item)
         if menu_video:
             cached_category.append(menu_video)
     return cached_category
+
+def map_categories_item(item, category_rule, category_code=None):
+    """Return a menu entry to access content of category item.
+    :param dict item: JSON node item
+    :param str category_rule: value is either cached_category, either api_category.
+    :param str category_code: if None, use item code.
+    """
+    if not category_code:
+        category_code = item.get('code')
+    return {
+        'label': utils.colorize(item.get('title'), item.get('color')),
+        'path': plugin.url_for(category_rule, category_code=category_code)
+    }

--- a/plugin.video.arteplussept/resources/lib/player.py
+++ b/plugin.video.arteplussept/resources/lib/player.py
@@ -1,3 +1,5 @@
+"""Events enhancing behavior of default Kodi player"""
+# pylint: disable=import-error
 from xbmcswift2 import xbmc
 from . import api
 
@@ -6,57 +8,71 @@ from . import api
 # when playback is paused or stopped or crashed
 # https://xbmc.github.io/docs.kodi.tv/master/kodi-dev-kit/group__python___player_c_b.html
 class Player(xbmc.Player):
+    """Events enhancing behavior of default Kodi player
+    used to track in Arte TV progress time and history"""
 
     def __init__(self, plugin, settings, program_id):
-        super(Player, self).__init__()
+        super().__init__()
         self.plugin = plugin
         self.settings = settings
         self.program_id = program_id
         self.last_time = 0
 
     def is_playback(self):
+        """Track progress time during playback"""
         try:
-            # need to keep track of last time to avoid 
+            # need to keep track of last time to avoid
             # RuntimeError: Kodi is not playing any media file
             # when calling player.getTime() in onPlayBackStopped()
             self.last_time = self.getTime()
             return self.isPlaying() and self.isPlayingVideo() and self.last_time >= 0
+        # pylint: disable=broad-exception-caught
+        # https://codedocs.xyz/MartijnKaijser/xbmc/group__python___player.html
         except Exception:
             return False
 
     def onAVStarted(self):
-        # Will be called when user stars playing
+        # pylint: disable=invalid-name
+        # method name defined by Kodi framework
+        """Track progress time when user stars playing"""
         self.synch_progress()
-        pass
 
     def onPlayBackStopped(self):
-        # Will be called when user stops playing
+        # pylint: disable=invalid-name
+        # method name defined by Kodi framework
+        """Track progress time when user stops playing"""
         self.synch_progress()
-        pass
 
     def onPlayBackEnded(self):
-        # Will be called when kodi stops playing
+        # pylint: disable=invalid-name
+        # method name defined by Kodi framework
+        """Track progress time when kodi stops playing"""
         self.synch_progress()
-        pass
 
     def onPlayBackError(self):
-        # Will be called when kodi stops playing
+        # pylint: disable=invalid-name
+        # method name defined by Kodi framework
+        """Track progress time when kodi stops playing"""
         self.synch_progress()
-        pass
 
     def onPlayBackPaused(self):
-        # Will be called when kodi stops playing
+        # pylint: disable=invalid-name
+        # method name defined by Kodi framework
+        """Track progress time when kodi pauses playing"""
         self.synch_progress()
-        pass
 
     def synch_progress(self):
+        """Track progress/playback time and share it with Arte TV,
+        so that other device with the user account can share progress and history"""
         if not self.settings.username or not self.settings.password:
-            xbmc.log("Unable to synchronise progress with Arte TV for {pid}".format(pid=self.program_id), level=xbmc.LOGWARNING)
+            xbmc.log(f"Unable to synchronise progress with Arte TV for {self.program_id}",
+                     level=xbmc.LOGWARNING)
             xbmc.log("Missing user or password to authenticate", level=xbmc.LOGWARNING)
             return 400
 
         if not self.last_time:
-            xbmc.log("Unable to synchronise progress with Arte TV for {pid}.".format(pid=self.program_id), level=xbmc.LOGWARNING)
+            xbmc.log(f"Unable to synchronise progress with Arte TV for {self.program_id}.",
+                     level=xbmc.LOGWARNING)
             xbmc.log("Missing time to synch", level=xbmc.LOGWARNING)
             return 400
 
@@ -65,5 +81,7 @@ class Player(xbmc.Player):
             self.plugin,
             self.settings.username, self.settings.password,
             self.program_id, self.last_time)
-        xbmc.log("Synchronisation of progress {t}s with Arte TV for {pid} ended with {status}".format(t=self.last_time, pid=self.program_id, status=status), level=xbmc.LOGINFO)
+        xbmc.log(f"Synchronisation of progress {self.last_time}s with Arte TV " +
+                 f"for {self.program_id} ended with {status}",
+                 level=xbmc.LOGINFO)
         return status

--- a/plugin.video.arteplussept/resources/lib/settings.py
+++ b/plugin.video.arteplussept/resources/lib/settings.py
@@ -1,9 +1,11 @@
-
+"""Add-on settings"""
 languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
 qualities = ['SQ', 'EQ', 'HQ']
 
 
 class Settings:
+    # pylint: disable=too-few-public-methods
+    """Add-on settings"""
     def __init__(self, plugin):
         # Language used to query arte api
         # defaults to fr

--- a/plugin.video.arteplussept/resources/lib/utils.py
+++ b/plugin.video.arteplussept/resources/lib/utils.py
@@ -1,70 +1,78 @@
+"""Utility methods mainly to format strings and manipulate date"""
 import datetime
-import dateutil.parser
-from xbmcswift2 import xbmc
 import html
 import urllib.parse
+# pylint: disable=import-error
+import dateutil.parser
+# pylint: disable=import-error
+from xbmcswift2 import xbmc
 
 
 def format_live_title_and_subtitle(title, subtitle=None):
-    label = u'[COLOR ffffa500]LIVE[/COLOR] - '
-    label += format_title_and_subtitle(title, subtitle)
-    return label
+    """Orange prefix LIVE for live stream"""
+    return f"[COLOR ffffa500]LIVE[/COLOR] - {format_title_and_subtitle(title, subtitle)}"
 
 def colorize(text, color):
     """
-    color: a hex color string (RRGGBB or #RRGGBB) or None
+    Wrap text to be display with color
+    :param str text: text to colorize
+    :param str color: a hex color string (RRGGBB or #RRGGBB) or None
     """
     if not color:
         return text
     if color.startswith('#'):
         color = color[1:]
-    return '[COLOR ff' + color + ']' + text + '[/COLOR]'
+    return f"[COLOR ff{color}]{text}[/COLOR]"
 
 
 def format_title_and_subtitle(title, subtitle=None):
-    label = u'[B]{title}[/B]'.format(title=html.unescape(title))
+    """Build string for menu entry thanks to title and optionally subtitle"""
+    label = f"[B]{html.unescape(title)}[/B]"
     # suffixes
     if subtitle:
-        label += u' - {subtitle}'.format(subtitle=html.unescape(subtitle))
+        label += f" - {html.unescape(subtitle)}"
     return label
 
 
-def encode_string(str):
-    return urllib.parse.quote_plus(str, encoding='utf-8', errors='replace')
+def encode_string(string):
+    """Return escaped string to be used as URL. More details in
+    https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus"""
+    return urllib.parse.quote_plus(string, encoding='utf-8', errors='replace')
 
 
-def decode_string(str):
-    return urllib.parse.unquote_plus(str, encoding='utf-8', errors='replace')
+def decode_string(string):
+    """Return unescaped string to be human readable. More details in
+    https://docs.python.org/3/library/urllib.parse.html#urllib.parse.unquote_plus"""
+    return urllib.parse.unquote_plus(string, encoding='utf-8', errors='replace')
 
 
-def parse_date(datestr):
+def parse_date_hbbtv(datestr):
+    """Try to parse ``datestr`` into a ``datetime`` object. Return ``None`` if parsing fails.
+    Similar to parse_date_artetv."""
     date = None
     try:
         date = dateutil.parser.parse(datestr)
-    except dateutil.parser.ParserError as e:
-        logmsg = "[{addon_id}] Problem with parsing date: {error}".format(addon_id="plugin.video.arteplussept", error=e)
-        xbmc.log(msg=logmsg, level=xbmc.LOGWARNING)
+    except dateutil.parser.ParserError as error:
+        xbmc.log(f"[plugin.video.arteplussept] Problem with parsing date: {error}",
+                 level=xbmc.LOGWARNING)
     return date
 
 
-def parse_artetv_date(datestr):
+def parse_date_artetv(datestr):
+    """Try to parse ``datestr`` into a ``datetime`` object like 2022-07-01T03:00:00Z for instance.
+     Return ``None`` if parsing fails.
+     Similar to ``parse_date_hbbtv``"""
     date = None
     try:
-        date = datetime.datetime.strptime(datestr, '%Y-%m-%dT%H:%M:%S%z') # 2022-07-01T03:00:00Z
+        date = datetime.datetime.strptime(datestr, '%Y-%m-%dT%H:%M:%S%z')
     except TypeError:
         date = None
     return date
 
 
-def past_week():
-    today = datetime.date.today()
-    one_day = datetime.timedelta(days=1)
-
-    for i in range(0, 8):  # TODO: find better interval
-        yield today - (one_day * i)
-
 def is_playlist(program_id):
-    is_playlist = False
+    """Return True if program_id is a str starting with PL- or RC-."""
+    is_playlist_var = False
     if isinstance(program_id, str):
-        is_playlist = program_id.startswith('RC-') or program_id.startswith('PL-')
-    return is_playlist
+        is_playlist_var = program_id.startswith('RC-') or program_id.startswith('PL-')
+    return is_playlist_var

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -1,22 +1,28 @@
+"""Manage views like home menu, dynamic menus, search, favorites..."""
+# pylint: disable=import-error
 from xbmcswift2 import xbmc
 
 from . import api
 from . import mapper
-from . import hof
-from . import utils
 
-def build_home_page(plugin, cached_categories, settings):
+
+def build_home_page(cached_categories, settings):
+    """Display home menu based on fixed entries and then content from API home page"""
     addon_menu = [
         mapper.create_search_item(),
     ]
     try:
         live_stream_data = api.program_video(settings.language, 'LIVE')
-        live_stream_item = mapper.map_live_video(live_stream_data, settings.quality, '1')
+        live_stream_item = mapper.map_live_video(
+            live_stream_data, settings.quality, '1')
         addon_menu.append(live_stream_item)
-    except:
-        xbmc.log("Unable to build live stream item with lang:{ln} quality:{qlt}".format(ln=settings.language, qlt=settings.quality))
+    # pylint: disable=broad-exception-caught
+    # Could be improve. possible exceptions are limited to auth. errors
+    except Exception:
+        xbmc.log("Unable to build live stream item with " +
+                 f"lang:{settings.language} quality:{settings.quality}")
 
-    arte_home = api.page(settings.language)
+    arte_home = api.page_content(settings.language)
     for zone in arte_home.get('zones'):
         menu_item = mapper.map_zone_to_item(zone, cached_categories)
         if menu_item:
@@ -24,47 +30,31 @@ def build_home_page(plugin, cached_categories, settings):
     return addon_menu
 
 
-def build_categories(plugin, cached_categories, settings):
-    categories = [
-        mapper.create_search_item(),
-        mapper.map_live_video(api.program_video(settings.language, 'LIVE'), settings.quality, '1'),
-        mapper.create_favorites_item(),
-        mapper.create_last_viewed_item(),
-        mapper.create_newest_item(),
-        mapper.create_most_viewed_item(),
-        mapper.create_last_chance_item(),
-    ]
-    categories.extend(mapper.map_categories(
-        api.categories(settings.language), settings.show_video_streams, cached_categories))
-    # categories.append(mapper.create_creative_item())
-    categories.append(mapper.create_magazines_item())
-    categories.append(mapper.create_week_item())
-    return categories
-
-
 def build_api_category(category_code, settings):
+    """Build the menu for a category that needs an api call"""
     category = [mapper.map_category_item(item, category_code) for item in
-            api.category(category_code, settings.language)]
+                api.category(category_code, settings.language)]
 
     return category
 
 
 def get_cached_category(category_title, most_viewed_categories):
+    """Return the menu for a category that is stored
+    in cache from previous api call like home page"""
     return most_viewed_categories[category_title]
 
 
-def build_magazines(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            api.magazines(settings.language)]
-
-
 def build_favorites(plugin, settings):
+    """Build the menu for user favorites thanks to API call"""
     return [mapper.map_artetv_video(item) for item in
             api.get_favorites(plugin, settings.language, settings.username, settings.password) or
             # display an empty list in case of error. error should be display in a notification
             []]
 
+
 def add_favorite(plugin, usr, pwd, program_id, label):
+    """Add content program_id to user favorites.
+    Notify about completion success or failure with label."""
     if 200 == api.add_favorite(plugin, usr, pwd, program_id):
         msg = plugin.addon.getLocalizedString(30025).format(label=label)
         plugin.notify(msg=msg, image='info')
@@ -72,7 +62,10 @@ def add_favorite(plugin, usr, pwd, program_id, label):
         msg = plugin.addon.getLocalizedString(30026).format(label=label)
         plugin.notify(msg=msg, image='error')
 
+
 def remove_favorite(plugin, usr, pwd, program_id, label):
+    """Remove content program_id from user favorites.
+    Notify about completion success or failure with label."""
     if 200 == api.remove_favorite(plugin, usr, pwd, program_id):
         msg = plugin.addon.getLocalizedString(30027).format(label=label)
         plugin.notify(msg=msg, image='info')
@@ -82,55 +75,29 @@ def remove_favorite(plugin, usr, pwd, program_id, label):
 
 
 def build_last_viewed(plugin, settings):
+    """Build the menu of user history"""
     return [mapper.map_artetv_video(item) for item in
             api.get_last_viewed(plugin, settings.language, settings.username, settings.password) or
             # display an empty list in case of error. error should be display in a notification
             []]
 
+
 def purge_last_viewed(plugin, usr, pwd):
+    """Flush user history and notify about success or failure"""
     if 200 == api.purge_last_viewed(plugin, usr, pwd):
         plugin.notify(msg=plugin.addon.getLocalizedString(30031), image='info')
     else:
         plugin.notify(msg=plugin.addon.getLocalizedString(30032), image='error')
 
 
-
-def build_newest(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            api.home_category('mostRecent', settings.language)]
-
-
-def build_most_viewed(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            api.home_category('mostViewed', settings.language)]
-
-
-def build_last_chance(settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            api.home_category('lastChance', settings.language)]
-
-
-def build_sub_category_by_code(sub_category_code, settings):
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            api.subcategory(sub_category_code, settings.language)]
-
-
-def build_sub_category_by_title(category_code, sub_category_title, settings):
-    category = api.category(category_code, settings.language)
-    unquoted_title = utils.decode_string(sub_category_title)
-
-    sub_category = hof.find(lambda i: i.get('title') == unquoted_title, category)
-
-    return [mapper.map_generic_item(item, settings.show_video_streams) for item in
-            sub_category.get('teasers')]
-
-
 def build_mixed_collection(kind, collection_id, settings):
+    """Build menu of content available in collection collection_id thanks to HBB TV API"""
     return [mapper.map_generic_item(item, settings.show_video_streams) for item in
             api.collection(kind, collection_id, settings.language)]
 
 
 def build_video_streams(program_id, settings):
+    """Build the menu with the audio streams available for content program_id"""
     item = api.video(program_id, settings.language)
 
     if item is None:
@@ -139,57 +106,45 @@ def build_video_streams(program_id, settings):
     program_id = item.get('programId')
     kind = item.get('kind')
 
-    return mapper.map_streams(item, api.streams(kind, program_id, settings.language), settings.quality)
+    return mapper.map_streams(
+        item, api.streams(kind, program_id, settings.language), settings.quality)
 
 
 def build_stream_url(plugin, kind, program_id, audio_slot, settings):
+    """Return URL to stream content"""
+    # first try with content
     program_stream = api.streams(kind, program_id, settings.language)
-    if not program_stream:
-        msg = plugin.addon.getLocalizedString(30029)
-        plugin.notify(msg=msg.format(strm=program_id, ln=settings.language), image='error')
-    else:
+    if program_stream:
         return mapper.map_playable(program_stream, settings.quality, audio_slot, mapper.match_hbbtv)
+    # second try to fallback clip. It allows to display a trailer,
+    # when a documentary is not available anymore like on arte tv website
+    clip_stream = api.streams('CLIP', program_id, settings.language)
+    if clip_stream:
+        return mapper.map_playable(clip_stream, settings.quality, audio_slot, mapper.match_hbbtv)
+    # otherwise raise the error
+    msg = plugin.addon.getLocalizedString(30029)
+    plugin.notify(msg=msg.format(strm=program_id, ln=settings.language), image='error')
+    return None
 
-
-_useless_kinds = ['CLIP', 'MANUAL_CLIP', 'TRAILER']
-
-
-def build_weekly(settings):
-    programs = hof.flatten([api.daily(date, settings.language)
-                            for date in utils.past_week()])
-
-    def keep_video_item(item):
-        video = hof.get_property(item, 'video')
-
-        if video is None:
-            return False
-        return hof.get_property(item, 'kind') not in _useless_kinds
-
-    videos_filtered = [hof.get_property(item, 'video')
-                       for item in programs if keep_video_item(item)]
-
-    videos_mapped = [mapper.map_generic_item(
-        item, settings.show_video_streams) for item in videos_filtered]
-    videos_mapped.sort(key=lambda item: hof.get_property(
-        item, 'info.aired'), reverse=True)
-
-    return videos_mapped
 
 def search(plugin, settings):
+    """Display the keyboard to search for content. Then, display the menu of search results.
+    Do not display an empty, if search is aborted or search for empty string"""
     query = get_search_query(plugin)
     if not query:
         plugin.end_of_directory(succeeded=False)
     return mapper.map_cached_categories(
         api.search(settings.language, query))
 
+
 def get_search_query(plugin):
-    searchStr = ''
-    keyboard = xbmc.Keyboard(searchStr, plugin.addon.getLocalizedString(30012))
+    """Display the keyboard to enter the search query and return it"""
+    search_query = ''
+    keyboard = xbmc.Keyboard(search_query, plugin.addon.getLocalizedString(30012))
     keyboard.doModal()
-    if False == keyboard.isConfirmed():
-        return
-    searchStr = keyboard.getText()
-    if len(searchStr) == 0:
-        return
-    else:
-        return searchStr
+    if keyboard.isConfirmed() is False:
+        return None
+    search_query = keyboard.getText()
+    if len(search_query) == 0:
+        return None
+    return search_query


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.1.9
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:


        Highlights since 1.1.2
        - Improve security and performance by caching token to limit authentication requests
        - Fallback on clip, when stream is not available anymore.
        - Clean-up and lint code
        - Add CI with Pylint and Kodi addon submitter
        - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
        - Move from HBB TV to Arte TV API.
        - Fixed playback progress / resume point retrieved from Arte TV
        - Added synchronisation of playback progress with Arte TV when video playback paused, stopped or crashed
        - Manage favorites in Arte profile from context menu
        - Added Search in root menu
        - Added Live stream in root menu
        - Added purge of my history
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
