### PR TITLE
[plugin.video.tvvlaanderen@matrix] 1.0.7+matrix.1

### DIFF
--- a/plugin.video.tvvlaanderen/CHANGELOG.md
+++ b/plugin.video.tvvlaanderen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.7](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.7) (2023-07-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.6...v1.0.7)
+
+**Fixed bugs:**
+
+- Fix EPG parser [\#61](https://github.com/add-ons/plugin.video.tvvlaanderen/pull/61) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.0.6](https://github.com/add-ons/plugin.video.tvvlaanderen/tree/v1.0.6) (2023-02-09)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.tvvlaanderen/compare/v1.0.5...v1.0.6)

--- a/plugin.video.tvvlaanderen/addon.xml
+++ b/plugin.video.tvvlaanderen/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.6+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.tvvlaanderen" name="TV Vlaanderen" version="1.0.7+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,8 +22,8 @@
         <disclaimer lang="en_GB">This add-on is not officially commissioned/supported by TV Vlaanderen and is provided 'as is' without any warranty of any kind. TV Vlaanderen is a brand of Canal+ Luxembourg S. à r.l.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.0.6 (2023-02-09)
-- Add support for VOD.</news>
+        <news>v1.0.7 (2023-07-26)
+- Fix EPG.</news>
         <source>https://github.com/add-ons/plugin.video.tvvlaanderen</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
+++ b/plugin.video.tvvlaanderen/resources/lib/solocoo/util.py
@@ -213,7 +213,7 @@ def parse_epg_capi(program, tenant):
 
     # Parse credits
     credit_list = []
-    for credit in program.get('credits', []):
+    for credit in program.get('credits', []) or []:
         if not credit.get('r'):  # Actor
             credit_list.append(Credit(role=Credit.ROLE_ACTOR, person=credit.get('p'), character=credit.get('c')))
         elif credit.get('r') == 1:  # Director


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: TV Vlaanderen
  - Add-on ID: plugin.video.tvvlaanderen
  - Version number: 1.0.7+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.tvvlaanderen

Deze add-on geeft toegang tot de live TV kanalen en de video-on-demand content dat beschikbaar is via je TV Vlaanderen abonnement.

### What's new

v1.0.7 (2023-07-26)
- Fix EPG.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
