### PR TITLE
[plugin.video.cbc-sports] 1.0.6

### DIFF
--- a/plugin.video.cbc-sports/addon.xml
+++ b/plugin.video.cbc-sports/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.5" provider-name="Jbinkley60">
+<addon id="plugin.video.cbc-sports" name="CBC Sports" version="1.0.6" provider-name="Jbinkley60">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.beautifulsoup4" version="4.3.2"/>

--- a/plugin.video.cbc-sports/changelog.txt
+++ b/plugin.video.cbc-sports/changelog.txt
@@ -1,3 +1,7 @@
+Version 1.0.6
+
+- Fixed a bug where an invalid hour of 24 wasn't being caught
+
 Version 1.0.5
 
 -  Added a generic check for all improperly formatted times being returned by the CBC

--- a/plugin.video.cbc-sports/resources/lib/common.py
+++ b/plugin.video.cbc-sports/resources/lib/common.py
@@ -18,7 +18,7 @@ def timeConvert(orgtime):				#  Verify CBC Sports time format
         else:
             retime = 'invalid'
 
-        if int(orgtime[11:13]) > 24:
+        if int(orgtime[11:13]) > 23:
             retime = 'invalid'     
 
         return(retime)


### PR DESCRIPTION
### Description
v1.0.6 is a minor update to fix a problem with malformed hours from CBC-Sports API

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X ] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
