### PR TITLE
[plugin.video.vtm.go@matrix] 1.4.2+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.4.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.2) (2023-07-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.1...v1.4.2)
+
+**Fixed bugs:**
+
+- Support multiple episodes with same index [\#363](https://github.com/add-ons/plugin.video.vtm.go/pull/363) ([michaelarnauts](https://github.com/michaelarnauts))
+- Fix subtitle delay function [\#355](https://github.com/add-ons/plugin.video.vtm.go/pull/355) ([mediaminister](https://github.com/mediaminister))
+
 ## [v1.4.1](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.1) (2023-02-08)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.0...v1.4.1)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.1+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.2+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,8 +22,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.4.1 (2023-02-09)
-- Fix Live TV on older Kodi versions.</news>
+        <news>v1.4.2 (2023-07-26)
+- Fix for missing episodes.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/modules/catalog.py
+++ b/plugin.video.vtm.go/resources/lib/modules/catalog.py
@@ -110,7 +110,7 @@ class Catalog:
             # Show the season that was selected
             seasons = [program_obj.seasons[season]]
 
-        listing = [Menu.generate_titleitem(e) for s in seasons for e in list(s.episodes.values())]
+        listing = [Menu.generate_titleitem(e) for s in seasons for e in s.episodes]
 
         # Sort by episode number by default. Takes seasons into account.
         kodiutils.show_listing(listing, program_obj.name, content='episodes', sort=['episode', 'duration'])

--- a/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/__init__.py
@@ -179,7 +179,7 @@ class Season:
     def __init__(self, number=None, episodes=None, channel=None, legal=None):
         """
         :type number: str
-        :type episodes: dict[int, Episode]
+        :type episodes: list[Episode]
         :type channel: str
         :type legal: str
         """

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
@@ -256,7 +256,7 @@ class VtmGo:
 
         seasons = {}
         for item_season in program.get('seasonIndices', []):
-            episodes = {}
+            episodes = []
 
             # Fetch season
             season_response = util.http_get(API_ENDPOINT + '/%s/detail/%s?selectedSeasonIndex=%s' % (self._mode(), program_id, item_season),
@@ -265,7 +265,7 @@ class VtmGo:
             season = json.loads(season_response.text).get('selectedSeason')
 
             for item_episode in season.get('episodes', []):
-                episodes[item_episode.get('index')] = Episode(
+                episodes.append(Episode(
                     episode_id=item_episode.get('id'),
                     program_id=program_id,
                     program_name=program.get('name'),
@@ -283,7 +283,7 @@ class VtmGo:
                     aired=item_episode.get('broadcastTimestamp'),
                     progress=item_episode.get('playerPositionSeconds', 0),
                     watched=item_episode.get('doneWatching', False),
-                )
+                ))
 
             seasons[item_season] = Season(
                 number=item_season,
@@ -314,7 +314,7 @@ class VtmGo:
         :rtype Episode
         """
         for season in list(program.seasons.values()):
-            for episode in list(season.episodes.values()):
+            for episode in season.episodes:
                 if episode.episode_id == episode_id:
                     return episode
 
@@ -331,7 +331,7 @@ class VtmGo:
         next_season_episode = None
 
         # First, try to find a match in the current season
-        for episode in [e for s in list(program.seasons.values()) for e in list(s.episodes.values())]:
+        for episode in [e for s in list(program.seasons.values()) for e in s.episodes]:
             if episode.season == season and episode.number == number + 1:
                 return episode
             if episode.season == season + 1 and episode.number == 1:

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -263,11 +263,12 @@ class VtmGoStream:
         for timestamp in match.groups():
             hours, minutes, seconds, millis = (int(x) for x in [timestamp[:-10], timestamp[-9:-7], timestamp[-6:-4], timestamp[-3:]])
             sub_timings.append(timedelta(hours=hours, minutes=minutes, seconds=seconds, milliseconds=millis))
+        original_start_time = sub_timings[0]
         for ad_break in ad_breaks:
             # time format: seconds.fraction or seconds
             ad_break_start = timedelta(milliseconds=ad_break.get('start') * 1000)
             ad_break_duration = timedelta(milliseconds=ad_break.get('duration') * 1000)
-            if ad_break_start <= sub_timings[0]:
+            if ad_break_start <= original_start_time:
                 for idx, item in enumerate(sub_timings):
                     sub_timings[idx] += ad_break_duration
         for idx, item in enumerate(sub_timings):


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.4.2+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.4.2 (2023-07-26)
- Fix for missing episodes.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
