### PR TITLE
[plugin.video.arteplussept@matrix] 1.4.2

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.4.2 (2024-1-3)
+- Rename quality parameter.
+- Use https to get HBB TV Stream info.
+- Fix bug preventing to open series menu
+
 v1.4.1 (2023-10-10)
 - Fix playing videos with siblings.
 

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.1" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.2" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -56,19 +56,15 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
         <news>
+v1.4.2 (2024-1-3)
+- Rename quality parameter.
+- Use https to get HBB TV Stream info.
+- Fix bug preventing to open series menu
 v1.4.1 (2023-10-10)
 - Fix playing videos with siblings.
 v1.4.0 (2023-8-14)
 - Add support for content over multiple pages.
 - Refactor most of the code in OO style
-v1.3.1 (2023-8-12)
-- Add context menu to view collection as menu instead of playlist
-- Set resume point to 0 when video was fully watched. Avoid crash when playing seq of watched videos in playlist.
-v1.3.0 (2023-8-6)
-- Improve security with better password management
-        - Stop storing password on filesystem though addon settings
-- Make thomas-ernest fork official in addon.xml for visibility in wiki
-- Minor fix/clean-up in translation
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -11,7 +11,7 @@ from resources.lib import logger
 _PLUGIN_NAME = Plugin().name
 _PLUGIN_VERSION = Plugin().addon.getAddonInfo('version')
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
-_HBBTV_URL = 'http://www.arte.tv/hbbtvv2/services/web/index.php'
+_HBBTV_URL = 'https://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
     'user-agent': f"{_PLUGIN_NAME}/{_PLUGIN_VERSION}"
 }

--- a/plugin.video.arteplussept/resources/lib/mapper/artecollection.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artecollection.py
@@ -30,7 +30,11 @@ class ArteCollection:
         # Abstract class should NOT be instantiated
         # pylint: disable=assignment-from-none
         meta = self._get_page_meta(json_dict)
-        items = [ArteTvVideoItem(self.plugin, item).map_artetv_item() for item in pages]
+        items = []
+        for page_item in pages:
+            menu_item = ArteTvVideoItem(self.plugin, page_item).map_artetv_item()
+            if menu_item is not None:
+                items.append(menu_item)
         if meta and meta.get('pages', False):
             total_pages = meta.get('pages')
             current_page = meta.get('page')

--- a/plugin.video.arteplussept/resources/lib/settings.py
+++ b/plugin.video.arteplussept/resources/lib/settings.py
@@ -3,7 +3,9 @@
 import dataclasses
 
 languages = ['fr', 'de', 'en', 'es', 'pl', 'it']
-qualities = ['SQ', 'EQ', 'HQ']
+# though misleqding the below mapping is correct e.g. SQ is High Quality 720p
+# dict keys must be in same order as in settings.xml
+quality_map = {'Low': 'HQ', 'Medium': 'EQ', 'High': 'SQ'}
 loglevel = ['DEFAULT', 'API']
 
 
@@ -16,9 +18,9 @@ class Settings:
         self.language = plugin.get_setting(
             'lang', choices=languages) or languages[0]
         # Quality of the videos
-        # defaults to SQ
-        self.quality = plugin.get_setting(
-            'quality', choices=qualities) or qualities[0]
+        # defaults to High, SQ, 720p
+        self.quality = quality_map[plugin.get_setting(
+            'quality', choices=list(quality_map.keys()))] or quality_map['High']
         # Should the plugin display all available streams for videos?
         # defaults to False
         self.show_video_streams = plugin.get_setting(

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -12,8 +12,8 @@
 			id="quality"
 			type="enum"
 			label="30052"
-			values="SQ (High)|EQ (Medium)|HQ (Low)"
-			default="0"/>
+			values="Low|Medium|High"
+			default="2"/>
 		<setting
 			id="show_video_streams"
 			type="bool"


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.4.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:


v1.4.2 (2024-1-3)
- Rename quality parameter.
- Use https to get HBB TV Stream info.
- Fix bug preventing to open series menu
v1.4.1 (2023-10-10)
- Fix playing videos with siblings.
v1.4.0 (2023-8-14)
- Add support for content over multiple pages.
- Refactor most of the code in OO style
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
