### PR TITLE
[plugin.audio.deutschlandfunk] 2.0.8

### DIFF
--- a/plugin.audio.deutschlandfunk/addon.xml
+++ b/plugin.audio.deutschlandfunk/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.deutschlandfunk" name="Deutschlandfunk" version="2.0.7" provider-name="Heckie">
+<addon id="plugin.audio.deutschlandfunk" name="Deutschlandfunk" version="2.0.8" provider-name="Heckie">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.requests" version="2.25.1" />
@@ -25,6 +25,9 @@ sämtliche Podcasts der Sender gestreamt werden.</description>
         <website>https://github.com/Heckie75/kodi-addon-deutschlandfunk</website>
         <source>https://github.com/Heckie75/kodi-addon-deutschlandfunk/tree/master/plugin.audio.deutschlandfunk</source>
         <news>
+v2.0.8 (2023-11-26)
+- Fixed URLs of live streams
+
 v2.0.7 (2023-03-05)
 - Changed URL of Deutschlandfunk Kultur podcasts
 

--- a/plugin.audio.deutschlandfunk/resources/lib/deutschlandfunk/deutschlandfunkaddon.py
+++ b/plugin.audio.deutschlandfunk/resources/lib/deutschlandfunk/deutschlandfunkaddon.py
@@ -15,7 +15,9 @@ class DeutschlandfunkAddon(AbstractRssAddon):
 
     __PLUGIN_ID__ = "plugin.audio.deutschlandfunk"
 
-    URL_STREAMS_RPC = "https://srv.deutschlandradio.de/config-feed.2828.de.rpc"
+    URL_STREAM_DLF = "https://st01.sslstream.dlf.de/dlf/01/high/aac/stream.aac?aggregator=web"
+    URL_STREAM_DFK = "https://st02.sslstream.dlf.de/dlf/02/high/aac/stream.aac?aggregator=web"
+    URL_STREAM_NOVA = "https://st03.sslstream.dlf.de/dlf/03/high/aac/stream.aac?aggregator=web"
 
     URL_PODCASTS_DLF = "https://www.deutschlandfunk.de/podcasts"
     URL_PODCASTS_DFK = "https://www.deutschlandfunkkultur.de/program-and-podcast"
@@ -65,16 +67,6 @@ class DeutschlandfunkAddon(AbstractRssAddon):
 
     def _make_station_menu(self, station):
 
-        try:
-            _json, _cookies = http_request(self.addon, self.URL_STREAMS_RPC)
-            meta = json.loads(_json)
-
-        except HttpStatusError as error:
-            xbmc.log("HTTP Status Error: %s, station=%s" %
-                     (error.message, station), xbmc.LOGERROR)
-            xbmcgui.Dialog().notification(self.addon.getLocalizedString(32151), error.message)
-            return
-
         nodes = list()
         if DeutschlandfunkAddon.PATH_DLF == station:
             nodes.append({
@@ -82,7 +74,7 @@ class DeutschlandfunkAddon(AbstractRssAddon):
                 "name": "Deutschlandfunk",
                 "icon": os.path.join(
                         self.addon_dir, "resources", "assets", "icon_dlf.png"),
-                "stream_url": meta['livestreams']['dlf']['mp3']['high'],
+                "stream_url": DeutschlandfunkAddon.URL_STREAM_DLF,
                 "type": "music",
                 "specialsort": "top"
             })
@@ -100,7 +92,7 @@ class DeutschlandfunkAddon(AbstractRssAddon):
                 "name": "Deutschlandfunk Kultur",
                 "icon": os.path.join(
                         self.addon_dir, "resources", "assets", "icon_drk.png"),
-                "stream_url": meta['livestreams']['dlf_kultur']['mp3']['high'],
+                "stream_url": DeutschlandfunkAddon.URL_STREAM_DFK,
                 "type": "music",
                 "specialsort": "top"
             })
@@ -118,7 +110,7 @@ class DeutschlandfunkAddon(AbstractRssAddon):
                 "name": "Deutschlandfunk Nova",
                 "icon": os.path.join(
                         self.addon_dir, "resources", "assets", "icon_nova.png"),
-                "stream_url": meta['livestreams']['dlf_nova']['mp3']['high'],
+                "stream_url": DeutschlandfunkAddon.URL_STREAM_NOVA,
                 "type": "music",
                 "specialsort": "top"
             })


### PR DESCRIPTION
### Description
v2.0.8 (2023-11-26)
- Fixed URLs of live streams

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
