### PR TITLE
[plugin.video.external.library@nexus] 1.0.1

### DIFF
--- a/plugin.video.external.library/addon.xml
+++ b/plugin.video.external.library/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.external.library"
-    version="1.0.0"
+    version="1.0.1"
     name="External Kodi Videolibrary Client"
     provider-name="Roman V.M.">
   <requires>
@@ -20,7 +20,9 @@
       <icon>icon.png</icon>
     </assets>
     <source>https://github.com/romanvm/kodi.external.library</source>
-    <news>1.0.0: Initial public release.</news>
+    <news>1.0.1: Add show titles to recent episode item labels.
+
+1.0.0: Initial public release.</news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>

--- a/plugin.video.external.library/libs/content_type_handlers.py
+++ b/plugin.video.external.library/libs/content_type_handlers.py
@@ -42,7 +42,7 @@ VIDEO_URL = urljoin(REMOTE_KODI_URL, 'vfs')
 class BaseContentTypeHandler:
     mediatype: str
     item_is_folder: bool
-    should_save_to_mem_storage: bool
+    should_save_to_mem_storage: bool = False
     api_class: Type[json_rpc_api.BaseMediaItemsRetriever]
 
     def __init__(self, tvshowid: Optional[int] = None,
@@ -128,7 +128,6 @@ class RecentMoviesHandler(MoviesHandler):
 class TvShowsHandler(BaseContentTypeHandler):
     mediatype = 'tvshow'
     item_is_folder = True
-    should_save_to_mem_storage = False
     api_class = json_rpc_api.GetTVShows
 
     class FlattenSeasons(enum.IntEnum):
@@ -161,7 +160,6 @@ class TvShowsHandler(BaseContentTypeHandler):
 class SeasonsHandler(BaseContentTypeHandler):
     mediatype = 'season'
     item_is_folder = True
-    should_save_to_mem_storage = False
     api_class = json_rpc_api.GetSeasons
 
     def get_plugin_category(self) -> str:
@@ -203,6 +201,11 @@ class RecentEpisodesHandler(EpisodesHandler):
 
     def get_sort_methods(self) -> List[int]:
         return []
+
+    def get_media_items(self) -> Iterable[Dict[str, Any]]:
+        for media_item in super().get_media_items():
+            media_item['title'] = f'{media_item["showtitle"]} - {media_item["label"]}'
+            yield media_item
 
 
 class MusicVideosHandler(PlayableContentMixin, BaseContentTypeHandler):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: External Kodi Videolibrary Client
  - Add-on ID: plugin.video.external.library
  - Version number: 1.0.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/romanvm/kodi.external.library
  
A plugin that allows to browse and play items from a video library on an external Kodi instance.

### Description of changes:

1.0.1: Add show titles to recent episode item labels.

1.0.0: Initial public release.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
