### PR TITLE
[plugin.video.viwx] v1.2.1

### DIFF
--- a/plugin.video.viwx/addon.xml
+++ b/plugin.video.viwx/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.viwx" name="viwX" version="1.2.0" provider-name="Dimitri Kroon">
+<addon id="plugin.video.viwx" name="viwX" version="1.2.1" provider-name="Dimitri Kroon">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="inputstream.adaptive" version="19.0.5"/>
@@ -30,24 +30,12 @@
       <fanart>resources/fanart.png</fanart>
     </assets>
     <news>
-[B]v1.2.0[/B]
+[B]v1.2.1[/B]
 [B]Fixes:[/B]
-* All categories failed to open due to various changes at ITVX.
-* Error on opening some series named 'Other Episodes', due to changes at ITVX.
-* Some sub-collections failed with error 'Not Found', due to error in ITVX data'
-* Added support for hero and collections items of type 'page'. Fixes some collections being empty, or hero item not shown.
-
-[B]New features:[/B]
-* Added a 'My itvX' entry in the main menu with:
-    - My List - ITVX's My List.
-    - Continue Watching: supports continue watching on different devices and different platforms.
-    - Because You Watched: recommendations by ITV based on a recently watched programme.
-    - Recommended: general recommendations by ITV.
-* All programmes and series now have a context menu item to add/remove the programme to/from My List.
+* All categories failed to open with KeyError('pathSegment') due to a change at ITVX.
 
 [B]Changes:[/B]
-* When not signed in, a user is now always offered to sign in via viwX's settings when an item was opened that required authentication.
-* Search now respects setting 'Hide premium content'.
+* Schedules of live channels are now listed up to 6 hours in the future (was 4 hrs).
     </news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>

--- a/plugin.video.viwx/changelog.txt
+++ b/plugin.video.viwx/changelog.txt
@@ -1,3 +1,10 @@
+v1.2.1
+Fixes:
+- All categories failed to open with KeyError('pathSegment') due to a change at ITVX.
+
+Changes:
+- Schedules of live channels are now listed up to 6 hours in the future (was 4 hrs).
+
 v1.2.0
 Fixes:
 - All categories failed to open due to various changes at ITVX.

--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -1,6 +1,6 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
-#  Copyright (c) 2022-2023 Dimitri Kroon.
+#  Copyright (c) 2022-2024 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
@@ -124,7 +124,7 @@ def get_live_channels(local_tz=None):
         local_tz = pytz.timezone('Europe/London')
 
     schedule = get_now_next_schedule(local_tz)
-    main_schedule = get_live_schedule(local_tz=local_tz)
+    main_schedule = get_live_schedule(6, local_tz=local_tz)
 
     # Replace the schedule of the main channels with the longer one obtained from get_live_schedule().
     for channel in schedule:
@@ -383,7 +383,7 @@ def category_content(url: str, hide_paid=False):
         return cached_data['items_list']
 
     cat_data = get_page_data(url + '/all', cache_time=0)
-    category = cat_data['category']['pathSegment']
+    category = cat_data['category']['id']
     progr_list = cat_data.get('programmes')
 
     parse_progr = parsex.parse_category_item
@@ -514,7 +514,7 @@ def my_list(user_id, programme_id=None, operation=None, offer_login=True, use_ca
     data = itv_account.fetch_authenticated(fetcher, url, data=None, login=offer_login)
     # Empty lists will return HTTP status 204, which results in data being None.
     if data:
-        my_list_items = [parsex.parse_my_list_item(item) for item in data]
+        my_list_items = list(filter(None, (parsex.parse_my_list_item(item) for item in data)))
     else:
         my_list_items = []
     cache.set_item('mylist_' + user_id, my_list_items, 1800)

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -1,6 +1,6 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
-#  Copyright (c) 2022-2023 Dimitri Kroon.
+#  Copyright (c) 2022-2024 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
@@ -22,7 +22,7 @@ logger = logging.getLogger(logger_id + '.parse')
 # NOTE: The resolutions below are those specified by Kodi for their respective usage. There is no guarantee that
 #       the image returned by itvX is of that exact resolution.
 IMG_PROPS_THUMB = {'treatment': 'title', 'aspect_ratio': '16x9', 'class': '04_DesktopCTV_RailTileLandscape',
-                   'distributionPartner': '', 'fallback': 'standard', 'width': '960', 'height': '540',
+                   'distributionPartner': '', 'fallback': 'default', 'width': '960', 'height': '540',
                    'quality': '80', 'blur': 0, 'bg': 'false', 'image_format': 'jpg'}
 IMG_PROPS_POSTER = {'treatment': 'title', 'aspect_ratio': '2x3', 'class': '07_RailTilePortrait',
                     'distributionPartner': '', 'fallback': 'standard', 'width': '1000', 'height': '1500',
@@ -327,7 +327,7 @@ def parse_trending_collection_item(trending_item, hide_paid=False):
         return None
 
 
-def parse_category_item(prog, category):
+def parse_category_item(prog, category_id):
     # At least all items without an encodedEpisodeId are playable.
     # Unfortunately there are items that do have an episodeId, but are in fact single
     # episodes, and thus playable, but there is no reliable way of detecting these,
@@ -359,7 +359,9 @@ def parse_category_item(prog, category):
                  'sorttitle': sort_title(title)},
     }
 
-    if category == 'films':
+    # Currently the films category has id 'FILM' while in other data the plural 'FILMS' is used.
+    # Ensure a future change to 'FILMS' will not break the add-on again.
+    if category_id and 'FILM' in category_id:
         programme_item['art']['poster'] = prog['imageTemplate'].format(**IMG_PROPS_POSTER)
 
     if is_playable:
@@ -545,7 +547,7 @@ def parse_my_list_item(item, hide_paid=False):
         progr_id = item['programmeId'].replace('/', '_')
         num_episodes = item['numberOfEpisodes']
         content_info = ' - {} episodes'.format(num_episodes) if num_episodes is not None else ''
-        img_link = item.get('itvxImageLink') or item.get('imageUrl')
+        img_link = item.get('itvxImageLink') or item.get('itvxImageUrl')
         is_playable = item['contentType'].lower() != 'programme'
 
         item_dict = {


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Fix: all categories failed to open.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
