### PR TITLE
[plugin.video.arteplussept@matrix] 1.2.0

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,24 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.3.1 (2023-8-12)
+- Add context menu to view collection as menu instead of playlist
+- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
+
+v1.3.0 (2023-8-6)
+- Improve security with better password management
+  - Stop storing password on filesystem though addon settings
+- Make thomas-ernest fork official in addon.xml for visibility in wiki
+- Minor fix/clean-up in translation
+
+v1.2.1 (2023-8-12)
+- Add context menu to view collection as menu instead of playlist
+- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
+
+v1.2.0 (2023-7-26)
+- Manage collections TV_SERIES and MAGAZINE as video playlist
+- Add a context menu item to purge favorites
+- Add a context menu item to mark as video as watched in Arte
+
 v1.1.10 (2023-5-28)
 - Bugfix to display favorites and last vieweds following id change in Arte
 

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.1.10" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.3.1" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -18,57 +18,52 @@
         <description lang="fr_FR">
 Regardez les vidéos de Arte +7
 Pour toute demande ou reporter un problème:
-https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+https://github.com/thomas-ernest/plugin.video.arteplussept/issues
 Les contributions sont les bienvenues:
-https://github.com/known-as-bmf/plugin.video.arteplussept
+https://github.com/thomas-ernest/plugin.video.arteplussept
         </description>
         <description lang="de_DE">
 Sehen Sie Videos von Arte +7
 Für Fehlerberichte und Verbesserungsvorschläge:
-https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+https://github.com/thomas-ernest/plugin.video.arteplussept/issues
 Mithilfe ist willkommen:
-https://github.com/known-as-bmf/plugin.video.arteplussept
+https://github.com/thomas-ernest/plugin.video.arteplussept
         </description>
         <description lang="en_GB">
 Watch videos from Arte +7
 For feature requests / issues:
-https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+https://github.com/thomas-ernest/plugin.video.arteplussept/issues
 Contributions are welcome:
-https://github.com/known-as-bmf/plugin.video.arteplussept
+https://github.com/thomas-ernest/plugin.video.arteplussept
         </description>
         <description lang="it_IT">
 Guarda video da Arte +7
 Per richiedere nuove funzionalità o segnalare problemi:
-https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+https://github.com/thomas-ernest/plugin.video.arteplussept/issues
 Nuovi contributi sono ben accetti:
-https://github.com/known-as-bmf/plugin.video.arteplussept
+https://github.com/thomas-ernest/plugin.video.arteplussept
         </description>
         <description lang="pl_PL">
 Oglądaj wideos z Arte +7
 W przypadku problemów lub próśb o ulepszenie:
-https://github.com/known-as-bmf/plugin.video.arteplussept/issues
+https://github.com/thomas-ernest/plugin.video.arteplussept/issues
 Każda pomoc mile widziana:
-https://github.com/known-as-bmf/plugin.video.arteplussept
+https://github.com/thomas-ernest/plugin.video.arteplussept
         </description>
         <language>fr de en it pl</language>
         <platform>all</platform>
         <license>MIT</license>
         <website>https://www.arte.tv/fr/</website>
-        <source>https://github.com/known-as-bmf/plugin.video.arteplussept</source>
+        <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
         <news>
-        Highlights since 1.1.2
-        - Improve security and performance by caching token to limit authentication requests
-        - Fallback on clip, when stream is not available anymore.
-        - Clean-up and lint code
-        - Add CI with Pylint and Kodi addon submitter
-        - Integrate Arte account favorites, last viewed items and playback progress (thanks to Arte account to be configured in settings).
-        - Move from HBB TV to Arte TV API.
-        - Fixed playback progress / resume point retrieved from Arte TV
-        - Added synchronisation of playback progress with Arte TV when video playback paused, stopped or crashed
-        - Manage favorites in Arte profile from context menu
-        - Added Search in root menu
-        - Added Live stream in root menu
-        - Added purge of my history
+v1.3.1 (2023-8-12)
+- Add context menu to view collection as menu instead of playlist
+- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
+v1.3.0 (2023-8-6)
+- Improve security with better password management
+        - Stop storing password on filesystem though addon settings
+- Make thomas-ernest fork official in addon.xml for visibility in wiki
+- Minor fix/clean-up in translation
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
@@ -34,26 +34,65 @@ msgctxt "#30054"
 msgid "Email"
 msgstr "E-Mail-Adresse"
 
-msgctxt "#30055"
-msgid "Password"
-msgstr "Passwort"
+msgctxt "#30056"
+msgid "Log level"
+msgstr "Log level"
+
+msgctxt "#30057"
+msgid "Log in"
+msgstr "Einloggen"
+
+msgctxt "#30058"
+msgid "Log out"
+msgstr "Austragen"
+
+
+msgctxt "#30011"
+msgid "View collection as menu"
+msgstr "Sammlung als Menü anzeigen"
 
 
 msgctxt "#30012"
 msgid "Search"
 msgstr "Suche"
 
+
+msgctxt "#30014"
+msgid "Authentication needed in addon settings"
+msgstr "Authentifizierung in den Add-on-Einstellungen erforderlich"
+
+msgctxt "#30015"
+msgid "User already logged in"
+msgstr "Benutzer bereits angemeldet"
+
+msgctxt "#30016"
+msgid "Do you want to log in as \"{new_user}\" instead of \"{old_user}\" ?"
+msgstr "Möchten Sie sich als \"{new_user}\" statt als \"{old_user}\" anmelden?"
+
+msgctxt "#30017"
+msgid "Logged in as \"{user}\""
+msgstr "Als \"{user}\" angemeldet"
+
+msgctxt "#30018"
+msgid "Logged out"
+msgstr "Abgemeldet"
+
+msgctxt "#30019"
+msgid "Enter password please:"
+msgstr "Bitte Passwort eingeben:"
+
 msgctxt "#30020"
 msgid "Unable to authenticate"
 msgstr "Authentifizierungsfehler"
 
 msgctxt "#30021"
-msgid "Email or password missing"
-msgstr "E-Mail oder Passwort fehlen"
+msgid "Email missing"
+msgstr "E-Mail fehlen"
 
 msgctxt "#30022"
-msgid "Update your profile in settings to fetch this content"
-msgstr "Aktualisieren Sie Ihre Profil in den Einstellungen, um diesen Inhalt abzurufen"
+msgid "Password missing"
+msgstr "Passwort fehlen"
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"
@@ -94,3 +133,37 @@ msgstr "Videoverlauf erfolgreich gelöscht"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Mein Videoerlauf konnte nicht gelöscht werden"
+
+msgctxt "#30033"
+msgid "Do you really want to purge your history ?"
+msgstr "Wollen Sie wirklich Ihr Videoverlauf löschen ?"
+
+
+msgctxt "#30035"
+msgid "Mark as watched in Arte"
+msgstr "Als geschaut in Arte markieren"
+
+msgctxt "#30036"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" erfolgreich als geschaut markiert"
+
+msgctxt "#30037"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "\"{label}\" konnte nicht als geschaut markiert werden"
+
+
+msgctxt "#30040"
+msgid "Purge my Arte favorites"
+msgstr "Lösche meine Arte-Favoriten"
+
+msgctxt "#30041"
+msgid "Successfully purged favorites"
+msgstr "Favoriten erfolgreich gelöscht"
+
+msgctxt "#30042"
+msgid "Failed to purge favorites"
+msgstr "Meine Favoriten konnte nicht gelöscht werden"
+
+msgctxt "#30043"
+msgid "Do you really want to purge Arte favorites ?"
+msgstr "Wollen Sie wirklich Arte-Favoriten löschen ?"

--- a/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
@@ -34,8 +34,21 @@ msgctxt "#30054"
 msgid "Email"
 msgstr ""
 
-msgctxt "#30055"
-msgid "Password"
+msgctxt "#30056"
+msgid "Log level"
+msgstr "Log level"
+
+msgctxt "#30057"
+msgid "Log in"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Log out"
+msgstr ""
+
+
+msgctxt "#30011"
+msgid "View collection as menu"
 msgstr ""
 
 
@@ -43,17 +56,43 @@ msgctxt "#30012"
 msgid "Search"
 msgstr ""
 
+
+msgctxt "#30014"
+msgid "Authentication needed in addon settings"
+msgstr ""
+
+msgctxt "#30015"
+msgid "User already logged in"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Do you want to log in as \"{new_user}\" instead of \"{old_user}\" ?"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Logged in as \"{user}\""
+msgstr ""
+
+msgctxt "#30018"
+msgid "Logged out"
+msgstr ""
+
+msgctxt "#30019"
+msgid "Enter password please :"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Unable to authenticate"
 msgstr ""
 
 msgctxt "#30021"
-msgid "Email or password missing"
+msgid "Email missing"
 msgstr ""
 
 msgctxt "#30022"
-msgid "Update your profile in settings to fetch this content"
+msgid "Password missing"
 msgstr ""
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"
@@ -93,4 +132,37 @@ msgstr ""
 
 msgctxt "#30032"
 msgid "Failed to purge my history"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Do you really want to purge your history ?"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Mark as watched in Arte"
+msgstr ""
+
+msgctxt "#30036"
+msgid "\"{label}\" successfully marked as watched"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Failed to mark as watched \"{label}\""
+msgstr ""
+
+
+msgctxt "#30040"
+msgid "Purge my Arte favorites"
+msgstr ""
+
+msgctxt "#30041"
+msgid "Successfully purged favorites"
+msgstr ""
+
+msgctxt "#30042"
+msgid "Failed to purge favorites"
+msgstr ""
+
+msgctxt "#30043"
+msgid "Do you really want to purge Arte favorites ?"
 msgstr ""

--- a/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
@@ -34,26 +34,65 @@ msgctxt "#30054"
 msgid "Email"
 msgstr "Adresse e-mail"
 
-msgctxt "#30055"
-msgid "Password"
-msgstr "Mot de passe"
+msgctxt "#30056"
+msgid "Log level"
+msgstr "Log level"
+
+msgctxt "#30057"
+msgid "Log in"
+msgstr "Se connecter"
+
+msgctxt "#30058"
+msgid "Log out"
+msgstr "Se déconnecter"
+
+
+msgctxt "#30011"
+msgid "View collection as menu"
+msgstr "Voir la collection dans un menu"
 
 
 msgctxt "#30012"
 msgid "Search"
 msgstr "Recherche"
 
+
+msgctxt "#30014"
+msgid "Authentication needed in addon settings"
+msgstr "Authentification nécessaire dans les paramètres de l'addon"
+
+msgctxt "#30015"
+msgid "User already logged in"
+msgstr "Utilisateur déjà connecté"
+
+msgctxt "#30016"
+msgid "Do you want to log in as \"{new_user}\" instead of \"{old_user}\" ?"
+msgstr "Voulez vous connecter en tant que \"{new_user}\" au lieu de \"{old_user}\" ?"
+
+msgctxt "#30017"
+msgid "Logged in as \"{user}\""
+msgstr "Connecté en tant que \"{user}\""
+
+msgctxt "#30018"
+msgid "Logged out"
+msgstr "Déconnecté"
+
+msgctxt "#30019"
+msgid "Enter password please:"
+msgstr "Entrez votre mot de passe s'il vous plaît:"
+
 msgctxt "#30020"
 msgid "Unable to authenticate"
 msgstr "Impossible de s'authentifier"
 
 msgctxt "#30021"
-msgid "Email or password missing"
-msgstr "E-mail ou mot de passe manquant"
+msgid "Email missing"
+msgstr "E-Mail manquant"
 
 msgctxt "#30022"
-msgid "Update your profile in settings to fetch this content"
-msgstr "Mettez à jour votre profil dans la configuration pour télécharger ce contenu"
+msgid "Password missing"
+msgstr "Mot de passe manquant"
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"
@@ -94,3 +133,37 @@ msgstr "Historique purgé avec succès"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Echec de la purge de mon historique"
+
+msgctxt "#30033"
+msgid "Do you really want to purge your history ?"
+msgstr "Voulez vous vraiment purger votre historique ?"
+
+
+msgctxt "#30035"
+msgid "Mark as watched in Arte"
+msgstr "Marquer comme lu dans Arte"
+
+msgctxt "#30036"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" marqué comme lu avec succès"
+
+msgctxt "#30037"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Echec pour marquer comme lu \"{label}\""
+
+
+msgctxt "#30040"
+msgid "Purge my Arte favorites"
+msgstr "Purger mes favoris Arte"
+
+msgctxt "#30041"
+msgid "Successfully purged favorites"
+msgstr "Favoris purgés avec succès"
+
+msgctxt "#30042"
+msgid "Failed to purge favorites"
+msgstr "Echec de la purge des favoris"
+
+msgctxt "#30043"
+msgid "Do you really want to purge Arte favorites ?"
+msgstr "Voulez vous vraiment purger les favoris Arte ?"

--- a/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
@@ -34,26 +34,65 @@ msgctxt "#30054"
 msgid "Email"
 msgstr "Indirizzo email"
 
-msgctxt "#30055"
-msgid "Password"
-msgstr "Password"
+msgctxt "#30056"
+msgid "Log level"
+msgstr "Log level"
+
+msgctxt "#30057"
+msgid "Log in"
+msgstr "Per accedere"
+
+msgctxt "#30058"
+msgid "Log out"
+msgstr "Disconnessione"
+
+
+msgctxt "#30011"
+msgid "View collection as menu"
+msgstr "Visualizza la raccolta come menu"
 
 
 msgctxt "#30012"
 msgid "Search"
 msgstr "Search"
 
+
+msgctxt "#30014"
+msgid "Authentication needed in addon settings"
+msgstr "Autenticazione necessaria nelle impostazioni del componente aggiuntivo"
+
+msgctxt "#30015"
+msgid "User already logged in"
+msgstr "Utente già loggato"
+
+msgctxt "#30016"
+msgid "Do you want to log in as \"{new_user}\" instead of \"{old_user}\" ?"
+msgstr "Vuoi accedere come \"{new_user}\" invece che come \"{old_user}\" ?"
+
+msgctxt "#30017"
+msgid "Logged in as \"{user}\""
+msgstr "Effettuato l'accesso come \"{user}\""
+
+msgctxt "#30018"
+msgid "Logged out"
+msgstr "Disconnesso"
+
+msgctxt "#30019"
+msgid "Enter password please:"
+msgstr "Inserisci la password per favore:"
+
 msgctxt "#30020"
 msgid "Unable to authenticate"
 msgstr "Impossibile autenticare"
 
 msgctxt "#30021"
-msgid "Email or password missing"
-msgstr "E-mail o password mancanti"
+msgid "Email missing"
+msgstr "E-Mail mancanti"
 
 msgctxt "#30022"
-msgid "Update your profile in settings to fetch this content"
-msgstr "Aggiorna il tuo profilo nelle impostazioni per recuperare questo contenuto"
+msgid "Password missing"
+msgstr "Password mancanti"
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"
@@ -83,14 +122,49 @@ msgctxt "#30029"
 msgid "Stream \"{strm}\" in \"{ln}\" is not available"
 msgstr "Lo streaming \"{strm}\" in \"{ln}\" non è disponibile"
 
+
 msgctxt "#30030"
 msgid "Purge my history"
 msgstr "Elimina la cronologia"
 
 msgctxt "#30031"
 msgid "Successfully purged history"
-msgstr "Cronologia eliminata con successo"
+msgstr "Cronologia eliminata correttamente"
 
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Impossibile eliminare la cronologia"
+
+msgctxt "#30033"
+msgid "Do you really want to purge your history ?"
+msgstr "Vuoi davvero eliminare la tua storia ?"
+
+
+msgctxt "#30035"
+msgid "Mark as watched in Arte"
+msgstr "Segna come guardato in Arte"
+
+msgctxt "#30036"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "\"{label}\" contrassegnato con successo come guardato"
+
+msgctxt "#30037"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Impossibile contrassegnare come guardato \"{label}\""
+
+
+msgctxt "#30040"
+msgid "Purge my Arte favorites"
+msgstr "Elimina i miei preferiti di Arte"
+
+msgctxt "#30041"
+msgid "Successfully purged favorites"
+msgstr "Preferiti eliminati correttamente"
+
+msgctxt "#30042"
+msgid "Failed to purge favorites"
+msgstr "Impossibile eliminare i preferiti"
+
+msgctxt "#30043"
+msgid "Do you really want to purge Arte favorites ?"
+msgstr "Vuoi davvero eliminare i preferiti di Arte ?"

--- a/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
@@ -34,26 +34,65 @@ msgctxt "#30054"
 msgid "Email"
 msgstr "E-mail"
 
-msgctxt "#30055"
-msgid "Password"
-msgstr "Hasło"
+msgctxt "#30056"
+msgid "Log level"
+msgstr "Log level"
+
+msgctxt "#30057"
+msgid "Log in"
+msgstr "Zalogować się"
+
+msgctxt "#30058"
+msgid "Log out"
+msgstr "Wyloguj się"
+
+
+msgctxt "#30011"
+msgid "View collection as menu"
+msgstr "Zobacz kolekcję jako menu"
 
 
 msgctxt "#30012"
 msgid "Search"
 msgstr "Wyszukiwanie"
 
+
+msgctxt "#30014"
+msgid "Authentication needed in addon settings"
+msgstr "Wymagane uwierzytelnienie w ustawieniach dodatku"
+
+msgctxt "#30015"
+msgid "User already logged in"
+msgstr "Użytkownik jest już zalogowany"
+
+msgctxt "#30016"
+msgid "Do you want to log in as \"{new_user}\" instead of \"{old_user}\" ?"
+msgstr "Czy chcesz się zalogować jako \"{new_user}\" zamiast \"{old_user}\" ?"
+
+msgctxt "#30017"
+msgid "Logged in as \"{user}\""
+msgstr "Zalogowany jako \"{user}\""
+
+msgctxt "#30018"
+msgid "Logged out"
+msgstr "Wylogowano"
+
+msgctxt "#30019"
+msgid "Enter password please:"
+msgstr "Proszę wprowadzić hasło:"
+
 msgctxt "#30020"
 msgid "Unable to authenticate"
 msgstr "Nie można uwierzytelnić"
 
 msgctxt "#30021"
-msgid "Email or password missing"
-msgstr "Brak e-mail lub hasła"
+msgid "Email missing"
+msgstr "Brak e-mail"
 
 msgctxt "#30022"
-msgid "Update your profile in settings to fetch this content"
-msgstr "Zaktualizuj swój profil w ustawieniach, aby pobrać tę zawartość"
+msgid "Password missing"
+msgstr "Brak hasła"
+
 
 msgctxt "#30023"
 msgid "Add to Arte favorites"
@@ -94,3 +133,37 @@ msgstr "Pomyślnie wyczyszczono historię"
 msgctxt "#30032"
 msgid "Failed to purge my history"
 msgstr "Nie udało się wyczyścić mojej historii"
+
+msgctxt "#30033"
+msgid "Do you really want to purge your history ?"
+msgstr "Czy naprawdę chcesz wyczyścić swoją historię ?"
+
+
+msgctxt "#30035"
+msgid "Mark as watched in Arte"
+msgstr "Oznacz jako obejrzane w Arte"
+
+msgctxt "#30036"
+msgid "\"{label}\" successfully marked as watched"
+msgstr "Pomyślnie oznaczone \"{label}\" jako obejrzane"
+
+msgctxt "#30037"
+msgid "Failed to mark as watched \"{label}\""
+msgstr "Nie udało się oznaczyć jako oglądane \"{label}\""
+
+
+msgctxt "#30040"
+msgid "Purge my Arte favorites"
+msgstr "Wyczyść moje ulubione Arte"
+
+msgctxt "#30041"
+msgid "Successfully purged favorites"
+msgstr "Pomyślnie wyczyszczono ulubione"
+
+msgctxt "#30042"
+msgid "Failed to purge favorites"
+msgstr "Nie udało się wyczyścić ulubionych"
+
+msgctxt "#30043"
+msgid "Do you really want to purge Arte favorites ?"
+msgstr "Czy naprawdę chcesz wyczyścić ulubione Arte ?"

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -4,13 +4,16 @@ from collections import OrderedDict
 import requests
 # pylint: disable=import-error
 from xbmcswift2 import xbmc
+from xbmcswift2.plugin import Plugin
 from . import hof
+from . import logger
 
-
+_PLUGIN_NAME = Plugin().name
+_PLUGIN_VERSION = Plugin().addon.getAddonInfo('version')
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.10'
+    'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}"
 }
 _HBBTV_ENDPOINTS = {
     'category': '/EMAC/teasers/category/v2/{category_code}/{lang}',
@@ -37,6 +40,9 @@ ARTETV_ENDPOINTS = {
     # DELETE
     # needs token in authorization header
     'remove_favorite': '/sso/v3/favorites/{program_id}',
+    # PATCH empty payload
+    # needs token in authorization header
+    'purge_favorites': '/sso/v3/favorites/purge',
     # needs token in authorization header
     'get_last_viewed': '/sso/v3/lastvieweds/{lang}?page={page}&limit={limit}',
     # PUT
@@ -47,7 +53,9 @@ ARTETV_ENDPOINTS = {
     # needs token in authorization header
     'purge_last_viewed': '/sso/v3/lastvieweds/purge',
     # program_id can be 103520-000-A or LIVE
-    'program': '/player/v2/config/{lang}/{program_id}',
+    'player': '/player/v2/config/{lang}/{program_id}',
+    # rproxy
+    'program': '/emac/v4/{lang}/web/programs/{program_id}',
     # rproxy
     # category=HOME, CIN, SER, SEARCH client=app, tv, web, orange, free
     'page': '/emac/v4/{lang}/{client}/pages/{category}/',
@@ -60,7 +68,7 @@ ARTETV_ENDPOINTS = {
     'login': '/login',
 }
 ARTETV_HEADERS = {
-    'user-agent': 'plugin.video.arteplussept/1.1.10',
+    'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}",
     # required to use token endpoint
     'authorization': 'I6k2z58YGO08P1X0E8A7VBOjDxr8Lecg',
     # required for Arte TV API. values like web, app, tv, orange, free
@@ -69,89 +77,149 @@ ARTETV_HEADERS = {
     'accept': 'application/json'
 }
 
-def get_favorites(plugin, lang, usr, pwd):
+def get_favorites(lang, tkn):
     """Retrieve favorites from a personal account."""
     url = _ARTETV_URL + ARTETV_ENDPOINTS['get_favorites'].format(lang=lang, page='1', limit='50')
-    return _load_json_personal_content(plugin, url, usr, pwd)
+    return _load_json_personal_content('artetv_getfavorites', url, tkn)
 
-def add_favorite(plugin, usr, pwd, program_id):
-    """Add content program_id to user favorites.
-    :return: HTTP status code."""
+def add_favorite(tkn, program_id):
+    """
+    Add content program_id to user favorites.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['add_favorite']
-    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    headers = _add_auth_token(tkn, ARTETV_HEADERS)
     data = {'programId': program_id}
     reply = requests.put(url, data=data, headers=headers, timeout=10)
+    logger.log_json(reply, 'artetv_addfavorite')
     return reply.status_code
 
-def remove_favorite(plugin, usr, pwd, program_id):
-    """Remove content program_id from user favorites.
-    :return: HTTP status code."""
+def remove_favorite(tkn, program_id):
+    """
+    Remove content program_id from user favorites.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['remove_favorite'].format(program_id=program_id)
-    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    headers = _add_auth_token(tkn, ARTETV_HEADERS)
     reply = requests.delete(url, headers=headers, timeout=10)
+    logger.log_json(reply, 'artetv_removefavorite')
     return reply.status_code
 
-def get_last_viewed(plugin, lang, usr, pwd):
+def purge_favorites(tkn):
+    """Flush user favorites"""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['purge_favorites']
+    headers = _add_auth_token(tkn, ARTETV_HEADERS)
+    reply = requests.patch(url, data={}, headers=headers, timeout=10)
+    logger.log_json(reply, 'artetv_purgefavorites')
+    return reply.status_code
+
+def get_last_viewed(lang, tkn):
     """Retrieve content recently watched by a user."""
     url = _ARTETV_URL + ARTETV_ENDPOINTS['get_last_viewed'].format(lang=lang, page='1', limit='50')
-    return _load_json_personal_content(plugin, url, usr, pwd)
+    return _load_json_personal_content('artetv_lastviewed', url, tkn)
 
-def sync_last_viewed(plugin, usr, pwd, program_id, time):
-    """Synchronize in arte profile the progress time of content being played.
-    :return: HTTP status code."""
+def sync_last_viewed(tkn, program_id, time):
+    """
+    Synchronize in arte profile the progress time of content being played.
+    :return: HTTP status code.
+    """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['sync_last_viewed']
-    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    headers = _add_auth_token(tkn, ARTETV_HEADERS)
     data = {'programId': program_id, 'timecode': time}
     reply = requests.put(url, data=data, headers=headers, timeout=10)
+    logger.log_json(reply, 'artetv_synchlastviewed')
     return reply.status_code
 
-def purge_last_viewed(plugin, usr, pwd):
+def purge_last_viewed(tkn):
     """Flush user history"""
     url = _ARTETV_URL + ARTETV_ENDPOINTS['purge_last_viewed']
-    headers = _add_auth_token(plugin, usr, pwd, ARTETV_HEADERS)
+    headers = _add_auth_token(tkn, ARTETV_HEADERS)
     reply = requests.patch(url, data={}, headers=headers, timeout=10)
+    logger.log_json(reply, 'artetv_purgelastviewed')
     return reply.status_code
+
+def player_video(lang, program_id):
+    """Get the info of content program_id from Arte TV API."""
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['player'].format(lang=lang, program_id=program_id)
+    return _load_json_full_url('artetv_player', url, None).get('data', {})
 
 def program_video(lang, program_id):
     """Get the info of content program_id from Arte TV API."""
-    url = _ARTETV_URL + ARTETV_ENDPOINTS['program'].format(lang=lang, program_id=program_id)
-    return _load_json_full_url(url, None).get('data', {})
+    url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['program'].format(lang=lang, program_id=program_id)
+    return _load_json_full_url('artetv_program', url, None).get('value', {})
 
+def get_parent_collection(lang, program_id):
+    """
+    Get parent collection of program program_id.
+    Return an empty list, if nothing found.
+    """
+    artetv_program_stream = program_video(lang, program_id)
+    if artetv_program_stream:
+        for zone in artetv_program_stream.get('zones', []):
+            if zone.get('content'):
+                for data in zone.get('content').get('data'):
+                    return data.get('parentCollections', [])
+    return []
+
+def is_of_kind(arte_item, kind):
+    """Return true if arte_item is not None and of the kind provided as parameter"""
+    return (arte_item and arte_item.get('kind') == kind) or False
 
 def category(category_code, lang):
     """Get the info of category with category_code."""
     url = _HBBTV_ENDPOINTS['category'].format(category_code=category_code, lang=lang)
-    return _load_json(url).get('category', {})
+    return _load_json('hbbtv_category', url).get('category', {})
 
 
 def collection(kind, collection_id, lang):
     """Get the info of collection collection_id"""
     url = _HBBTV_ENDPOINTS['collection'].format(
         kind=kind, collection_id=collection_id, lang=lang)
-    sub_collections = _load_json(url).get('subCollections', [])
+    sub_collections = _load_json('hbbtv_collection', url).get('subCollections', [])
     return hof.flat_map(
         lambda sub_collections: sub_collections.get('videos', []),
         sub_collections)
+
+def collection_with_last_viewed(lang, tkn, kind, collection_id):
+    """
+    Get the info of collection collection_id and enhanced them with last_viewed details
+    e.g. progress
+    """
+    collection_items = collection(kind, collection_id, lang)
+    last_viewed_items = get_last_viewed(lang, tkn)
+    # nothing to do
+    if len(collection_items) < 1 or last_viewed_items is None or len(last_viewed_items) < 1:
+        return collection_items
+    # merge the 2 collection based on program id.
+    last_viewed_map = {}
+    for item in last_viewed_items:
+        last_viewed_map[item.get('programId')] = item
+    for idx, basic_item in enumerate(collection_items):
+        if basic_item is not None and basic_item.get('programId') is not None:
+            enhanced_item = last_viewed_map.get(basic_item.get('programId'))
+            if enhanced_item is not None:
+                collection_items[idx] = enhanced_item
+    return collection_items
 
 
 def video(program_id, lang):
     """Get the info of content program_id from HBB TV API."""
     url = _HBBTV_ENDPOINTS['video'].format(
         program_id=program_id, lang=lang)
-    return _load_json(url).get('videos', [])[0]
+    return _load_json('hbbtv_video', url).get('videos', [])[0]
 
 
 def streams(kind, program_id, lang):
     """Get the stream info of content program_id."""
     url = _HBBTV_ENDPOINTS['streams'].format(
         kind=kind, program_id=program_id, lang=lang)
-    return _load_json(url).get('videoStreams', [])
+    return _load_json('hbbtv_streams', url).get('videoStreams', [])
 
 def page_content(lang):
     """Get content to be display in a page. It can be a page for a category or the home page."""
     url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['page'].format(
         lang=lang, category='HOME', client='tv')
-    return _load_json_full_url(url, ARTETV_HEADERS).get('value', [])
+    return _load_json_full_url('artetv_home', url, ARTETV_HEADERS).get('value', [])
 
 def search(lang, query, page='1'):
     """Search for content in Arte TV API.
@@ -160,84 +228,62 @@ def search(lang, query, page='1'):
     url = ARTETV_RPROXY_URL + ARTETV_ENDPOINTS['page'].format(
         lang=lang, category='SEARCH', client='tv')
     params = {'page' : page, 'query' : query}
-    return _load_json_full_url(url, ARTETV_HEADERS, params).get('value', []).get('zones', [None])[0]
+    return _load_json_full_url('artetv_search', url, ARTETV_HEADERS, params).get(
+        'value', []).get('zones', [None])[0]
 
-def _load_json(path, headers=None):
+def _load_json(request_scope, path, headers=None):
     """Deprecated since 2022. Prefer building url on client side"""
     if headers is None:
         headers = _HBBTV_HEADERS
     url = _HBBTV_URL + path
-    return _load_json_full_url(url, headers)
+    return _load_json_full_url(request_scope, url, headers)
 
-def _load_json_full_url(url, headers=None, params=None):
+def _load_json_full_url(request_scope, url, headers=None, params=None):
     if headers is None:
         headers = _HBBTV_HEADERS
     # https://requests.readthedocs.io/en/latest/
     reply = requests.get(url, headers=headers, params=params, timeout=10)
+    logger.log_json(reply, request_scope)
     return reply.json(object_pairs_hook=OrderedDict)
 
-def _load_json_personal_content(plugin, url, usr, pwd, hdrs=None):
+def _load_json_personal_content(request_scope, url, tkn, hdrs=None):
     """Get a bearer token and add it in headers before sending the request"""
     if hdrs is None:
         hdrs = ARTETV_HEADERS
-    headers = _add_auth_token(plugin, usr, pwd, hdrs)
+    headers = _add_auth_token(tkn, hdrs)
     if not headers:
         return None
-    return _load_json_full_url(url, headers).get('data', [])
+    return _load_json_full_url(request_scope, url, headers).get('data', [])
 
 # Get a bearer token and add it as HTTP header authorization
-def _add_auth_token(plugin, usr, pwd, hdrs):
-    tkn = get_and_persist_token(plugin, usr, pwd)
+def _add_auth_token(tkn, hdrs):
     if not tkn:
         return None
     headers = hdrs.copy()
-    headers['authorization'] = tkn['token_type'] + ' ' + tkn['access_token']
+    headers['authorization'] = f"{tkn['token_type']} {tkn['access_token']}"
     # web client needed to reuse token. Otherwise API rejects with
     # {"error":"invalid_client","error_description":"Client not authorized"}
     headers['client'] = 'web'
     return headers
 
 
-def get_and_persist_token(plugin, username='', password='', headers=None):
+def get_and_persist_token_in_arte(plugin, username, password):
     """Log in user thanks to his/her settings and get a bearer token.
     Return None if:
         - any parameter is empty
         - silenty if both parameters are empty
         - with a notification if one is not empty
         - connection to arte tv failed"""
-    if headers is None:
-        headers = ARTETV_HEADERS
-    # unable to authenticate if either username or password are empty
-    if not username and not password:
-        plugin.notify(msg=plugin.addon.getLocalizedString(30022), image='info')
-        return None
-    # inform that settings are incomplete
-    if not username or not password:
-        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30021)}"
-        plugin.notify(msg=msg, image='warning')
-        return None
 
-    cached_token = plugin.get_storage('token', TTL=24*60)
-    token_idx = f"{username}_{hash(password)}"
-    if token_idx in cached_token:
-        tkn_data = cached_token[token_idx]
-        xbmc.log(f"\"{username}\" already authenticated to Arte TV : {tkn_data['access_token']}")
-        return tkn_data
-
-    # set client to web, because with tv get error client_invalid, error Client not authorized
-    headers['client'] = 'web'
-
-    tokens = authenticate_in_arte(plugin, username, password, headers)
+    tokens = authenticate_in_arte(plugin, username, password)
     # exit if authentication failed
     if not tokens:
         return None
 
     # try to persist token in arte to be allowed to reuse; otherwise token is one-shot
-    if persist_token_in_arte(plugin, tokens, headers):
-        # token persisted remotly are stored in kodi cache to be reused
-        cached_token[token_idx] = tokens
-        xbmc.log(f"\"{username}\" is successfully authenticated to Arte TV")
-        xbmc.log(f"Token persisted for a day \"{tokens['access_token']}\"")
+    if not persist_token_in_arte(plugin, tokens):
+        return None
+
     # return persisted or unpersisted token anyway
     return tokens
 
@@ -248,6 +294,9 @@ def authenticate_in_arte(plugin, username='', password='', headers=None):
     (i.e. status 200, no exception)"""
     if headers is None:
         headers = ARTETV_HEADERS
+    # set client to web, because with tv get error client_invalid, error Client not authorized
+    headers['client'] = 'web'
+
     url = _ARTETV_URL + ARTETV_ENDPOINTS['token']
     token_data = {
         'anonymous_token': None,
@@ -261,19 +310,20 @@ def authenticate_in_arte(plugin, username='', password='', headers=None):
     try:
         # https://requests.readthedocs.io/en/latest/
         reply = requests.post(url, data=token_data, headers=headers, timeout=10)
+        logger.log_json(reply, 'artetv_auth')
     except requests.exceptions.ConnectionError as err:
         # unable to auth. e.g.
         # HTTPSConnectionPool(host='api.arte.tv', port=443):
         # Max retries exceeded with url: /api/sso/v3/token
         error = err
     if error or not reply or reply.status_code != 200:
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='error')
         err_dtls = str(error) if error else (reply.text if reply is not None else '')
-        xbmc.log(f"Unable to authenticate to Arte TV : {err_dtls}")
+        xbmc.log(f"Unable to authenticate to Arte TV : {err_dtls}", level=xbmc.LOGERROR)
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='error')
         return None
     return reply.json(object_pairs_hook=OrderedDict)
 
-def persist_token_in_arte(plugin, tokens, headers):
+def persist_token_in_arte(plugin, tokens, headers=None):
     """Calls the sequence of 2 services to be able to reuse authentication token
     Return True, if token is persisted, False otherwise.
     Notify the user with a warning if persistance failed.
@@ -287,6 +337,11 @@ def persist_token_in_arte(plugin, tokens, headers):
         'TC_PRIVACY_CENTER' : None
     }
 
+    if headers is None:
+        headers = ARTETV_HEADERS
+    # set client to web, because with tv get error client_invalid, error Client not authorized
+    headers['client'] = 'web'
+
     # step 1/2 : get additional cookies for step 2.
     url = _ARTETV_AUTH_URL + ARTETV_ENDPOINTS['custom_token']
     params = {
@@ -299,12 +354,15 @@ def persist_token_in_arte(plugin, tokens, headers):
     cstm_tkn = None
     try:
         cstm_tkn = requests.get(url,params=params, headers=headers, cookies=cookies, timeout=10)
+        logger.log_json(cstm_tkn, 'artetv_customtoken')
     except requests.exceptions.ConnectionError as err:
         error = err
     if error or not cstm_tkn or cstm_tkn.status_code != 200:
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
         err_dtls = str(error) if error else (cstm_tkn.text if cstm_tkn is not None else '')
-        xbmc.log(f"Unable to persist Arte TV token {tokens['access_token']}. Step 1/2: {err_dtls}")
+        xbmc.log(
+            f"Unable to persist Arte TV token {tokens['access_token']}. Step 1/2: {err_dtls}",
+            level=xbmc.LOGERROR)
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
         return False
 
     # step 2/2 : persist / remember token so that it can be reused
@@ -314,12 +372,15 @@ def persist_token_in_arte(plugin, tokens, headers):
     login = None
     try:
         login = requests.get(url,params=params, headers=headers, cookies=cookies, timeout=10)
+        logger.log_json(login, 'artetv_login')
     except requests.exceptions.ConnectionError as err:
         error = err
     if error or not login or login.status_code != 200:
-        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
         err_dtls = str(error) if error else (login.text if login is not None else '')
-        xbmc.log(f"Unable to persist Arte TV token {tokens['access_token']}. Step 2/2: {err_dtls}")
+        xbmc.log(
+            f"Unable to persist Arte TV token {tokens['access_token']}. Step 2/2: {err_dtls}",
+            level=xbmc.LOGERROR)
+        plugin.notify(msg=plugin.addon.getLocalizedString(30020), image='warning')
         return False
 
     return True

--- a/plugin.video.arteplussept/resources/lib/logger.py
+++ b/plugin.video.arteplussept/resources/lib/logger.py
@@ -1,0 +1,40 @@
+"""Utilities to write log files with api traces"""
+
+from os.path import join as OSPJoin
+from datetime import datetime
+# pylint: disable=import-error
+from xbmcswift2 import Plugin
+# pylint: disable=import-error
+from xbmcswift2 import xbmcvfs
+from . import settings
+
+def log_json(reply, log_suffix):
+    """save request and response in reply into a file
+    with file name containing log_suffix in addon user data
+    if loglevel settings is set to API.
+    :param reply Python requests library object with every information to log
+    :param log_suffix string to be used in log file name along current date and time
+    """
+    plugin = Plugin()
+    msettings = settings.Settings(plugin)
+    if (not reply or msettings.loglevel != settings.loglevel[1]):
+        return
+
+    base_path = plugin.storage_path
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S%f')
+    log_path = OSPJoin(base_path, f"{timestamp}_{log_suffix}.json")
+    reqhdrs = format_headers(reply.request.headers)
+    reshdrs = format_headers(reply.headers)
+    with xbmcvfs.File(log_path, 'w') as log_file:
+        log_file.write("---------------- request ----------------\n")
+        log_file.write(f"{reply.request.method} {reply.request.url}\n")
+        log_file.write(f"{reqhdrs}\n")
+        log_file.write(f"payload : {reply.request.body}\n")
+        log_file.write("---------------- response ----------------\n")
+        log_file.write(f"{reply.status_code} {reply.reason} {reply.url}\n")
+        log_file.write(f"{reshdrs}\n")
+        log_file.write(f"payload : {reply.text}")
+
+def format_headers (headers):
+    """Map headers into a readable string to be logged"""
+    return '\n'.join(f'{k}: {v}' for k, v in headers.items())

--- a/plugin.video.arteplussept/resources/lib/settings.py
+++ b/plugin.video.arteplussept/resources/lib/settings.py
@@ -1,6 +1,7 @@
 """Add-on settings"""
 languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
 qualities = ['SQ', 'EQ', 'HQ']
+loglevel = ['DEFAULT', 'API']
 
 
 class Settings:
@@ -23,7 +24,6 @@ class Settings:
 		# defaults to empty string to return false with if not str
         self.username = plugin.get_setting(
             'username') or ""
-		# Arte TV user password
-		# defaults to empty string to return false with if not str
-        self.password = plugin.get_setting(
-            'password') or ""
+        # Enable additional logs managed by plugin : API messages
+        self.loglevel = plugin.get_setting(
+            'loglevel', choices=loglevel) or loglevel[0]

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -1,0 +1,150 @@
+"""
+Manage Arte user content and state e.g. favorites and last vieweds.
+Manage settings and user interactions to create a token.
+Manage token in cache. Avoid storing password in settings, only token.
+"""
+
+# pylint: disable=import-error
+from xbmcswift2 import xbmc
+from xbmcswift2 import xbmcgui
+
+from resources.lib import api
+
+# key to manage token in plugin storage
+_STORAGE_KEY = 'token'
+# Time to live of 30d
+_TTL = 30*24*60
+
+def login(plugin, settings):
+    """
+    Get user password from UI, create a token with Arte API, persist it in storage
+    and update settings state to show user is logged in.
+    """
+    erase_password_in_old_config(plugin)
+
+    # ensure user to log in is identified
+    usr = settings.username
+    if not usr:
+        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30021)}"
+        plugin.notify(msg=msg, image='error')
+        return False
+
+    # ensure no user is not logged in
+    loggedin_usr = is_logged_in_as(plugin)
+    tkn_data = get_cached_token(plugin, usr, True)
+    if len(loggedin_usr) > 0 and tkn_data:
+        xbmc.log(
+            f"\"{loggedin_usr}\" already authenticated to Arte TV : {tkn_data['access_token']}")
+        # notify user that current token might be replaced
+        accept_to_replace = xbmcgui.Dialog().yesno(
+            plugin.addon.getLocalizedString(30015),
+            plugin.addon.getLocalizedString(30016).format(new_user=usr, old_user=loggedin_usr),
+            autoclose=10000
+        )
+        # user didn't accept replacement, so leave
+        if not accept_to_replace:
+            xbmc.log('Authentication aborted by user - keep initial token', level=xbmc.LOGWARNING)
+            return False
+
+    # get password
+    pwd = get_user_password(plugin)
+    if not pwd:
+        xbmc.log('Authentication aborted by user - no password entered', level=xbmc.LOGWARNING)
+        msg = f"{plugin.addon.getLocalizedString(30020)} : {plugin.addon.getLocalizedString(30022)}"
+        plugin.notify(msg=msg, image='error')
+        return False
+
+    # get token for user and password
+    tokens = api.get_and_persist_token_in_arte(plugin, usr, pwd)
+    if tokens is None:
+        xbmc.log('Authentication failed in arte', level=xbmc.LOGERROR)
+        msg = f"{plugin.addon.getLocalizedString(30020)}"
+        plugin.notify(msg=msg, image='error')
+        return False
+
+    # store token
+    set_cached_token(plugin, usr, tokens)
+    update_settings_state(plugin, usr)
+    msg = plugin.addon.getLocalizedString(30017).format(user=usr)
+    plugin.notify(msg=msg, image='info')
+    return True
+
+
+def get_user_password(plugin):
+    """
+    Display a keyboard to get user password.
+    Return None. If user didn't enter a password or close the UI.
+    """
+    user_password = ''
+    keyboard = xbmc.Keyboard(user_password, plugin.addon.getLocalizedString(30019), True)
+    keyboard.doModal()
+    if keyboard.isConfirmed() is False:
+        return None
+    user_password = keyboard.getText()
+    if len(user_password) == 0:
+        return None
+    return user_password
+
+
+def logout(plugin, settings):
+    """Delete user token and reset settings state"""
+    erase_password_in_old_config(plugin)
+
+    set_cached_token(plugin, settings.username, '')
+    clear_cached_tokens(plugin)
+    update_settings_state(plugin, '')
+
+    plugin.notify(msg=plugin.addon.getLocalizedString(30018), image='info')
+    return True
+
+
+def update_settings_state(plugin, usr):
+    """Update setting state to know who belong the token to"""
+    message = plugin.addon.getLocalizedString(30017).format(user=usr)
+    if usr is None or len(usr) <= 0:
+        message = plugin.addon.getLocalizedString(30018)
+    return plugin.set_setting('login_acc', message)
+
+def is_logged_in_as(plugin):
+    """Extract the logged in user from settings state"""
+    login_acc = plugin.get_setting('login_acc')
+    usr = ''
+    if isinstance(login_acc, str) and len(login_acc) > 1:
+        # remove everything before opening double quote included
+        usr = login_acc[login_acc.find('"')+1:]
+        # remove everything after closing double quote included
+        usr = usr[:usr.rfind('"')]
+    return usr
+
+
+def get_cached_token(plugin, token_idx, silent=False):
+    """
+    Return cached token for identified user or None.
+    If user logged in and later changed the user email, it returns None
+    """
+    cached_token = plugin.get_storage(_STORAGE_KEY, TTL=_TTL)
+    if token_idx in cached_token and isinstance(cached_token[token_idx], dict):
+        tokens = cached_token[token_idx]
+    else :
+        tokens = None
+        if not silent:
+            plugin.notify(msg=plugin.addon.getLocalizedString(30014), image='warning')
+    return tokens
+
+def set_cached_token(plugin, token_idx, tokens):
+    """Set cached token"""
+    cached_token = plugin.get_storage(_STORAGE_KEY)
+    cached_token[token_idx] = tokens
+
+def clear_cached_tokens(plugin):
+    """Clear every tokens. Not just the one of the user in parameter."""
+    cached_token = plugin.get_storage(_STORAGE_KEY)
+    cached_token.clear()
+
+def erase_password_in_old_config(plugin):
+    """
+    Clean old password, that could be stored in settings from old way
+    to authenticate user.
+    Deprecated since creation JUL2023, v1.3.0.
+    """
+    return plugin.set_setting('password', '')

--- a/plugin.video.arteplussept/resources/lib/utils.py
+++ b/plugin.video.arteplussept/resources/lib/utils.py
@@ -76,3 +76,20 @@ def is_playlist(program_id):
     if isinstance(program_id, str):
         is_playlist_var = program_id.startswith('RC-') or program_id.startswith('PL-')
     return is_playlist_var
+
+
+def get_progress(item):
+    """
+    Return item progress or 0 as float.
+    Never None, even if lastviewed or item is None.
+    """
+    # pylint raises that it is not snake_case. it's in uppercase, because it's a constant
+    # pylint: disable=invalid-name
+    DEFAULT_PROGRESS = 0.0
+    if not item:
+        return DEFAULT_PROGRESS
+    if not item.get('lastviewed'):
+        return DEFAULT_PROGRESS
+    if not item.get('lastviewed').get('progress'):
+        return DEFAULT_PROGRESS
+    return float(item.get('lastviewed') and item.get('lastviewed').get('progress'))

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -1,9 +1,14 @@
 """Manage views like home menu, dynamic menus, search, favorites..."""
 # pylint: disable=import-error
 from xbmcswift2 import xbmc
+# pylint: disable=import-error
+from xbmcswift2 import xbmcgui
 
 from . import api
+from . import hof
 from . import mapper
+from . import settings as stg
+from . import user
 
 
 def build_home_page(cached_categories, settings):
@@ -12,7 +17,7 @@ def build_home_page(cached_categories, settings):
         mapper.create_search_item(),
     ]
     try:
-        live_stream_data = api.program_video(settings.language, 'LIVE')
+        live_stream_data = api.player_video(settings.language, 'LIVE')
         live_stream_item = mapper.map_live_video(
             live_stream_data, settings.quality, '1')
         addon_menu.append(live_stream_item)
@@ -46,16 +51,16 @@ def get_cached_category(category_title, most_viewed_categories):
 
 def build_favorites(plugin, settings):
     """Build the menu for user favorites thanks to API call"""
-    return [mapper.map_artetv_video(item) for item in
-            api.get_favorites(plugin, settings.language, settings.username, settings.password) or
+    return [mapper.map_artetv_item(item) for item in api.get_favorites(
+                settings.language, user.get_cached_token(plugin, settings.username)) or
             # display an empty list in case of error. error should be display in a notification
             []]
 
 
-def add_favorite(plugin, usr, pwd, program_id, label):
+def add_favorite(plugin, usr, program_id, label):
     """Add content program_id to user favorites.
     Notify about completion success or failure with label."""
-    if 200 == api.add_favorite(plugin, usr, pwd, program_id):
+    if 200 == api.add_favorite(user.get_cached_token(plugin, usr), program_id):
         msg = plugin.addon.getLocalizedString(30025).format(label=label)
         plugin.notify(msg=msg, image='info')
     else:
@@ -63,10 +68,10 @@ def add_favorite(plugin, usr, pwd, program_id, label):
         plugin.notify(msg=msg, image='error')
 
 
-def remove_favorite(plugin, usr, pwd, program_id, label):
+def remove_favorite(plugin, usr, program_id, label):
     """Remove content program_id from user favorites.
     Notify about completion success or failure with label."""
-    if 200 == api.remove_favorite(plugin, usr, pwd, program_id):
+    if 200 == api.remove_favorite(user.get_cached_token(plugin, usr), program_id):
         msg = plugin.addon.getLocalizedString(30027).format(label=label)
         plugin.notify(msg=msg, image='info')
     else:
@@ -74,20 +79,61 @@ def remove_favorite(plugin, usr, pwd, program_id, label):
         plugin.notify(msg=msg, image='error')
 
 
+def purge_favorites(plugin, usr):
+    """Flush user favorites and notify about success or failure"""
+    purge_confirmed = xbmcgui.Dialog().yesno(
+        plugin.addon.getLocalizedString(30040),
+        plugin.addon.getLocalizedString(30043),
+        autoclose=10000)
+
+    if purge_confirmed:
+        if 200 == api.purge_favorites(user.get_cached_token(plugin, usr)):
+            plugin.notify(msg=plugin.addon.getLocalizedString(30041), image='info')
+        else:
+            plugin.notify(msg=plugin.addon.getLocalizedString(30042), image='error')
+
+
+def mark_as_watched(plugin, usr, program_id, label):
+    """
+    Get program duration and synch progress with total duration
+    in order to mark a program as watched
+    """
+    status = -1
+    try:
+        program_info = api.player_video(stg.languages[0], program_id)
+        total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
+        status = api.sync_last_viewed(user.get_cached_token(plugin, usr), program_id, total_time)
+    # pylint: disable=broad-exception-caught
+    except Exception as excp:
+        xbmc.log(f" exception caught :{str(excp)}")
+
+    if 200 == status:
+        msg = plugin.addon.getLocalizedString(30036).format(label=label)
+        plugin.notify(msg=msg, image='info')
+    else:
+        msg = plugin.addon.getLocalizedString(30037).format(label=label)
+        plugin.notify(msg=msg, image='error')
+
+
 def build_last_viewed(plugin, settings):
     """Build the menu of user history"""
-    return [mapper.map_artetv_video(item) for item in
-            api.get_last_viewed(plugin, settings.language, settings.username, settings.password) or
+    return [mapper.map_artetv_item(item) for item in api.get_last_viewed(
+                settings.language, user.get_cached_token(plugin, settings.username)) or
             # display an empty list in case of error. error should be display in a notification
             []]
 
 
-def purge_last_viewed(plugin, usr, pwd):
+def purge_last_viewed(plugin, usr):
     """Flush user history and notify about success or failure"""
-    if 200 == api.purge_last_viewed(plugin, usr, pwd):
-        plugin.notify(msg=plugin.addon.getLocalizedString(30031), image='info')
-    else:
-        plugin.notify(msg=plugin.addon.getLocalizedString(30032), image='error')
+    purge_confirmed = xbmcgui.Dialog().yesno(
+        plugin.addon.getLocalizedString(30030),
+        plugin.addon.getLocalizedString(30033),
+        autoclose=10000)
+    if purge_confirmed:
+        if 200 == api.purge_last_viewed(user.get_cached_token(plugin, usr)):
+            plugin.notify(msg=plugin.addon.getLocalizedString(30031), image='info')
+        else:
+            plugin.notify(msg=plugin.addon.getLocalizedString(30032), image='error')
 
 
 def build_mixed_collection(kind, collection_id, settings):
@@ -110,8 +156,44 @@ def build_video_streams(program_id, settings):
         item, api.streams(kind, program_id, settings.language), settings.quality)
 
 
+def build_sibling_playlist(plugin, settings, program_id):
+    """
+    Return a pair with videos belonging to the same parent as program id
+    e.g. other episodes of a same serie, videos around the same topic
+    and the start program id of this collection i.e. program_id
+    """
+    parent_program = None
+    # get parent of prefered kind first. for the moment TV_SERIES only
+    for prefered_kind in mapper.PREFERED_KINDS:
+        # pylint: disable=cell-var-from-loop
+        parent_program = hof.find(
+            lambda parent: api.is_of_kind(parent, prefered_kind),
+            api.get_parent_collection(settings.language, program_id))
+        if parent_program:
+            break
+    # if a parent was found, then return the list of kodi playable dict.
+    if parent_program:
+        sibling_arte_items = api.collection_with_last_viewed(
+            settings.language, user.get_cached_token(plugin, settings.username, True),
+            parent_program.get('kind'), parent_program.get('programId'))
+        return mapper.map_collection_as_playlist(sibling_arte_items, program_id)
+    return None
+
+def build_collection_playlist(plugin, settings, kind, collection_id):
+    """
+    Return a pair with collection with collection_id
+    and program id of the first element in the collection
+    """
+    return mapper.map_collection_as_playlist(api.collection_with_last_viewed(
+        settings.language,
+        user.get_cached_token(plugin, settings.username, True),
+        kind, collection_id))
+
 def build_stream_url(plugin, kind, program_id, audio_slot, settings):
-    """Return URL to stream content"""
+    """
+    Return URL to stream content.
+    If the content is not available, it tries to return a related trailer or teaser.
+    """
     # first try with content
     program_stream = api.streams(kind, program_id, settings.language)
     if program_stream:
@@ -133,8 +215,7 @@ def search(plugin, settings):
     query = get_search_query(plugin)
     if not query:
         plugin.end_of_directory(succeeded=False)
-    return mapper.map_cached_categories(
-        api.search(settings.language, query))
+    return mapper.map_collection_as_menu(api.search(settings.language, query))
 
 
 def get_search_query(plugin):

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-
-    <!-- General -->
-    <category label="30044">
+	<!-- General -->
+	<category label="30044">
 		<setting
 			id="lang"
 			type="enum"
 			label="30050"
 			values="fr|de|en|es|pl|it"
 			default="0"/>
-		<!-- <setting id="prefer_vost"      type="bool"   label="30051" default="false"/> -->
 		<setting
 			id="quality"
 			type="enum"
@@ -21,18 +19,34 @@
 			type="bool"
 			label="30053"
 			default="false"/>
+		<setting
+			id="loglevel"
+			type="enum"
+			label="30056"
+			values="DEFAULT|API"
+			default="0"/>
 	</category>
 	
-    <!-- Profile -->
-    <category label="30045">
+	<!-- Profile -->
+	<category label="30045">
 		<setting
 			id="username"
 			type="text"
 			label="30054" />
 		<setting
-			id="password"
+			type="action"
+			action="RunPlugin(plugin://plugin.video.arteplussept/user/login)"
+			label="30057" />
+		<setting
+			id="login_acc"
 			type="text"
-			option="hidden"
-			label="30055" />
+			enable="false"
+			default=""
+			subsetting="true"
+			label="" />
+		<setting
+			type="action"
+			action="RunPlugin(plugin://plugin.video.arteplussept/user/logout)"
+			label="30058" />
 	</category>
 </settings>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.2.0
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/known-as-bmf/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/known-as-bmf/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/known-as-bmf/plugin.video.arteplussept
        

### Description of changes:


        Highlights since 1.1.10
        - Manage collections TV_SERIES and MAGAZINE as video playlist
        - Add a context menu item to purge favorites
        - Add a context menu item to mark as video as watched in Arte
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
