### PR TITLE
[plugin.video.tagesschau] 2.5.4

### DIFF
--- a/plugin.video.tagesschau/addon.xml
+++ b/plugin.video.tagesschau/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
     id="plugin.video.tagesschau"
-    version="2.5.3"
+    version="2.5.4"
     name="Tagesschau"
     provider-name="J.Schumacher, H.Saul, C.Prasch">
   <requires>
@@ -31,6 +31,10 @@
       <screenshot>resources/assets/screenshot_3.png</screenshot>
     </assets>
     <news>
+version 2.5.4 (2023-12-03)
+ * Fixed content types so that skins use landscape viewtype
+ * Added setting to hide "Europadruck" and "Aktueller Wolkenfilm" from news list
+
 version 2.5.3 (2023-05-24)
  * Bugfixes
  * Added setting for the tagesthemen listing: show broadcasts, topics or both

--- a/plugin.video.tagesschau/libs/tagesschau.py
+++ b/plugin.video.tagesschau/libs/tagesschau.py
@@ -61,8 +61,9 @@ def addVideoContentDirectory(title, method):
     url_data = { ACTION_PARAM: 'list_feed', FEED_PARAM: method  }
     url = 'plugin://' + ADDON_ID + '/?' + urllib.parse.urlencode(url_data)
     li = xbmcgui.ListItem(str(title))
-    li.setArt({'thumb':DEFAULT_IMAGE_URL})
+    li.setArt({'thumb':DEFAULT_IMAGE_URL, 'landscape':DEFAULT_IMAGE_URL})
     li.setProperty('Fanart_Image', FANART)
+    xbmcplugin.setContent(int(sys.argv[1]), 'videos')
     xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=li, isFolder=True)
 
 def getListItem(videocontent):
@@ -71,17 +72,18 @@ def getListItem(videocontent):
     if(not image_url):
         image_url = DEFAULT_IMAGE_URL
     li = xbmcgui.ListItem(title)
-    li.setArt({'thumb':image_url})
+    li.setArt({'thumb':image_url, 'landscape':image_url})
     li.setProperty('Fanart_Image', FANART)
     li.setProperty('IsPlayable', 'true')
-    li.setInfo(type="Video",
+    li.setInfo(type="video",
                infoLabels={ "Title": str(title),
                             "Plot": str(videocontent.description),
-                            "Duration": str((videocontent.duration or 0)/60)
+                            "Duration": str((videocontent.duration or 0)/60),
+                            "mediatype": "video"
                           }
               )
     if( videocontent.timestamp ):
-        li.setInfo(type="Video",
+        li.setInfo(type="video",
                    infoLabels={ "premiered": str(videocontent.timestamp.strftime('%d.%m.%Y')),
                                 "aired": str(videocontent.timestamp.strftime('%d.%m.%Y')),
                                 "date": str(videocontent.timestamp.strftime('%d.%m.%Y'))
@@ -98,6 +100,7 @@ def getUrl(videocontent, method):
 def addVideoContentItem(videocontent, method):
     li = getListItem(videocontent)
     url = getUrl(videocontent, method)
+    xbmcplugin.setContent(int(sys.argv[1]), 'videos')
     return xbmcplugin.addDirectoryItem(int(sys.argv[1]), url, li, False)
 
 def addVideoContentItems(videocontents, method):
@@ -107,6 +110,7 @@ def addVideoContentItems(videocontents, method):
         li = getListItem(videocontent)
         url = getUrl(videocontent, method)
         items.append((url, li, False))
+    xbmcplugin.setContent(int(sys.argv[1]), 'videos')
     return xbmcplugin.addDirectoryItems(int(sys.argv[1]), items, len(items))
 
 def get_params():

--- a/plugin.video.tagesschau/libs/tagesschau_json_api.py
+++ b/plugin.video.tagesschau/libs/tagesschau_json_api.py
@@ -31,6 +31,8 @@ base_url = "https://www.tagesschau.de/api2u/"
 addon = xbmcaddon.Addon(id=ADDON_ID)
 showage = addon.getSettingBool('ShowAge')
 tt_listopt = addon.getSetting('tt_list')
+hide_europadruck = addon.getSettingBool('hide_europadruck')
+hide_wolkenfilm = addon.getSettingBool('hide_wolkenfilm')
 
 class VideoContent(object):
     """Represents a single video or broadcast.
@@ -231,13 +233,19 @@ class VideoContentProvider(object):
                 A list of VideoContent items.
         """
         self._logger.info("retrieving videos")
+
         videos = []
         data = self._jsonsource.latest_videos()
         for jsonvideo in data["news"]:
             try:
                 if( (jsonvideo["type"] == "video") and (jsonvideo["tracking"][0]["src"] == "ard-aktuell") ):
-                    video = self._parser.parse_video(jsonvideo)
-                    videos.append(video)
+                    if( hide_europadruck and ("Europadruck" in jsonvideo["title"]) ):
+                        pass
+                    elif( hide_wolkenfilm and ("Wolkenfilm" in jsonvideo["title"]) ):
+                        pass
+                    else:
+                        video = self._parser.parse_video(jsonvideo)
+                        videos.append(video)
             except:
                 self._logger.info("ignoring")
 

--- a/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
@@ -40,6 +40,14 @@ msgctxt "#30006"
 msgid "Broadcasts and Topics"
 msgstr "Sendungen und Beiträge"
 
+msgctxt "#30007"
+msgid "Hide \"Europadruck\" in news"
+msgstr "Verstecke \"Europadruck\" in Nachrichten"
+
+msgctxt "#30008"
+msgid "Hide \"Aktueller Wolkenfilm\" in news"
+msgstr "Verstecke \"Aktueller Wolkenfilm\" in Nachrichten"
+
 msgctxt "#30100"
 msgid "News"
 msgstr "Nachrichten"

--- a/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
@@ -40,6 +40,14 @@ msgctxt "#30006"
 msgid "Broadcasts and Topics"
 msgstr ""
 
+msgctxt "#30007"
+msgid "Hide \"Europadruck\" in news"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Hide \"Aktueller Wolkenfilm\" in news"
+msgstr ""
+
 msgctxt "#30100"
 msgid "News"
 msgstr ""

--- a/plugin.video.tagesschau/resources/settings.xml
+++ b/plugin.video.tagesschau/resources/settings.xml
@@ -3,4 +3,6 @@
   <setting id="quality" type="enum" label="30001" values="Small (480x272)|Medium (640x368)|Large (1280x720)" default="2" />
   <setting id="ShowAge" type="bool" label="30002" default="true" />
   <setting id="tt_list" type="enum" label="30003" lvalues="30004|30005|30006" default="2" />
+  <setting id="hide_europadruck" type="bool" label="30007" default="true" />
+  <setting id="hide_wolkenfilm"  type="bool" label="30008" default="true" />
 </settings>


### PR DESCRIPTION
### Description
 * Fixed content types so that skins can use landscape viewtype
 * Added setting to hide "Europadruck" and "Aktueller Wolkenfilm" from news list

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0