### PR TITLE
[plugin.video.retrospect] v5.6.2

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.6.1"
+        version="5.6.2"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -122,23 +122,18 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.6.1 - Changelog - 2023-06-02[/B]
+        <news>[B]Retrospect v5.6.2 - Changelog - 2023-06-03[/B]
 
-This update introduces IPTV Manager support (Thanks to @landgenoot) for NPO Start. Besides this, some minor bugs were squashed.
+Fixed a minor error in the RTL XL code.
 
 [B]Framework related[/B]
-* Added: IPTV Manager support (See #1674).
-* Fixed: Minor logging in issue for NPO.
+_None_
 
 [B]GUI/Settings/Language related[/B]
 _None_
 
 [B]Channel related[/B]
-* Fixed: RTV Drenthe playback.
-* Changed: Switched to the VRT MAX Add-on for now for VRT NU/MAX.
-* Fixed: Kijk.nl subtitle issue with image url&#x27;s instead of text (Fixes #1705).
-* Fixed: RTL XL broke due to API changes.
-* Removed: Nickelodeon.nl as they remove their content.
+* Fixed: RTL Single video entries.
 
         </news>
         <assets>

--- a/plugin.video.retrospect/channels/channel.rtlnl/rtl/chn_rtl.py
+++ b/plugin.video.retrospect/channels/channel.rtlnl/rtl/chn_rtl.py
@@ -156,6 +156,8 @@ class Channel(chn_class.Channel):
             return self.create_video_item(result_set, include_serie_title=True)
         elif item_type == "series":
             return self.create_series_item(result_set)
+        elif item_type == "program":
+            return self.create_program_item(result_set)
 
         Logger.error("Missing API type: %s", item_type)
         return None
@@ -173,6 +175,9 @@ class Channel(chn_class.Channel):
         :rtype: MediaItem|None
 
         """
+
+        if result_set["type"].lower() == "program":
+            return self.create_video_item(result_set)
 
         Logger.trace(result_set)
         serie_info = result_set["series"]


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Fixed a minor error in the RTL XL code.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
