### PR TITLE
[plugin.video.vtm.go@matrix] 1.4.4+matrix.1

### DIFF
--- a/plugin.video.vtm.go/CHANGELOG.md
+++ b/plugin.video.vtm.go/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.4.4](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.4) (2024-02-26)
+
+[Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.3...v1.4.4)
+
+**Fixed bugs:**
+
+- Fix recommendations and drop usage of Popcorn V5 API [\#377](https://github.com/add-ons/plugin.video.vtm.go/pull/377) ([michaelarnauts](https://github.com/michaelarnauts))
+- Upgrade User-Agent to v15 \(\#375\) [\#376](https://github.com/add-ons/plugin.video.vtm.go/pull/376) ([mrtreg](https://github.com/mrtreg))
+
 ## [v1.4.3](https://github.com/add-ons/plugin.video.vtm.go/tree/v1.4.3) (2023-11-04)
 
 [Full Changelog](https://github.com/add-ons/plugin.video.vtm.go/compare/v1.4.2...v1.4.3)

--- a/plugin.video.vtm.go/addon.xml
+++ b/plugin.video.vtm.go/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.3+matrix.1" provider-name="Michaël Arnauts">
+<addon id="plugin.video.vtm.go" name="VTM GO" version="1.4.4+matrix.1" provider-name="Michaël Arnauts">
     <requires>
         <import addon="xbmc.python" version="3.0.0" />
         <import addon="script.module.dateutil" version="2.6.0" />
@@ -22,7 +22,7 @@
         <disclaimer lang="nl_NL">Deze add-on wordt niet ondersteund door DPG Media en wordt aangeboden 'as is', zonder enige garantie. De VTM GO naam, VTM GO logo en de kanaallogo's zijn eigendom van DPG Media en worden gebruikt in overeenstemming met de fair use policy.</disclaimer>
         <platform>all</platform>
         <license>GPL-3.0-only</license>
-        <news>v1.4.3 (2023-11-04)
+        <news>v1.4.4 (2024-02-26)
 - Fix API.</news>
         <source>https://github.com/add-ons/plugin.video.vtm.go</source>
         <assets>

--- a/plugin.video.vtm.go/resources/lib/vtmgo/util.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/util.py
@@ -17,8 +17,8 @@ _LOGGER = logging.getLogger(__name__)
 # Setup a static session that can be reused for all calls
 SESSION = requests.Session()
 SESSION.headers = {
-    'User-Agent': 'VTM_GO/14.231023 (be.vmma.vtm.zenderapp; build:18041; Android 23) okhttp/4.11.0',
-    'x-app-version': '14',
+    'User-Agent': 'VTM_GO/15.231023 (be.vmma.vtm.zenderapp; build:18041; Android 23) okhttp/4.11.0',
+    'x-app-version': '15',
     'x-persgroep-mobile-app': 'true',
     'x-persgroep-os': 'android',
     'x-persgroep-os-version': '28',

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgo.py
@@ -107,7 +107,7 @@ class VtmGo:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('teasers'):
+        for item in result.get('row', {}).get('teasers'):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                 items.append(self._parse_movie_teaser(item))
 
@@ -129,7 +129,7 @@ class VtmGo:
         result = json.loads(response.text)
 
         items = []
-        for item in result.get('teasers'):
+        for item in result.get('teasers', []):
             if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE and content_filter in [None, Movie]:
                 items.append(self._parse_movie_teaser(item, cache=cache))
 

--- a/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
+++ b/plugin.video.vtm.go/resources/lib/vtmgo/vtmgostream.py
@@ -18,7 +18,6 @@ _LOGGER = logging.getLogger(__name__)
 class VtmGoStream:
     """ VTM GO Stream API """
 
-    _V5_API_KEY = '3vjmWnsxF7SUTeNCBZlnUQ4Z7GQV8f6miQ514l10'
     _V6_API_KEY = 'r9EOnHOp1pPL5L4FuGzBPSIHwrQnPu5TBfW16y75'
 
     def __init__(self, tokens=None):
@@ -160,34 +159,21 @@ class VtmGoStream:
         """
         url = 'https://videoplayer-service.dpgmedia.net/config/%s/%s' % (strtype, stream_id)
         _LOGGER.debug('Getting video info from %s', url)
-        # Live channels: Fallback to old Popcorn SDK 5 for Kodi 19 and lower, because new livestream format is not supported
-        if kodiutils.kodi_version_major() <= 19 and strtype == 'channels':
-            response = util.http_get(url,
-                                     params={
-                                         'startPosition': '0.0',
-                                         'autoPlay': 'true',
-                                     },
-                                     headers={
-                                         'Accept': 'application/json',
-                                         'x-api-key': self._V5_API_KEY,
-                                         'Popcorn-SDK-Version': '5',
-                                     })
-        else:
-            response = util.http_post(url,
-                                      params={
-                                          'startPosition': '0.0',
-                                          'autoPlay': 'true',
-                                      },
-                                      data={
-                                          'deviceType': 'android-tv',
-                                          'zone': 'vtmgo',
-                                      },
-                                      headers={
-                                          'Accept': 'application/json',
-                                          'x-api-key': self._V6_API_KEY,
-                                          'Popcorn-SDK-Version': '6',
-                                          'Authorization': 'Bearer ' + player_token,
-                                      })
+        response = util.http_post(url,
+                                  params={
+                                      'startPosition': '0.0',
+                                      'autoPlay': 'true',
+                                  },
+                                  data={
+                                      'deviceType': 'android-tv',
+                                      'zone': 'vtmgo',
+                                  },
+                                  headers={
+                                      'Accept': 'application/json',
+                                      'x-api-key': self._V6_API_KEY,
+                                      'Popcorn-SDK-Version': '6',
+                                      'Authorization': 'Bearer ' + player_token,
+                                  })
 
         info = json.loads(response.text)
         return info


### PR DESCRIPTION
### Description

- **General**
  - Add-on name: VTM GO
  - Add-on ID: plugin.video.vtm.go
  - Version number: 1.4.4+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vtm.go

This add-on gives access to all live tv channels and all video-on-demand content available on the VTM GO platform.

### What's new

v1.4.4 (2024-02-26)
- Fix API.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
