### PR TITLE
[plugin.video.tagesschau] 2.5.3

### DIFF
--- a/plugin.video.tagesschau/addon.xml
+++ b/plugin.video.tagesschau/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
     id="plugin.video.tagesschau"
-    version="2.4.0"
+    version="2.5.3"
     name="Tagesschau"
     provider-name="J.Schumacher, H.Saul, C.Prasch">
   <requires>
@@ -31,6 +31,14 @@
       <screenshot>resources/assets/screenshot_3.png</screenshot>
     </assets>
     <news>
+version 2.5.3 (2023-05-24)
+ * Bugfixes
+ * Added setting for the tagesthemen listing: show broadcasts, topics or both
+
+version 2.5.0 (2023-05-07)
+ * Added listing vor tagesschau 20:00 broadcasts
+ * Added listing vor tagesthemen broadcasts
+
 version 2.4.0 (2023-04-28)
  * Switched to Tagesschau API2 because API1 was disabled by ARD
  * New option to show age of news in title

--- a/plugin.video.tagesschau/libs/tagesschau.py
+++ b/plugin.video.tagesschau/libs/tagesschau.py
@@ -44,7 +44,9 @@ quality = ['M', 'L', 'X'][int(quality_id)]
 language = addon.getLocalizedString
 strings = { 'latest_videos':       language(30100),
             'latest_broadcasts':   language(30101),
-            'livestreams':         language(30102)
+            'livestreams':         language(30102),
+            'tagesschau_20':       language(30104),
+            'tagesthemen':         language(30105)
 }
 
 #-- Subtitles ------------------------------------------------
@@ -72,9 +74,19 @@ def getListItem(videocontent):
     li.setArt({'thumb':image_url})
     li.setProperty('Fanart_Image', FANART)
     li.setProperty('IsPlayable', 'true')
-    li.setInfo(type="Video", infoLabels={ "Title": str(title),
-                                          "Plot": str(videocontent.description),
-                                          "Duration": str((videocontent.duration or 0)/60) })
+    li.setInfo(type="Video",
+               infoLabels={ "Title": str(title),
+                            "Plot": str(videocontent.description),
+                            "Duration": str((videocontent.duration or 0)/60)
+                          }
+              )
+    if( videocontent.timestamp ):
+        li.setInfo(type="Video",
+                   infoLabels={ "premiered": str(videocontent.timestamp.strftime('%d.%m.%Y')),
+                                "aired": str(videocontent.timestamp.strftime('%d.%m.%Y')),
+                                "date": str(videocontent.timestamp.strftime('%d.%m.%Y'))
+                              }
+                  )
 
     return li
 
@@ -90,6 +102,7 @@ def addVideoContentItem(videocontent, method):
 
 def addVideoContentItems(videocontents, method):
     items = []
+    videocontents = sorted(videocontents)
     for videocontent in videocontents:
         li = getListItem(videocontent)
         url = getUrl(videocontent, method)
@@ -109,6 +122,7 @@ def tagesschau():
     # TODO: can't figure out how to set fanart for root/back folder of plugin
     # http://trac.xbmc.org/ticket/8228?
     xbmcplugin.setPluginFanart(int(sys.argv[1]), 'special://home/addons/' + ADDON_ID + '/resources/assets/fanart.jpg')
+    xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_NONE)
 
     params = get_params()
     provider = VideoContentProvider(JsonSource())
@@ -157,5 +171,7 @@ def tagesschau():
         add_named_directory = lambda x: addVideoContentDirectory(strings[x], x)
         add_named_directory('latest_videos')
         add_named_directory('latest_broadcasts')
+        add_named_directory('tagesschau_20')
+        add_named_directory('tagesthemen')
 
     xbmcplugin.endOfDirectory(int(sys.argv[1]))

--- a/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
@@ -24,6 +24,22 @@ msgctxt "#30002"
 msgid "Show age of news in title"
 msgstr "Zeige Alter der Nachricht im Titel"
 
+msgctxt "#30003"
+msgid "Tagesthemen Listing"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Broadcasts only"
+msgstr "Nur ganze Sendungen"
+
+msgctxt "#30005"
+msgid "Topics only"
+msgstr "Nur einzelne Beiträge"
+
+msgctxt "#30006"
+msgid "Broadcasts and Topics"
+msgstr "Sendungen und Beiträge"
+
 msgctxt "#30100"
 msgid "News"
 msgstr "Nachrichten"
@@ -39,3 +55,11 @@ msgstr "Livestream"
 msgctxt "#30103"
 msgid "ago"
 msgstr "Vor"
+
+msgctxt "#30104"
+msgid "Tagesschau 20:00"
+msgstr "Tagesschau 20 Uhr"
+
+msgctxt "#30105"
+msgid "Tagesthemen"
+msgstr "Tagesthemen"

--- a/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
@@ -24,6 +24,22 @@ msgctxt "#30002"
 msgid "Show age of news in title"
 msgstr ""
 
+msgctxt "#30003"
+msgid "Tagesthemen Listing"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Broadcasts only"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Topics only"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Broadcasts and Topics"
+msgstr ""
+
 msgctxt "#30100"
 msgid "News"
 msgstr ""
@@ -38,4 +54,12 @@ msgstr ""
 
 msgctxt "#30103"
 msgid "ago"
+msgstr ""
+
+msgctxt "#30104"
+msgid "Tagesschau 20:00"
+msgstr ""
+
+msgctxt "#30105"
+msgid "Tagesthemen"
 msgstr ""

--- a/plugin.video.tagesschau/resources/settings.xml
+++ b/plugin.video.tagesschau/resources/settings.xml
@@ -2,4 +2,5 @@
 <settings>
   <setting id="quality" type="enum" label="30001" values="Small (480x272)|Medium (640x368)|Large (1280x720)" default="2" />
   <setting id="ShowAge" type="bool" label="30002" default="true" />
+  <setting id="tt_list" type="enum" label="30003" lvalues="30004|30005|30006" default="2" />
 </settings>


### PR DESCRIPTION
### Description
 * Added listing vor tagesschau 20:00 broadcasts
 * Added listing vor tagesthemen broadcasts
 * Added setting for the tagesthemen listing: show broadcasts, topics or both
 * Bugfixes

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
