### PR TITLE
[plugin.audio.podcasts] 2.3.2

### DIFF
--- a/plugin.audio.podcasts/addon.xml
+++ b/plugin.audio.podcasts/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.3.0" provider-name="Heckie">
+<addon id="plugin.audio.podcasts" name="RSS Podcasts" version="2.3.2" provider-name="Heckie">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.requests" version="2.25.1" />
@@ -26,6 +26,12 @@ Dateien direkt eingehängt werden.
 		<website>https://github.com/Heckie75/kodi-addon-podcast</website>
 		<source>https://github.com/Heckie75/kodi-addon-podcast</source>
 		<news>
+v2.3.2 (2024-01-21)
+- Fixed bug #23: Addon crashes immediately after starting it (prob. MS Windows only)
+
+v2.3.1 (2023-10-02)
+- Fixed bug #1, support network paths like smb://
+
 v2.3.0 (2023-08-06)
 - Added feature in order to search for podcasts in fyyd.de podcast directory
 - Support for Nextcloud Gpoddersync
@@ -55,16 +61,7 @@ v2.1.1 (2021-08-13)
 v2.1.0 (2021-05-24)
 - Added support for importing subscriptions from your gPodder account or from local files 
 - Added information like duration and plot for video podcasts
-- many refactorings and bugfixes
-
-v2.0.2 (2021-05-14)
-- Bugfix according missing HTTP header and improved exception handling:
-  - see https://github.com/Heckie75/kodi-addon-podcast/issues/4
-  - see https://github.com/Heckie75/kodi-addon-podcast/issues/5
-- new setting for anchor for latest item in order to turn it on/off   
-
-v2.0.1 (2021-05-12)
-- Bugfix for Kodi v19 which has no order by date. Only availble in Kodi v20
+- many refactorings and bugfixes 
 </news>
 		<assets>
 			<icon>resources/assets/icon.png</icon>

--- a/plugin.audio.podcasts/resources/lib/podcasts/actions/download_gpodder_subscriptions_action.py
+++ b/plugin.audio.podcasts/resources/lib/podcasts/actions/download_gpodder_subscriptions_action.py
@@ -1,6 +1,7 @@
 import re
 
 import xbmcgui
+import xbmcvfs
 import xmltodict
 from resources.lib.podcasts.actions.action import Action
 from resources.lib.podcasts.gpodder import GPodder
@@ -62,7 +63,7 @@ class DownloadGpodderSubscriptionsAction(Action):
 
         try:
             fullpath = "%s%s" % (path, filename)
-            with open(fullpath, "w", encoding="utf-8") as _file:
+            with xbmcvfs.File(fullpath, 'w') as _file:
                 _file.write(data)
 
             return fullpath, filename

--- a/plugin.audio.podcasts/resources/lib/podcasts/actions/export_opml_action.py
+++ b/plugin.audio.podcasts/resources/lib/podcasts/actions/export_opml_action.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import xbmcgui
+import xbmcvfs
 from resources.lib.podcasts.actions.opml_action import OpmlAction
 from resources.lib.podcasts.util import get_asset_path
 
@@ -45,9 +46,8 @@ class ExportOpmlAction(OpmlAction):
             title, created, "".join(outlines))
 
         try:
-            with open("%s%s.opml" % (path, title), mode="w") as _file:
-                _file.writelines(_xml)
-                _file.close()
+            with xbmcvfs.File("%s%s.opml" % (path, title), 'w') as _file:
+                _file.write(_xml)
 
             return True
 

--- a/plugin.audio.podcasts/resources/lib/podcasts/actions/remote_action.py
+++ b/plugin.audio.podcasts/resources/lib/podcasts/actions/remote_action.py
@@ -8,7 +8,7 @@ class RemoteAction(OpmlAction):
     def __init__(self) -> None:
         super().__init__()
 
-    def subscribe_feeds(self, feeds: list[dict]) -> 'tuple[list[dict], bool]':
+    def subscribe_feeds(self, feeds: 'list[dict]') -> 'tuple[list[dict], bool]':
 
         items: 'list[xbmcgui.ListItem]' = list()
         for f in feeds:

--- a/plugin.audio.podcasts/resources/lib/podcasts/opml_file.py
+++ b/plugin.audio.podcasts/resources/lib/podcasts/opml_file.py
@@ -1,7 +1,9 @@
 import re
 
 import xbmcaddon
+import xbmcvfs
 import xmltodict
+
 
 def parse_opml(data: str, limit=0) -> 'tuple[str,list[dict]]':
 
@@ -29,7 +31,7 @@ def parse_opml(data: str, limit=0) -> 'tuple[str,list[dict]]':
             if "@type" in o and o["@type"] == "rss" and "@xmlUrl" in o:
                 entry["params"] = [{
                     "rss": o["@xmlUrl"],
-                    "limit" : str(limit)
+                    "limit": str(limit)
                 }]
                 entries.append(entry)
 
@@ -59,5 +61,5 @@ def parse_opml(data: str, limit=0) -> 'tuple[str,list[dict]]':
 
 def open_opml_file(path: str) -> str:
 
-    with open(path, encoding="utf-8") as _opml_file:
+    with xbmcvfs.File(path, 'r') as _opml_file:
         return _opml_file.read()

--- a/plugin.audio.podcasts/resources/lib/podcasts/podcastsaddon.py
+++ b/plugin.audio.podcasts/resources/lib/podcasts/podcastsaddon.py
@@ -1,8 +1,8 @@
-import os
 from datetime import datetime
 
 import xbmc
 import xbmcplugin
+import xbmcvfs
 from resources.lib.podcasts.opml_file import open_opml_file, parse_opml
 from resources.lib.rssaddon.abstract_rss_addon import AbstractRssAddon
 
@@ -81,9 +81,8 @@ class PodcastsAddon(AbstractRssAddon):
             if self.addon.getSetting("opml_file_%i" % g) == "":
                 continue
 
-            path = os.path.join(
-                self.addon_dir, self.addon.getSetting("opml_file_%i" % g))
-
+            path = xbmcvfs.translatePath(
+                self.addon.getSetting("opml_file_%i" % g))
             try:
                 name, nodes = parse_opml(open_opml_file(path), limit=limit)
                 groups.append({


### PR DESCRIPTION
### Description
v2.3.2 (2024-01-21)
- Fixed bug https://github.com/Heckie75/kodi-addon-podcast/issues/23: Addon crashes immediately after starting it (prob. MS Windows only)

v2.3.1 (2023-10-02)
- Fixed bug https://github.com/Heckie75/kodi-addon-podcast/issues/1, support network paths like smb://

### Checklist:
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
