### PR TITLE
[plugin.video.svtplay@matrix] 5.1.20+matrix.1

### DIFF
--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.19+matrix.1">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.20+matrix.1">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="3.0.0" />
@@ -19,7 +19,7 @@
     <source>https://github.com/nilzen/xbmc-svtplay</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=67110</forum>
     <news>
-- Fixes broken listings due to provider change
+- Updates to program listings
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/plugin.video.svtplay/resources/lib/api/graphql.py
+++ b/plugin.video.svtplay/resources/lib/api/graphql.py
@@ -104,24 +104,24 @@ class GraphQL:
     if not json_data:
       return None
     items = json_data["selectionById"]["items"]
-    video_items = []
+    list_items = []
     for teaser in items:
-      raw_item = teaser["item"]
-      season_title = ""
-      if teaser["__typename"] == "season" and teaser["name"]:
-        season_title = teaser["name"]
-      title = raw_item["name"]
-      video_id = raw_item["urls"]["svtplay"]
-      geo_restricted = raw_item["restrictions"]["onlyAvailableInSweden"]
-      thumbnail = self.get_thumbnail_url(raw_item["images"]["cleanWide"]["id"], raw_item["images"]["cleanWide"]["changed"]) if "images" in raw_item else ""
+      item = teaser["item"]
+      title = item["name"]
+      if self.__is_video(item["__typename"]) and item["__typename"] != "Single":
+        title = "{tvshow} - {episode}".format(episode=item["name"], tvshow=item["parent"]["name"])
+      item_id = item["urls"]["svtplay"]
+      geo_restricted = item["restrictions"]["onlyAvailableInSweden"]
+      thumbnail = self.get_thumbnail_url(item["images"]["cleanWide"]["id"], item["images"]["cleanWide"]["changed"]) if "images" in item else ""
       fanart = self.get_fanart_url(teaser["images"]["wide"]["id"], teaser["images"]["wide"]["changed"]) if "images" in teaser else ""
       info = {
         "plot" : teaser["description"],
-        "duration" : raw_item.get("duration", 0)
+        "duration" : item.get("duration", 0),
+        "episode" : item.get("number", 0),
+        "tvshowtitle" : item["parent"]["name"] if "parent" in item else ""
       }
-      video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart, season_title)
-      video_items.append(video_item)
-    return video_items
+      list_items.append(self.__create_item(title, item["__typename"], item_id, geo_restricted, thumbnail, info, fanart))
+    return list_items
 
   def getVideoContent(self, slug):
     operation_name = "DetailsPageQuery"
@@ -136,22 +136,22 @@ class GraphQL:
     show_data = json_data["detailsPageByPath"]
     show_image_id = show_data["images"]["wide"]["id"]
     show_image_changed = show_data["images"]["wide"]["changed"]
-    for content in json_data["detailsPageByPath"]["associatedContent"]:
-      if content["id"] == "upcoming":
+    for selection in json_data["detailsPageByPath"]["associatedContent"]:
+      if selection["id"] == "upcoming":
         continue
-      for content_item in content["items"]:
-        item = content_item["item"]
-        season_title = ""
-        if content["selectionType"] == "season" and content["name"]:
-          season_title = content["name"]
+      for teaser in selection["items"]:
+        item = teaser["item"]
+        season_title = selection["name"] if selection["selectionType"] == "season" else ""
         title = item["name"]
         video_id = item["urls"]["svtplay"]
         geo_restricted = item["restrictions"]["onlyAvailableInSweden"]
-        thumbnail = self.get_thumbnail_url(item["image"]["id"], item["image"]["changed"]) if "image" in item else ""
+        thumbnail = self.get_thumbnail_url(item["images"]["cleanWide"]["id"], item["images"]["cleanWide"]["changed"]) if "images" in item else ""
         fanart = self.get_fanart_url(show_image_id, show_image_changed)
         info = {
-          "plot" : content_item["description"],
-          "duration" : item.get("duration", 0)
+          "plot" : teaser["description"],
+          "duration" : item.get("duration", 0),
+          "episode" : item.get("number", 0),
+          "tvshowtitle" : item["parent"]["name"] if "parent" in item else ""
         }
         video_item = VideoItem(title, video_id, thumbnail, geo_restricted, info, fanart, season_title)
         video_items.append(video_item)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SVT Play
  - Add-on ID: plugin.video.svtplay
  - Version number: 5.1.20+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/nilzen/xbmc-svtplay
  
With this addon you can stream content from SVT Play (svtplay.se).

### Description of changes:


- Updates to program listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
