### PR TITLE
[plugin.video.curiositystream] 2.0.6

### DIFF
--- a/plugin.video.curiositystream/addon.xml
+++ b/plugin.video.curiositystream/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.curiositystream" name="Curiositystream" version="2.0.5+matrix.1" provider-name="GMaxera,mintsoft">
+<addon id="plugin.video.curiositystream" name="Curiositystream" version="2.0.6+matrix.1" provider-name="mintsoft,GMaxera">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.requests" version="2.22.0"/>
@@ -18,9 +18,13 @@ The add-on only provides an interface to access CuriosityStream media from Kodi.
     <language>en</language>
     <platform>all</platform>
     <license>GPL-2.0-or-later</license>
-    <email>gmaxera@gmail.com</email>
-    <source>https://github.com/GMaxera/repo-plugins/tree/curiositystream-leia/plugin.video.curiositystream</source>
+    <website>https://github.com/mintsoft/plugin.video.curiositystream</website>
+    <source>https://github.com/mintsoft/plugin.video.curiositystream</source>
     <news>
+v2.0.6
+ - Fixing playback of some content that is only available in 4k (Capturing A Black Hole for example)
+ - Updating contact information to clarify current maintainer
+
 v2.0.5
 - Fix issues breaking all playback (thanks wa3573)
 - Support for kodi 20

--- a/plugin.video.curiositystream/resources/lib/curiositystream.py
+++ b/plugin.video.curiositystream/resources/lib/curiositystream.py
@@ -491,7 +491,7 @@ class CuriosityStream(object):
             "streams": [
                 encoding
                 for encoding in data["data"]["encodings"]
-                if encoding["type"].lower() == "hd"
+                if encoding["type"].lower() == "hd" or encoding["type"].lower() == "4k"
             ],
             "subtitles": data["data"]["closed_captions"]
             if "closed_captions" in data["data"]


### PR DESCRIPTION
### Description
Fixing 4k only streams, also clarifying that I've taken over as maintainer: https://github.com/mintsoft/plugin.video.curiositystream/issues/1

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

