### PR TITLE
[plugin.video.mlbtv@matrix] 2023.4.14+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.3.28+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.4.14+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -25,6 +25,8 @@
             - fixed bug on stream select for games without video
             - fixed data source for game changer
             - use full team names for non-MLB teams
+            - added MiLB (minor league) games
+            - added country setting for better labeling international blackouts
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -16,6 +16,7 @@ icon = None
 fanart = None
 featured_video = None
 description = None
+sport = MLB_ID
 
 if 'name' in params:
     name = urllib.unquote_plus(params["name"])
@@ -59,6 +60,9 @@ if 'featured_video' in params:
 if 'description' in params:
     description = urllib.unquote_plus(params["description"])
 
+if 'sport' in params:
+    sport = urllib.unquote_plus(params["sport"])
+
 # default addon home screen
 if mode is None:
     # autoplay fav team, if that setting is enabled and a live broadcast is in progress
@@ -73,11 +77,11 @@ if mode is None:
 
 # Today's Games
 elif mode == 100:
-    todays_games(None, start_inning)
+    todays_games(None, start_inning, sport)
 
 # Prev and Next
 elif mode == 101:
-    todays_games(game_day, start_inning)
+    todays_games(game_day, start_inning, sport)
 
 # autoplay, use an extra parameter to force auto stream selection
 elif mode == 102:
@@ -117,6 +121,10 @@ elif mode == 108:
     game_day = yesterdays_date()
     # Refresh will erase history, so navigating back won't bring up the inning prompt again
     xbmc.executebuiltin('Container.Refresh("plugin://plugin.video.mlbtv/?mode=101&game_day='+game_day+'&start_inning='+str(start_inning)+'")')
+
+# MiLB Games
+elif mode == 109:
+    todays_games(None, start_inning, "11,12,13,14,16")
 
 # Goto Date
 elif mode == 200:

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -321,7 +321,7 @@ msgid "Watch in YouTube Add-on"
 msgstr ""
 
 msgctxt "#30415"
-msgid "Zip code (5 digits, for blackout labels)"
+msgid "USA Zip code (5 digits, for blackout labels)"
 msgstr ""
 
 msgctxt "#30416"
@@ -364,4 +364,15 @@ msgctxt "#30425"
 msgid "Skip adjust end (seconds)"
 msgstr ""
 
+msgctxt "#30426"
+msgid "Minor League Games"
+msgstr ""
+
+msgctxt "#30427"
+msgid "Include favorite team's affiliates"
+msgstr ""
+
+msgctxt "#30428"
+msgid "Country (for blackout labels)"
+msgstr ""
 

--- a/plugin.video.mlbtv/resources/lib/account.py
+++ b/plugin.video.mlbtv/resources/lib/account.py
@@ -60,8 +60,9 @@ class Account:
             r = requests.post(url, headers=headers, data=payload, verify=self.verify)
             if r.ok:
                 login_token = r.json()['access_token']
+                login_token_expiry = datetime.now() + timedelta(seconds=int(r.json()['expires_in']))
                 self.addon.setSetting('login_token', login_token)
-                self.addon.setSetting('last_login', str(time.time()))
+                self.addon.setSetting('login_token_expiry', str(login_token_expiry))
             else:
                 dialog = xbmcgui.Dialog()
                 msg = LOCAL_STRING(30263)
@@ -69,173 +70,35 @@ class Account:
                     msg = r.json()['error_description']
                 dialog.notification(LOCAL_STRING(30262), msg, ICON, 5000, False)
                 self.addon.setSetting('login_token', '')
-                self.addon.setSetting('last_login', '')
+                self.addon.setSetting('login_token_expiry', '')
                 sys.exit()
 
 
     def logout(self):
         self.util.delete_cookies()
         self.addon.setSetting('login_token', '')
-        self.addon.setSetting('last_login', '')
+        self.addon.setSetting('login_token_expiry', '')
         self.addon.setSetting('username', '')
         self.addon.setSetting('password', '')
-        self.addon.setSetting('okta_client_id', '')
-        self.addon.setSetting('session_token', '')
-        self.addon.setSetting('okta_access_token', '')
-        self.addon.setSetting('okta_access_token_expiry', '')
 
     def media_entitlement(self):
-        if self.addon.getSetting('last_login') == '' or \
-                (time.time() - float(self.addon.getSetting('last_login')) >= 86400):
-            self.login()
-
         url = 'https://media-entitlement.mlb.com/api/v3/jwt?os=Android&appname=AtBat&did=' + self.device_id()
         headers = {'User-Agent': UA_ANDROID,
-                   'Authorization': 'Bearer ' + self.addon.getSetting('login_token')
+                   'Authorization': 'Bearer ' + self.login_token()
                    }
 
         r = requests.get(url, headers=headers, verify=self.verify)
 
         return r.text
 
-    # the okta client id is used to get an okta access token (for featured videos like Big Inning)
-    # doesn't change, can be cached until logout
-    def okta_client_id(self):
-        if self.addon.getSetting('okta_client_id') == '':
-            xbmc.log('fetching okta_client_id')
-            url = 'https://www.mlbstatic.com/mlb.com/vendor/mlb-okta/mlb-okta.js'
-            headers = {
-                'User-Agent': UA_PC,
-                'Origin': 'https://www.mlb.com'
-            }
-
-            r = requests.get(url, headers=headers, verify=self.verify)
-            e = re.search('production:{clientId:"([^"]+)",', r.text)
-            if e:
-                xbmc.log('found okta_client_id')
-                okta_client_id = e.group(1)
-                xbmc.log('okta_client_id: ' + okta_client_id)
-                self.addon.setSetting(id='okta_client_id', value=okta_client_id)
-                return okta_client_id
-        else:
-            return self.addon.getSetting('okta_client_id')
-
-    # the session token is used to get an okta access token (for featured videos like Big Inning)
-    # doesn't change much, can be cached until logout or until reset by okta_access_token function as needed
-    def session_token(self):
-        xbmc.log('requesting new session_token')
-
-        # Check if username and password are provided
-        if self.username == '':
-            dialog = xbmcgui.Dialog()
-            self.username = dialog.input(LOCAL_STRING(30240), type=xbmcgui.INPUT_ALPHANUM)
-            self.addon.setSetting(id='username', value=self.username)
-
-        if self.password == '':
-            dialog = xbmcgui.Dialog()
-            self.password = dialog.input(LOCAL_STRING(30250), type=xbmcgui.INPUT_ALPHANUM,
-                                    option=xbmcgui.ALPHANUM_HIDE_INPUT)
-            self.addon.setSetting(id='password', value=self.password)
-
-        if self.username == '' or self.password == '':
-            sys.exit()
-        else:
-            url = 'https://ids.mlb.com/api/v1/authn'
-            headers = {
-                'User-Agent': UA_PC,
-                'Accept-Encoding': 'identity',
-                'Content-Type': 'application/json'
-            }
-            data = {
-              'username': self.username,
-              'password': self.password,
-              'options': {
-                'multiOptionalFactorEnroll': False,
-                'warnBeforePasswordExpired': True
-              }
-            }
-            r = requests.post(url, headers=headers, json=data, verify=self.verify)
-            xbmc.log(r.text)
-            if 'sessionToken' in r.json():
-                xbmc.log('found session_token')
-                session_token = r.json()['sessionToken']
-                self.addon.setSetting(id='session_token', value=session_token)
-
-    # generate a random string of specified length, using numbers and uppercase letters
-    # used for two variables in okta access token request
-    def get_random_string(self, length):
-        characters = string.ascii_uppercase + string.digits
-        result_str = ''.join(random.choice(characters) for i in range(length))
-        return result_str
-
-    # the okta access token is used to access featured videos like Big Inning
-    # can be cached until the specified expiry
-    def okta_access_token(self, retry=False):
-        # log in first, if needed
-        if self.addon.getSetting('last_login') == '' or \
-                (time.time() - float(self.addon.getSetting('last_login')) >= 86400):
+    # need to login to access featured videos like Big Inning and MiLB games
+    def login_token(self):
+        if self.addon.getSetting('login_token_expiry') == '' or \
+                parse(self.addon.getSetting('login_token_expiry')) < datetime.now():
             self.login()
-        # check if we don't have it cached, or the cache has expired
-        if self.addon.getSetting('okta_access_token') == '' or \
-                parse(self.addon.getSetting('okta_access_token_expiry')) < datetime.now():
-            xbmc.log('okta access token not set or expired')
-            # check if we have a cached session token (shouldn't expire often)
-            if self.addon.getSetting('session_token') == '':
-                self.session_token()
 
-            url = 'https://ids.mlb.com/oauth2/aus1m088yK07noBfh356/v1/authorize'
-            xbmc.log('url : ' + url)
-            headers = {
-                'User-Agent': UA_PC,
-                'accept-encoding': 'identity'
-            }
-            data = {
-                'client_id': self.okta_client_id(),
-                'redirect_uri': 'https://www.mlb.com/login',
-                'response_type': 'id_token token',
-                'response_mode': 'okta_post_message',
-                'state': self.get_random_string(64),
-                'nonce': self.get_random_string(64),
-                'prompt': 'none',
-                'sessionToken': self.addon.getSetting('session_token'),
-                'scope': 'openid email'
-            }
-            r = requests.get(url, headers=headers, params=data, verify=self.verify)
-            # check if the response indicates we need a new session token
-            e = re.search("data.error = 'login_required'", r.text)
-            if e:
-                # if this is our second try, and we're still getting this error, just abort
-                if retry == True:
-                    xbmc.log('log in error, aborting')
-                    sys.exit()
-                else:
-                    xbmc.log('not logged in, trying again')
-                    self.addon.setSetting(id='session_token', value='')
-                    okta_access_token = self.okta_access_token(True)
-            else:
-                xbmc.log('logged in')
-                e = re.search("data.access_token = '([^']+)'", r.text)
-                if e:
-                    xbmc.log('found token')
-                    # new token response likely contains a hyphen that needs to be decoded/un-escaped
-                    okta_access_token = e.group(1).replace('\\x2D', '-')
-                    xbmc.log('token result: ' + okta_access_token)
-                    self.addon.setSetting(id='okta_access_token', value=okta_access_token)
-                    # default token expiry is 86400 seconds (24 hours)
-                    okta_access_token_expires_in = '86400'
-                    e = re.search("data.expires_in = '([^']+)'", r.text)
-                    if e:
-                        xbmc.log('found expiry')
-                        okta_access_token_expires_in = e.group(1)
-                        xbmc.log('expires in: ' + okta_access_token_expires_in)
-                    okta_access_token_expiry = datetime.now() + timedelta(seconds=int(okta_access_token_expires_in))
-                    xbmc.log('expiry: ' + str(okta_access_token_expiry))
-                    self.addon.setSetting(id='okta_access_token_expiry', value=str(okta_access_token_expiry))
-        else:
-            # cached token response likely contains a hyphen that needs to be decoded/un-escaped
-            okta_access_token = self.addon.getSetting('okta_access_token').replace('\\x2D', '-')
+        return self.addon.getSetting('login_token')
 
-        return okta_access_token
 
     def access_token(self):
         url = 'https://us.edge.bamgrid.com/token'

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -44,6 +44,7 @@ CDN = str(settings.getSetting(id="cdn"))
 NO_SPOILERS = settings.getSetting(id="no_spoilers")
 DISABLE_VIDEO_PADDING = str(settings.getSetting(id='disable_video_padding'))
 FAV_TEAM = str(settings.getSetting(id="fav_team"))
+INCLUDE_FAV_AFFILIATES = str(settings.getSetting(id='include_fav_affiliates'))
 TEAM_NAMES = settings.getSetting(id="team_names")
 TIME_FORMAT = settings.getSetting(id="time_format")
 SINGLE_TEAM = str(settings.getSetting(id='single_team'))
@@ -99,7 +100,15 @@ VERIFY = True
 
 SECONDS_PER_SEGMENT = 5
 
-def find(source,start_str,end_str):    
+MLB_ID = '1'
+MILB_IDS = '11,12,13,14'
+MLB_TEAM_IDS = '108,109,110,111,112,113,114,115,116,117,118,119,120,121,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,158,159,160'
+
+AFFILIATE_TEAM_IDS = {"Los Angeles Angels":"401,559,460,561","Arizona Diamondbacks":"419,516,2310,5368","Baltimore Orioles":"418,568,548,488","Boston Red Sox":"428,414,533,546","Chicago Cubs":"521,451,550,553","Cincinnati Reds":"450,459,498,416","Cleveland Guardians":"445,402,437,481","Colorado Rockies":"259,486,342,538","Detroit Tigers":"512,570,582,106","Houston Astros":"482,5434,573,3712","Kansas City Royals":"1350,3705,541,565","Los Angeles Dodgers":"260,238,456,526","Washington Nationals":"436,534,547,426","New York Mets":"453,507,552,505","Oakland Athletics":"237,499,400,524","Pittsburgh Pirates":"3390,484,452,477","San Diego Padres":"103,510,584,4904","Seattle Mariners":"403,515,529,574","San Francisco Giants":"105,461,476,3410","St. Louis Cardinals":"279,235,440,443","Tampa Bay Rays":"2498,233,234,421","Texas Rangers":"102,485,540,448","Toronto Blue Jays":"424,435,463,422","Minnesota Twins":"492,509,1960,3898","Philadelphia Phillies":"427,522,1410,566","Atlanta Braves":"430,432,478,431","Chicago White Sox":"247,580,487,494","Miami Marlins":"479,564,554,4124","New York Yankees":"1956,587,531,537","Milwaukee Brewers":"249,572,556,5015"}
+
+ESPN_SUNDAY_NIGHT_BLACKOUT_COUNTRIES = ["Angola", "Anguilla", "Antigua and Barbuda", "Argentina", "Aruba", "Australia", "Bahamas", "Barbados", "Belize", "Belize", "Benin", "Bermuda", "Bolivia", "Bonaire", "Botswana", "Brazil", "British Virgin Islands", "Burkina Faso", "Burundi", "Cameroon", "Cape Verde", "Cayman Islands", "Central African Republic", "Chad", "Chile", "Colombia", "Comoros", "Cook Islands", "Costa Rica", "Cote d'Ivoire", "Curacao", "Democratic Republic of the Congo", "Djibouti", "Dominica", "Dominican Republic", "Ecuador", "El Salvador", "England", "Equatorial Guinea", "Eritrea", "Eswatini", "Ethiopia", "Falkland Islands", "Falkland Islands", "Fiji", "French Guiana", "French Guiana", "French Polynesia", "Gabon", "Ghana", "Grenada", "Guadeloupe", "Guatemala", "Guinea", "Guinea Bissau", "Guyana", "Guyana", "Haiti", "Honduras", "Ireland", "Jamaica", "Kenya", "Kiribati", "Lesotho", "Liberia", "Madagascar", "Malawi", "Mali", "Marshall Islands", "Martinique", "Mayotte", "Mexico", "Micronesia", "Montserrat", "Mozambique", "Namibia", "Netherlands", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Northern Ireland", "Palau Islands", "Panama", "Paraguay", "Peru", "Republic of Ireland", "Reunion", "Rwanda", "Saba", "Saint Maarten", "Samoa", "Sao Tome & Principe", "Scotland", "Senegal", "Seychelles", "Sierra Leone", "Solomon Islands", "Somalia", "South Africa", "St. Barthelemy", "St. Eustatius", "St. Kitts and Nevis", "St. Lucia", "St. Martin", "St. Vincent and the Grenadines", "Sudan", "Surinam", "Suriname", "Tahiti", "Tanzania & Zanzibar", "The Gambia", "The Republic of Congo", "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Uruguay", "Venezuela", "Wales", "Zambia", "Zimbabwe"]
+
+def find(source,start_str,end_str):
     start = source.find(start_str)
     end = source.find(end_str,start+len(start_str))
 
@@ -204,13 +213,18 @@ def get_params():
     return param
 
 
-def add_stream(name, title, desc, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler='True', suspended=None, start_inning='False', blackout='False'):
+def add_stream(name, title, desc, game_pk, icon=None, fanart=None, info=None, video_info=None, audio_info=None, stream_date=None, spoiler='True', suspended=None, start_inning='False', blackout='False', milb=None):
     ok=True
-    u_params = "&name="+urllib.quote_plus(title)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))+"&suspended="+urllib.quote_plus(str(suspended))+"&start_inning="+urllib.quote_plus(str(start_inning))+"&description="+urllib.quote_plus(desc)+"&blackout="+urllib.quote_plus(str(blackout))
-    if icon is None: icon = ICON
-    if fanart is None: fanart = FANART
-    art_params = "&icon="+urllib.quote_plus(icon)+"&fanart="+urllib.quote_plus(fanart)
-    u=sys.argv[0]+"?mode="+str(104)+u_params+art_params
+
+    if milb is not None:
+        u_params = "&featured_video="+urllib.quote_plus("https://dai.tv.milb.com/api/v2/playback-info/games/"+str(game_pk)+"/contents/14862/products/milb-carousel")+"&name="+urllib.quote_plus(title)+"&description="+urllib.quote_plus(desc)
+        u=sys.argv[0]+"?mode="+str(301)+u_params
+    else:
+        u_params = "&name="+urllib.quote_plus(title)+"&game_pk="+urllib.quote_plus(str(game_pk))+"&stream_date="+urllib.quote_plus(str(stream_date))+"&spoiler="+urllib.quote_plus(str(spoiler))+"&suspended="+urllib.quote_plus(str(suspended))+"&start_inning="+urllib.quote_plus(str(start_inning))+"&description="+urllib.quote_plus(desc)+"&blackout="+urllib.quote_plus(str(blackout))
+        if icon is None: icon = ICON
+        if fanart is None: fanart = FANART
+        art_params = "&icon="+urllib.quote_plus(icon)+"&fanart="+urllib.quote_plus(fanart)
+        u=sys.argv[0]+"?mode="+str(104)+u_params+art_params
 
     liz=xbmcgui.ListItem(name)
     liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
@@ -224,7 +238,8 @@ def add_stream(name, title, desc, game_pk, icon=None, fanart=None, info=None, vi
         liz.addStreamInfo('audio', audio_info)
 
     # add Choose Stream and Highlights as context menu items
-    liz.addContextMenuItems([(LOCAL_STRING(30390), 'PlayMedia(plugin://plugin.video.mlbtv/?mode='+str(103)+u_params+art_params+')'), (LOCAL_STRING(30391), 'Container.Update(plugin://plugin.video.mlbtv/?mode='+str(106)+'&name='+urllib.quote_plus(title)+'&game_pk='+urllib.quote_plus(str(game_pk))+art_params+')')])
+    if milb is None:
+        liz.addContextMenuItems([(LOCAL_STRING(30390), 'PlayMedia(plugin://plugin.video.mlbtv/?mode='+str(103)+u_params+art_params+')'), (LOCAL_STRING(30391), 'Container.Update(plugin://plugin.video.mlbtv/?mode='+str(106)+'&name='+urllib.quote_plus(title)+'&game_pk='+urllib.quote_plus(str(game_pk))+art_params+')')])
 
     ok=xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]),url=u,listitem=liz,isFolder=False)
     xbmcplugin.setContent(addon_handle, 'episodes')
@@ -259,10 +274,10 @@ def addLink(name,url,title,icon,info=None,video_info=None,audio_info=None,fanart
     return ok
 
 
-def addDir(name,mode,icon,fanart=None,game_day=None,start_inning='False'):
+def addDir(name,mode,icon,fanart=None,game_day=None,start_inning='False',sport=MLB_ID):
     ok=True
 
-    u_params="&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)+'&start_inning='+urllib.quote_plus(str(start_inning))
+    u_params="&name="+urllib.quote_plus(name)+"&icon="+urllib.quote_plus(icon)+'&start_inning='+urllib.quote_plus(str(start_inning))+'&sport='+urllib.quote_plus(str(sport))
     if game_day is not None:
         u_params = u_params+"&game_day="+urllib.quote_plus(game_day)
     u=sys.argv[0]+"?mode="+str(mode)+u_params
@@ -491,7 +506,7 @@ def get_last_name(full_name):
 # get the teams blacked out based on zip code
 def get_blackout_teams(zip_code):
     xbmc.log('Resetting blackout teams')
-    blackout_teams = []
+    found_blackout_teams = []
     try:
         if re.match('^[0-9]{5}$', zip_code):
             xbmc.log('Fetching new blackout teams')
@@ -501,21 +516,30 @@ def get_blackout_teams(zip_code):
                 'Origin': 'https://www.mlb.com',
                 'Referer': 'https://www.mlb.com/'
             }
-            r = requests.get(url, headers=headers, verify=VERIFY)
+            # set verify to False here to avoid a Python request error "unable to get local issuer certificate"
+            r = requests.get(url, headers=headers, verify=False)
             json_source = r.json()
             if 'teams' in json_source:
-                blackout_teams = json_source['teams']
+                found_blackout_teams = json_source['teams']
     except:
         pass
 
-    return blackout_teams
+    return found_blackout_teams
 
-
+COUNTRY = str(settings.getSetting(id='country'))
+OLD_COUNTRY = str(settings.getSetting(id='old_country'))
 ZIP_CODE = str(settings.getSetting(id='zip_code'))
 OLD_ZIP_CODE = str(settings.getSetting(id='old_zip_code'))
-if ZIP_CODE != OLD_ZIP_CODE:
-    settings.setSetting(id='old_zip_code', value=ZIP_CODE)
-    BLACKOUT_TEAMS = get_blackout_teams(ZIP_CODE)
-    settings.setSetting(id='blackout_teams', value=json.dumps(BLACKOUT_TEAMS))
+BLACKOUT_TEAMS = json.loads(str(settings.getSetting(id='blackout_teams')))
+if COUNTRY == 'Canada':
+    BLACKOUT_TEAMS = ['TOR']
+elif COUNTRY == 'USA':
+    if ZIP_CODE != OLD_ZIP_CODE or COUNTRY != OLD_COUNTRY:
+        BLACKOUT_TEAMS = get_blackout_teams(ZIP_CODE)
 else:
-    BLACKOUT_TEAMS = json.loads(str(settings.getSetting(id='blackout_teams')))
+    BLACKOUT_TEAMS = []
+
+settings.setSetting(id='blackout_teams', value=json.dumps(BLACKOUT_TEAMS))
+settings.setSetting(id='old_zip_code', value=ZIP_CODE)
+settings.setSetting(id='old_country', value=COUNTRY)
+

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -6,18 +6,16 @@
     <setting id="password" type="text" label="30150" option="hidden" default=""/>
     <setting id="single_team" type="bool" label="30151" default="false"/>
     <setting id="zip_code" type="number" label="30415" default=""/>
+    <setting id="country" type="labelenum" label="30428" default="USA" values="USA|Angola|Anguilla|Antigua and Barbuda|Argentina|Aruba|Australia|Bahamas|Barbados|Belize|Belize|Benin|Bermuda|Bolivia|Bonaire|Botswana|Brazil|British Virgin Islands|Burkina Faso|Burundi|Canada|Cameroon|Cape Verde|Cayman Islands|Central African Republic|Chad|Chile|Colombia|Comoros|Cook Islands|Costa Rica|Cote d'Ivoire|Curacao|Democratic Republic of the Congo|Djibouti|Dominica|Dominican Republic|Ecuador|El Salvador|England|Equatorial Guinea|Eritrea|Eswatini|Ethiopia|Falkland Islands|Falkland Islands|Fiji|French Guiana|French Guiana|French Polynesia|Gabon|Ghana|Grenada|Guadeloupe|Guatemala|Guinea|Guinea Bissau|Guyana|Guyana|Haiti|Honduras|Ireland|Jamaica|Kenya|Kiribati|Lesotho|Liberia|Madagascar|Malawi|Mali|Marshall Islands|Martinique|Mayotte|Mexico|Micronesia|Montserrat|Mozambique|Namibia|Netherlands|New Zealand|Nicaragua|Niger|Nigeria|Niue|Northern Ireland|Palau Islands|Panama|Paraguay|Peru|Republic of Ireland|Reunion|Rwanda|Saba|Saint Maarten|Samoa|Sao Tome &amp; Principe|Scotland|Senegal|Seychelles|Sierra Leone|Solomon Islands|Somalia|South Africa|St. Barthelemy|St. Eustatius|St. Kitts and Nevis|St. Lucia|St. Martin|St. Vincent and the Grenadines|Sudan|Surinam|Suriname|Tahiti|Tanzania &amp; Zanzibar|The Gambia|The Republic of Congo|Togo|Tokelau|Tonga|Trinidad and Tobago|Turks and Caicos Islands|Tuvalu|Uganda|Uruguay|Venezuela|Wales|Zambia|Zimbabwe|other" />
+    <setting id="old_country" type="text" label="" default="" visible="false"/>
     <setting id="old_zip_code" type="number" label="" default="" visible="false"/>
     <setting id="blackout_teams" type="text" label="" default="[]" visible="false"/>
     <setting label="30156" type="action" action="RunPlugin(plugin://plugin.video.mlbtv/?url=junk&amp;mode=400)" option="close" />
     <!--Hidden-->
     <setting id='session_key' type='text' visible="false" default=''/>
     <setting id='device_id' type='text' visible="false" default=''/>
-    <setting id='last_login' type='text' visible="false" default=''/>
     <setting id='login_token' type='text' visible="false" default=''/>
-    <setting id="session_token" type="text" label="" default="" visible="false"/>
-    <setting id="okta_client_id" type="text" label="" default="" visible="false"/>
-    <setting id="okta_access_token" type="text" label="" default="" visible="false"/>
-    <setting id="okta_access_token_expiry" type="text" label="" default="" visible="false"/>
+    <setting id='login_token_expiry' type='text' visible="false" default=''/>
   </category>
 
   <category label="30159">
@@ -26,6 +24,7 @@
     <setting id="no_spoilers" type="enum" label="30170" lvalues="30171|30172|30173|30174|30175" />
     <setting id="disable_video_padding" type="bool" label="30416" default="false" />
     <setting id="fav_team" type="labelenum" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
+    <setting id="include_fav_affiliates" type="bool" label="30427" default="true" />
 
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
     <setting id="time_format" type="select" label="30301" lvalues="30302|30303" default="0" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2023.4.14+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - fixed bug on stream select for games without video
            - fixed data source for game changer
            - use full team names for non-MLB teams
            - added MiLB (minor league) games
            - added country setting for better labeling international blackouts
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
