### PR TITLE
[plugin.video.mlbtv@matrix] 2023.6.24+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.6.6+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2023.6.24+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,10 +22,9 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - added affiliate and level menus for finding MiLB (minor league) games
-            - fixed play all recaps / condensed games behavior when clicking on date
-            - start at inning / automatic skip for minor league games
-            - show only in-game highlights for play all highlights or catch up
+            - fix for proxied streams ending early when not using Inputstream Adaptive
+            - fix for Always Ask stream quality when not using Inputstream Adaptive
+            - fix username/password prompt labels
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/service.py
+++ b/plugin.video.mlbtv/service.py
@@ -31,8 +31,8 @@ URI_START_DELIMETER = 'URI="'
 URI_END_DELIMETER = '"'
 KEY_TEXT = '-KEY:METHOD=AES-128'
 ENDLIST_TEXT = '#EXT-X-ENDLIST'
-REMOVE_IN_HEADERS = ['upgrade', 'host', 'accept-encoding', 'pad', 'alternate_english', 'alternate_spanish']
-REMOVE_OUT_HEADERS = ['date', 'server', 'transfer-encoding', 'keep-alive', 'connection', 'content-length', 'content-md5', 'access-control-allow-credentials', 'content-encoding']
+REMOVE_IN_HEADERS = ['upgrade', 'host', 'pad', 'alternate_english', 'alternate_spanish']
+REMOVE_OUT_HEADERS = ['date', 'server', 'transfer-encoding', 'keep-alive', 'connection', 'content-length', 'content-range', 'content-md5', 'access-control-allow-credentials', 'content-encoding']
 
 class RequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2023.6.24+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - fix for proxied streams ending early when not using Inputstream Adaptive
            - fix for Always Ask stream quality when not using Inputstream Adaptive
            - fix username/password prompt labels
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
