### PR TITLE
[plugin.video.arteplussept@matrix] 1.1.10

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.1.10 (2023-5-28)
+- Bugfix to display favorites and last vieweds following id change in Arte
+
 v1.1.9 (2023-4-18)
 - Improve security and performance by caching token to limit authentication requests
 - Fallback on clip, when stream is not available anymore. Same feature as on Arte mobile. For favorite content.

--- a/plugin.video.arteplussept/addon.py
+++ b/plugin.video.arteplussept/addon.py
@@ -119,8 +119,8 @@ def play_live(stream_url):
 @plugin.route('/play/<kind>/<program_id>/<audio_slot>', name='play_specific')
 def play(kind, program_id, audio_slot='1'):
     """Play content identified with program_id.
-    kind is a value of TODO (e.g. TRAILER, COLLECTION, LINK, ...)
-    audio_slot is a numeric
+    :param str kind: an enum in TODO (e.g. TRAILER, COLLECTION, LINK, CLIP, ...)
+    :param str audio_slot: a numeric to identify the audio stream to use e.g. 1 2
     """
     synched_player = Player(plugin, settings, program_id)
     item = view.build_stream_url(plugin, kind, program_id, int(audio_slot), settings)

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.9" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.10" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -10,7 +10,7 @@ from . import hof
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.9'
+    'user-agent': 'plugin.video.arteplussept/1.1.10'
 }
 _HBBTV_ENDPOINTS = {
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
@@ -60,7 +60,7 @@ ARTETV_ENDPOINTS = {
     'login': '/login',
 }
 ARTETV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.9',
+    'user-agent': 'plugin.video.arteplussept/1.1.10',
     # required to use token endpoint
     'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg',
     # required for Arte TV API. values like web, app, tv, orange, free

--- a/plugin.video.arteplussept/resources/lib/mapper.py
+++ b/plugin.video.arteplussept/resources/lib/mapper.py
@@ -139,7 +139,7 @@ def map_artetv_video(item):
     progress = item.get('lastviewed') and item.get('lastviewed').get('progress') or 0
     time_offset = item.get('lastviewed') and item.get('lastviewed').get('timecode') or 0
 
-    if not isinstance(kind, str):
+    if not isinstance(kind, str) and kind is not None:
         kind = kind.get('code')
     if kind == 'EXTERNAL':
         return None
@@ -319,9 +319,9 @@ def map_zone_to_item(zone, cached_categories):
     Populate cached_categories for zones with videos available in child 'content'"""
     menu_item = None
     title = zone.get('title')
-    if zone.get('id') == '9fc57105-847b-49c5-9b4a-f46863754059':
+    if zone.get('id') == 'b1dfd8e0-4757-4236-9dab-6f6331cb5ea4':
         menu_item = create_favorites_item(title)
-    elif zone.get('id') == '67cea6f3-7af0-4ffa-a6c2-59b1da0ecd4b':
+    elif zone.get('id') == '823d6af6-fedd-4b54-8049-ddb7158eee64':
         menu_item = create_last_viewed_item(title)
     elif zone.get('content') and zone.get('content').get('data'):
         cached_category = map_cached_categories(zone)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.1.10
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/known-as-bmf/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/known-as-bmf/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/known-as-bmf/plugin.video.arteplussept
        

### Description of changes:


        Highlights since 1.1.2
        - Improve security and performance by caching token to limit authentication requests
        - Fallback on clip, when stream is not available anymore.
        - Clean-up and lint code
        - Add CI with Pylint and Kodi addon submitter
        - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
        - Move from HBB TV to Arte TV API.
        - Fixed playback progress / resume point retrieved from Arte TV
        - Added synchronisation of playback progress with Arte TV when video playback paused, stopped or crashed
        - Manage favorites in Arte profile from context menu
        - Added Search in root menu
        - Added Live stream in root menu
        - Added purge of my history
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
