### PR TITLE
[plugin.video.invidious] 0.2.7+nexus.0

### DIFF
--- a/plugin.video.invidious/addon.xml
+++ b/plugin.video.invidious/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.invidious"
   name="Invidious"
-  version="0.2.6+nexus.0"
+  version="0.2.7+nexus.0"
   provider-name="petterreinholdtsen">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>

--- a/plugin.video.invidious/resources/lib/invidious_plugin.py
+++ b/plugin.video.invidious/resources/lib/invidious_plugin.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import json
+import os
 import requests
 import sys
 from urllib.parse import urlencode
@@ -25,6 +26,11 @@ class SearchHistory():
     def __init__(self, history_path, depth=10):
         self.history_path = history_path
         self.depth = depth
+
+        d = os.path.dirname(history_path)
+        if not os.path.exists(d):
+            xbmc.log(f'invidous created state directory {d}.', xbmc.LOGDEBUG)
+            os.mkdir(d)
 
 
     def push(self, query):
@@ -235,7 +241,12 @@ class InvidiousPlugin:
                 "premiered": datestr,
                 "duration": str(video_info["lengthSeconds"])
         })
-        xbmcplugin.setResolvedUrl(self.addon_handle, succeeded=True, listitem=listitem)
+        # basilgello: calling 'RunPlugin' via kodi-send results in CScriptRunner::ExecuteScript
+        # which in turn sets add9n_handle to -1 breaking the playback 
+        if self.addon_handle > -1:
+            xbmcplugin.setResolvedUrl(self.addon_handle, succeeded=True, listitem=listitem)
+        else:
+            xbmc.Player().play(url, listitem)
 
     def display_main_menu(self):
         def add_list_item(label, path):


### PR DESCRIPTION
A privacy-friendly way of watching YouTube content. Uses the great Invidious web service's API to do the heavy lifting.

Make code slightly more robust and work better with API requests.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0