### PR TITLE
[plugin.video.invidious] 0.2.8+nexus.0

### DIFF
--- a/plugin.video.invidious/addon.xml
+++ b/plugin.video.invidious/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.invidious"
   name="Invidious"
-  version="0.2.7+nexus.0"
+  version="0.2.8+nexus.0"
   provider-name="petterreinholdtsen">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>

--- a/plugin.video.invidious/resources/lib/invidious_api.py
+++ b/plugin.video.invidious/resources/lib/invidious_api.py
@@ -69,25 +69,13 @@ class InvidiousAPIClient:
 
         if response.status_code > 300:
             xbmc.log(f'invidious API request {assembled_url} with {params} failed with HTTP status {response.status_code}: {response.reason}.', xbmc.LOGWARNING)
-            dialog = xbmcgui.Dialog()
-            msg = self.addon.getLocalizedString(30014).format(
-                request_url=assembled_url,
-                request_params=params,
-                status_code=response.status_code,
-                status_reason=response.reason,
-            )
-            dialog.notification(
-                self.addon.getLocalizedString(30011),
-                msg,
-                "error"
-            )
             return None
 
         return response
 
     def parse_response(self, response):
         if not response:
-            return
+            return None
         data = response.json()
 
         # If a channel or playlist is opened, the videos are packaged
@@ -165,10 +153,9 @@ class InvidiousAPIClient:
 
     def fetch_video_information(self, video_id):
         response = self.make_get_request("videos/", video_id)
-
-        data = response.json()
-
-        return data
+        if not response:
+            return None
+        return response.json()
 
     def fetch_channel_list(self, channel_id):
         response = self.make_get_request(f"channels/videos/{channel_id}")

--- a/plugin.video.invidious/resources/lib/invidious_plugin.py
+++ b/plugin.video.invidious/resources/lib/invidious_plugin.py
@@ -91,10 +91,17 @@ class InvidiousPlugin:
             if 'https' == instance['type']:
                 instance_url = instance['uri']
                 # Make sure the instance work for us.  This test avoid
-                # those rejecting us with HTTP status 429.
+                # those rejecting us with HTTP status 429.  Some
+                # instances return a sensible value for the special
+                # lists but not for an individual video, so test with
+                # a fairly randomly picked video id to avoid partly
+                # working instances.
+                test_video_id = '1l2_uCyBXQ0'
                 api_client = invidious_api.InvidiousAPIClient(instance_url)
-                if api_client.fetch_special_list(self.SPECIAL_LISTS[0]):
+                if api_client.fetch_video_information(test_video_id):
                     return instance_url
+                else:
+                    xbmc.log(f'rejecting non-working instance {instanceinfo}', xbmc.LOGDEBUG)
 
         xbmc.log('invidious no working https type instance returned from api.invidious.io.', xbmc.LOGWARNING)
         # FIXME figure out how to show failing autodetection to the user.


### PR DESCRIPTION
A privacy-friendly way of watching YouTube content. Uses the great Invidious web service's API to do the heavy lifting.

Adjusted autodetection code to avoid picking partly working service provider. Made first run more robust.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0