### PR TITLE
[plugin.video.retrospect] v5.6.4

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.6.3"
+        version="5.6.4"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -122,18 +122,19 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.6.3 - Changelog - 2023-06-07[/B]
+        <news>[B]Retrospect v5.6.4 - Changelog - 2023-06-18[/B]
 
-Fixed more RTL related issues.
+Minor channel fixes for TV4 and Kijk.nl.
 
 [B]Framework related[/B]
 _None_
 
 [B]GUI/Settings/Language related[/B]
-* Fixed: De-duplicate before grouping to prevent duplicate items in grouped folders.
+_None_
 
 [B]Channel related[/B]
-* Fixed: A number of RTL XL related bugs (Fixes #1708).
+* Fixed: TV4 Play TV Show list broke.
+* Fixed: Kijk.nl broke (again) due to API changes.
 
         </news>
         <assets>

--- a/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
+++ b/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
@@ -102,13 +102,6 @@ class Channel(chn_class.Channel):
                               parser=["data", "liveVideos", "videoAssets"],
                               creator=self.create_api_typed_item)
 
-        # self._add_data_parser("https://www.tv4play.se/_next", json=True,
-        self._add_data_parser("https://www.tv4play.se/alla-program", json=True,
-                              name="Specific Program list API",
-                              preprocessor=self.extract_tv_show_list,
-                              parser=["props", "initialApolloState"],
-                              creator=self.create_api_typed_item)
-
         self._add_data_parser("http://tv4live-i.akamaihd.net/hls/live/",
                               updater=self.update_live_item)
         self._add_data_parser("http://tv4events1-lh.akamaihd.net/i/EXTRAEVENT5_1",
@@ -461,34 +454,6 @@ class Channel(chn_class.Channel):
         item.set_info_label("duration", int(result_set.get("duration", 0)))
         return item
 
-    def extract_tv_show_list(self, data):
-        """ Performs pre-process actions and converts the dictionary to a proper list
-
-        Accepts an data from the process_folder_list method, BEFORE the items are
-        processed. Allows setting of parameters (like title etc) for the channel.
-        Inside this method the <data> could be changed and additional items can
-        be created.
-
-        The return values should always be instantiated in at least ("", []).
-
-        :param str data: The retrieve data that was loaded for the current item and URL.
-
-        :return: A tuple of the data and a list of MediaItems that were generated.
-        :rtype: tuple[str|JsonHelper,list[MediaItem]]
-
-        """
-
-        # Find the build id for the current CMS build
-        # build_id = Regexer.do_regex(r'"buildId"\W*:\W*"([^"]+)"', data)[0]
-        # data = UriHandler.open("https://www.tv4play.se/_next/data/{}/allprograms.json".format(build_id))
-
-        data = Regexer.do_regex(r'__NEXT_DATA__" type="application/json">(.*?)</script>', data)[0]
-        json_data = JsonHelper(data)
-        # Make a list from the dictionary values.
-        json_data.json["props"]["initialApolloState"] = list(
-            json_data.json["props"]["initialApolloState"].values())
-        return json_data, []
-
     def add_next_page(self, data, items):
         """ Performs post-process actions for data processing.
 
@@ -590,7 +555,10 @@ class Channel(chn_class.Channel):
         extras = {
             LanguageHelper.get_localized_string(LanguageHelper.Search): ("searchSite", None, False),
             LanguageHelper.get_localized_string(LanguageHelper.TvShows): (
-                "https://www.tv4play.se/alla-program",
+                # "https://www.tv4play.se/alla-program",
+                self.__get_api_query("query{programSearch(per_page:1000){__typename,programs{"
+                                     "__typename,description,displayCategory,id,image,"
+                                     "images{main16x9},name,nid,genres},totalHits}}"),
                 None, False
             ),
             LanguageHelper.get_localized_string(LanguageHelper.Categories): (


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Minor channel fixes for TV4 and Kijk.nl.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
