### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.23

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.23 (2023-07-11)
+- Fix episode and featured listings (@mediaminister)
+
 ### v2.5.22 (2023-06-14)
 - Fix categories menu (@mediaminister)
 - Fix 1080p (@mediaminister)

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.22" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.23" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.23 (2023-07-11)
+- Fix episode and featured listings
+
 v2.5.22 (2023-06-14)
 - Fix categories menu
 - Fix 1080p

--- a/plugin.video.vrt.nu/resources/lib/api.py
+++ b/plugin.video.vrt.nu/resources/lib/api.py
@@ -1014,7 +1014,7 @@ def convert_seasons(api_data, program_name):
 
 def get_seasons(program_name):
     """Get seasons"""
-    season_json = get_url_json('https://www.vrt.be/vrtmax/a-z/{}.model.json'.format(program_name))
+    season_json = get_url_json('https://www.vrt.be/vrtnu/a-z/{}.model.json'.format(program_name))
     seasons = season_json.get('details').get('data').get('program').get('seasons')
     return seasons
 
@@ -1039,7 +1039,7 @@ def get_featured(feature=None, end_cursor=''):
             return episodes, sort, ascending, 'episodes'
     else:
         featured = []
-        featured_json = get_url_json('https://www.vrt.be/vrtmax/kijk.model.json')
+        featured_json = get_url_json('https://www.vrt.be/vrtnu/kijk.model.json')
         items = featured_json.get(':items').get('par').get(':items')
         for item in items:
             content_type = items.get(item).get('tileContentType')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.23
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.23 (2023-07-11)
- Fix episode and featured listings

v2.5.22 (2023-06-14)
- Fix categories menu
- Fix 1080p

v2.5.21 (2023-05-23)
- Fix 1080p for livestreams
- Remove All programs menu
- Fix paging in episode listings

v2.5.20 (2022-12-06)
- Fix all programs menu
- Fix latest episode API

v2.5.19 (2022-10-16)
- Fix categories and channels menu listings
- Fix resumepoints and Up Next integration
- Fix playing from VRT MAX url API interface

v2.5.18 (2022-10-07)
- Fix menu listings

v2.5.17 (2022-09-21)
- Fix watching VRT MAX abroad
- Fix 'My Programs' menu
- Fix login issue on Raspberry Pi

v2.5.16 (2022-09-13)
- Fix 'My Programs' menu
- Hide resumepoints error messages
- Implement new login api

v2.5.15 (2022-08-31)
- Fix add-on crash

v2.5.14 (2022-08-29)
- VRT MAX rebranding

v2.5.13 (2022-08-05)
- Support 1080p video on demand

v2.5.12 (2022-05-25)
- Fix playing from TV guide
- Fix listing programs with a single char in their name

v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
