### PR TITLE
[plugin.video.arteplussept@matrix] 1.4.1

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.4.1 (2023-10-10)
+- Fix playing videos with siblings.
+
 v1.4.0 (2023-8-14)
 - Add support for content over multiple pages. Manage pagination for favorites, history, search and collections : when there are more items in the history or favorities than the page size (currently 50), it is now possible to navigate through pages.
 - Refactor most of the code in OO style. Factorize duplicated code.

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.0" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.1" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -56,6 +56,8 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
         <news>
+v1.4.1 (2023-10-10)
+- Fix playing videos with siblings.
 v1.4.0 (2023-8-14)
 - Add support for content over multiple pages.
 - Refactor most of the code in OO style

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -112,7 +112,7 @@ def build_sibling_playlist(plugin, settings, program_id):
         sibling_arte_items = api.collection_with_last_viewed(
             settings.language, user.get_cached_token(plugin, settings.username, True),
             parent_program.get('kind'), parent_program.get('programId'))
-        return mapper.map_collection_as_playlist(sibling_arte_items, program_id)
+        return mapper.map_collection_as_playlist(plugin, sibling_arte_items, program_id)
     return None
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.4.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:


v1.4.1 (2023-10-10)
- Fix playing videos with siblings.
v1.4.0 (2023-8-14)
- Add support for content over multiple pages.
- Refactor most of the code in OO style
v1.3.1 (2023-8-12)
- Add context menu to view collection as menu instead of playlist
- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
v1.3.0 (2023-8-6)
- Improve security with better password management
        - Stop storing password on filesystem though addon settings
- Make thomas-ernest fork official in addon.xml for visibility in wiki
- Minor fix/clean-up in translation
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
