### PR TITLE
[plugin.video.vtm.go@matrix] 1.4.3+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.4.3](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.3) (2023-11-04)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.2...v1.4.3)
+
+**Fixed bugs:**
+
+- Upgrade API to 14 [\#369](https://github.com/add-ons/plugin.video.vtm.go/pull/369) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.4.2](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.2) (2023-07-26)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.1...v1.4.2)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.2+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.3+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,8 +22,8 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.4.2 (2023-07-26)
-- Fix for missing episodes.</news>
+        <news>v1.4.3 (2023-11-04)
+- Fix API.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -17,8 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTM_GO/13.12 (be.vmma.vtm.zenderapp; build:17181; Android TV 28) okhttp/4.10.0',
-    'x-app-version': '13',
+    'User-Agent': 'VTM_GO/14.231023 (be.vmma.vtm.zenderapp; build:18041; Android 23) okhttp/4.11.0',
+    'x-app-version': '14',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '28',

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
@@ -380,8 +380,8 @@ class VtmGo:
         :type search: str
         :rtype list[Union[Movie, Program]]
         """
-        response = util.http_get(API_ENDPOINT + '/%s/search/?query=%s' % (self._mode(),
-                                                                          kodiutils.to_unicode(quote(kodiutils.from_unicode(search)))),
+        response = util.http_get(API_ENDPOINT + '/%s/search?query=%s' % (self._mode(),
+                                                                         kodiutils.to_unicode(quote(kodiutils.from_unicode(search)))),
                                  token=self._tokens.access_token if self._tokens else None,
                                  profile=self._tokens.profile if self._tokens else None)
         results = json.loads(response.text)


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.4.3+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.4.3 (2023-11-04)
- Fix API.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
