### PR TITLE
[plugin.video.svtplay@matrix] 5.1.21+matrix.1

### DIFF
--- a/plugin.video.svtplay/addon.xml
+++ b/plugin.video.svtplay/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.20+matrix.1">
+<addon id="plugin.video.svtplay" name="SVT Play" provider-name="nilzen" version="5.1.21+matrix.1">
   <requires>
     <import addon="script.module.requests" version="2.22.0" />
     <import addon="xbmc.python" version="3.0.0" />
@@ -19,7 +19,7 @@
     <source>https://github.com/nilzen/xbmc-svtplay</source>
     <forum>https://forum.kodi.tv/showthread.php?tid=67110</forum>
     <news>
-- Updates to program listings
+- Update genre listings
     </news>
     <assets>
       <icon>icon.png</icon>

--- a/plugin.video.svtplay/resources/lib/api/graphql.py
+++ b/plugin.video.svtplay/resources/lib/api/graphql.py
@@ -23,16 +23,16 @@ class GraphQL:
     pass
 
   def getPopular(self):
-    return self.getGridPageContents("popular_start")
+    return self.getFionaPageContainer("popular_start")
 
   def getLatest(self):
-    return self.getGridPageContents("latest_start")
+    return self.getFionaPageContainer("latest_start")
   
   def getLastChance(self):
-    return self.getGridPageContents("lastchance_start")
+    return self.getFionaPageContainer("lastchance_start")
 
   def getLive(self):
-    return self.getGridPageContents("live_start")
+    return self.getFionaPageContainer("live_start")
 
   def getAtoO(self):
     return self.__get_all_programs()
@@ -86,19 +86,20 @@ class GraphQL:
       item = teaser["item"]
       title = item["name"]
       item_id = item["urls"]["svtplay"]
-      thumbnail = self.get_thumbnail_url(item["image"]["id"], item["image"]["changed"]) if "image" in item else ""
+      thumbnail = self.get_thumbnail_url(teaser["images"]["wide"]["id"], teaser["images"]["wide"]["changed"]) if "images" in teaser else ""
+      fanart = self.get_fanart_url(item["images"]["cleanWide"]["id"], item["images"]["cleanWide"]["changed"]) if "images" in item else ""
       geo_restricted = item["restrictions"]["onlyAvailableInSweden"]
       info = {
-        "plot" : teaser["subHeading"]
+        "plot" : teaser.get("description", "")
       }
       type_name = item["__typename"]
-      play_item = self.__create_item(title, type_name, item_id, geo_restricted, thumbnail, info)
+      play_item = self.__create_item(title, type_name, item_id, geo_restricted, thumbnail, info, fanart)
       programs.append(play_item)
     return programs
-  
-  def getGridPageContents(self, selectionId):
+
+  def getFionaPageContainer(self, selectionId):
     operation_name = "GridPage"
-    query_hash = "a8248fc130da34208aba94c4d5cc7bd44187b5f36476d8d05e03724321aafb40"
+    query_hash = "1e2d15ff7ffa578d33ebf1287d3f7af7fd47125552b564e96fd277a744345a69"
     variables = {"selectionId" : selectionId}
     json_data = self.__get(operation_name, query_hash, variables=variables)
     if not json_data:
@@ -123,7 +124,7 @@ class GraphQL:
       list_items.append(self.__create_item(title, item["__typename"], item_id, geo_restricted, thumbnail, info, fanart))
     return list_items
 
-  def getVideoContent(self, slug):
+  def getEpisodesForPath(self, slug):
     operation_name = "DetailsPageQuery"
     query_hash = "e240d515657bbb54f33cf158cea581f6303b8f01f3022ea3f9419fbe3a5614b0"
     variables = {"path":"/{}".format(slug)}

--- a/plugin.video.svtplay/resources/lib/svtplay.py
+++ b/plugin.video.svtplay/resources/lib/svtplay.py
@@ -185,9 +185,9 @@ class SvtPlay:
 
     def view_episodes(self, slug):
         logging.log("View episodes for {}".format(slug))
-        episodes = self.graphql.getVideoContent(slug)
+        episodes = self.graphql.getEpisodesForPath(slug)
         if episodes is None:
-            logging.log("No episodes found")
+            logging.log("No episodes found for {}".format(slug))
             return
         self.__create_dir_items(episodes)
 
@@ -256,7 +256,7 @@ class SvtPlay:
             logging.log("Hiding geo restricted item {} as setting is on".format(play_item.title))
             return
         info = play_item.info
-        fanart = play_item.fanart if play_item.item_type == PlayItem.VIDEO_ITEM else ""
+        fanart = play_item.fanart
         title = play_item.title
         if play_item.item_type == PlayItem.VIDEO_ITEM and play_item.season_title:
             title = "{episode} ({season})".format(season=play_item.season_title, episode=play_item.title)


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: SVT Play
  - Add-on ID: plugin.video.svtplay
  - Version number: 5.1.21+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/nilzen/xbmc-svtplay
  
With this addon you can stream content from SVT Play (svtplay.se).

### Description of changes:


- Update genre listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
