### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.24

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.24 (2023-07-18)
+- Fix 1080p quality and playback issue (@mediaminister)
+
 ### v2.5.23 (2023-07-11)
 - Fix episode and featured listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.23" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.24" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.24 (2023-07-18)
+- Fix 1080p quality and playback issue
+
 v2.5.23 (2023-07-11)
 - Fix episode and featured listings
 

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -64,7 +64,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
 
         # Avoid setting resumepoints for livestreams
         for channel in CHANNELS:
-            if ep_id.get('video_id') and ep_id.get('video_id') == channel.get('live_stream_id'):
+            if ep_id.get('video_id') and ep_id.get('video_id') in (channel.get('live_stream_id'), channel.get('name')):
                 log(3, '[PlayerInfo {id}] Avoid setting resumepoints for livestream {video_id}', id=self.thread_id, video_id=ep_id.get('video_id'))
                 self.listen = False
 

--- a/plugin.video.vrt.nu/resources/lib/streamservice.py
+++ b/plugin.video.vrt.nu/resources/lib/streamservice.py
@@ -170,7 +170,7 @@ class StreamService:
 
            Right after a program is completely broadcasted, the stop timestamp is usually missing and should be added to the manifest_url.
         """
-        if '?t=' in manifest_url:
+        if any(param in manifest_url for param in ('?t=', '&t=')):
             try:  # Python 3
                 from urllib.parse import parse_qs, urlsplit
             except ImportError:  # Python 2
@@ -243,7 +243,17 @@ class StreamService:
 
                 # External virtual subclip, live-to-VOD from past 24 hours archived livestream (airdate feature)
                 if video.get('start_date') and video.get('end_date'):
-                    manifest_url += '?t=' + video.get('start_date') + '-' + video.get('end_date')
+                    if '?' in manifest_url:
+                        manifest_parts = manifest_url.split('?')
+                        uri = manifest_parts[0]
+                        querystring = '&' + manifest_parts[1]
+                    else:
+                        uri = manifest_url
+                        querystring = ''
+                    manifest_url = '{}?t={}-{}{}'.format(uri, video.get('start_date'), video.get('end_date'), querystring)
+
+                # FIXME: Remove '#' URI fragment identifier from manifest url because InputStream Adaptive refuses to play these urls
+                manifest_url = manifest_url.replace('#', '')
 
                 # Fix virtual subclip
                 from datetime import timedelta

--- a/plugin.video.vrt.nu/resources/lib/tokenresolver.py
+++ b/plugin.video.vrt.nu/resources/lib/tokenresolver.py
@@ -303,10 +303,10 @@ class TokenResolver:
                     crypt_data = re.findall(crypt_rx, data)
                     if not crypt_data:
                         # Try redirect
-                        redirect_rx = re.compile(r"'(/[a-z]+\.[a-z0-9]{20}\.js)';")
+                        redirect_rx = re.compile(r"'([a-z]+\.[a-z0-9]{20}\.js)';")
                         redirect_path = re.search(redirect_rx, data)
                         if redirect_path:
-                            player_url = player_url[:player_url.rfind('/')] + redirect_path.group(1)
+                            player_url = '{}/{}'.format(player_url[:player_url.rfind('/')], redirect_path.group(1))
                         else:
                             return playerinfo
 
@@ -316,7 +316,7 @@ class TokenResolver:
         secret = base64.b64decode(secret_source[::-1]).decode('utf-8')
 
         # Extract player version
-        player_version = '3.0.3'
+        player_version = '3.1.1'
         pv_rx = re.compile(r'playerVersion:\"(\S*)\"')
         match = re.search(pv_rx, data)
         if match:

--- a/plugin.video.vrt.nu/resources/lib/utils.py
+++ b/plugin.video.vrt.nu/resources/lib/utils.py
@@ -206,6 +206,8 @@ def play_url_to_id(url):
         play_id['whatson_id'] = url.split('play/whatson/')[1]
     elif 'play/episode/' in url:
         play_id['episode_id'] = url.split('play/episode/')[1]
+    elif 'play/airdate/' in url:
+        play_id['video_id'] = url.split('play/airdate/')[1].split('/')[0]
     return play_id
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.24
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.24 (2023-07-18)
- Fix 1080p quality and playback issue

v2.5.23 (2023-07-11)
- Fix episode and featured listings

v2.5.22 (2023-06-14)
- Fix categories menu
- Fix 1080p

v2.5.21 (2023-05-23)
- Fix 1080p for livestreams
- Remove All programs menu
- Fix paging in episode listings

v2.5.20 (2022-12-06)
- Fix all programs menu
- Fix latest episode API

v2.5.19 (2022-10-16)
- Fix categories and channels menu listings
- Fix resumepoints and Up Next integration
- Fix playing from VRT MAX url API interface

v2.5.18 (2022-10-07)
- Fix menu listings

v2.5.17 (2022-09-21)
- Fix watching VRT MAX abroad
- Fix 'My Programs' menu
- Fix login issue on Raspberry Pi

v2.5.16 (2022-09-13)
- Fix 'My Programs' menu
- Hide resumepoints error messages
- Implement new login api

v2.5.15 (2022-08-31)
- Fix add-on crash

v2.5.14 (2022-08-29)
- VRT MAX rebranding

v2.5.13 (2022-08-05)
- Support 1080p video on demand

v2.5.12 (2022-05-25)
- Fix playing from TV guide
- Fix listing programs with a single char in their name

v2.5.11 (2022-05-15)
- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu

v2.5.10 (2022-04-29)
- Fix watching from the tv guide
- Fix season menu labels
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
