### PR TITLE
[plugin.video.streamz@matrix] 1.1.4+matrix.1

### DIFF
--- a/plugin.video.streamz/CHANGELOG.md
+++ b/plugin.video.streamz/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.1.4](https://github.com/add-ons/plugin.video.streamz/tree/v1.1.4) (2024-02-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.1.3...v1.1.4)
+
+**Fixed bugs:**
+
+- Bump API to 15 [\#60](https://github.com/add-ons/plugin.video.streamz/pull/60) ([michaelarnauts](https://github.com/michaelarnauts))
+
 ## [v1.1.3](https://github.com/add-ons/plugin.video.streamz/tree/v1.1.3) (2023-11-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.streamz/compare/v1.1.2...v1.1.3)

--- a/plugin.video.streamz/addon.xml
+++ b/plugin.video.streamz/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.streamz" name="Streamz" version="1.1.3+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.streamz" name="Streamz" version="1.1.4+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -21,7 +21,7 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door Streamz BV, en wordt aangeboden 'as is', zonder enige garantie. De Streamz naam en Streamz logo zijn eigendom van Streamz BV en worden gebruikt in overeenstemming met de 'fair use' regels.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-	    <news>v1.1.3 (2023-11-04)
+	    <news>v1.1.4 (2024-02-26)
 - Fix API.</news>
         <source>https://github.com/add-ons/plugin.video.streamz</source>
         <assets>

--- a/plugin.video.streamz/resources/lib/streamz/api.py
+++ b/plugin.video.streamz/resources/lib/streamz/api.py
@@ -102,7 +102,7 @@ class Api:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('teasers'):
+        for item in result.get('row', {}).get('teasers', []):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                 items.append(self._parse_movie_teaser(item))
 

--- a/plugin.video.streamz/resources/lib/streamz/util.py
+++ b/plugin.video.streamz/resources/lib/streamz/util.py
@@ -32,8 +32,8 @@ class StreamzAdapter(BaseAdapter):
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'STREAMZ/14.231023 (be.vmma.streamz; build:18041; Android 23) okhttp/4.11.0',
-    'x-app-version': '14',
+    'User-Agent': 'STREAMZ/15.231023 (be.vmma.streamz; build:18041; Android 23) okhttp/4.11.0',
+    'x-app-version': '15',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '28',


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: Streamz
  - Add-on ID: plugin.video.streamz
  - Version number: 1.1.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.streamz

Streamz is a video-on-demand platform offering Flemish content from DPG Media, Telenet and VRT, but also including 'Home of HBO' content and blockbuster movies.

### What's new

v1.1.4 (2024-02-26)
- Fix API.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
