### PR TITLE
[plugin.video.external.library@nexus] 1.1.0

### DIFF
--- a/plugin.video.external.library/addon.xml
+++ b/plugin.video.external.library/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.external.library"
-    version="1.0.1"
+    version="1.1.0"
     name="External Kodi Videolibrary Client"
     provider-name="Roman V.M.">
   <requires>
@@ -20,9 +20,9 @@
       <icon>icon.png</icon>
     </assets>
     <source>https://github.com/romanvm/kodi.external.library</source>
-    <news>1.0.1: Add show titles to recent episode item labels.
-
-1.0.0: Initial public release.</news>
+    <news>1.1.0:
+- Add a menu item for updating the remote videolibrary.
+- Allow to access the remote videolibary via HTTPS.</news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>

--- a/plugin.video.external.library/commands.py
+++ b/plugin.video.external.library/commands.py
@@ -12,7 +12,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 import logging
 import sys
 
@@ -39,5 +38,5 @@ def main():
 
 
 if __name__ == '__main__':
-    with catch_exception(logger.error):
+    with catch_exception():
         main()

--- a/plugin.video.external.library/libs/content_type_handlers.py
+++ b/plugin.video.external.library/libs/content_type_handlers.py
@@ -30,6 +30,8 @@ __all__ = [
     'SeasonsHandler',
     'EpisodesHandler',
     'RecentEpisodesHandler',
+    'MusicVideosHandler',
+    'RecentMusicVideosHandler',
 ]
 
 _ = GettextEmulator.gettext

--- a/plugin.video.external.library/libs/exception_logger.py
+++ b/plugin.video.external.library/libs/exception_logger.py
@@ -15,6 +15,7 @@
 """Exception logger with extended diagnostic info"""
 
 import inspect
+import logging
 import sys
 from contextlib import contextmanager
 from platform import uname
@@ -23,9 +24,7 @@ from typing import Any, Dict, Callable, Generator, Iterable, Optional
 
 import xbmc
 
-
-def _log_error(message: str) -> None:
-    xbmc.log(message, level=xbmc.LOGERROR)
+logger = logging.getLogger(__name__)
 
 
 def _format_vars(variables: Dict[str, Any]) -> str:
@@ -156,7 +155,9 @@ def format_exception(exc_obj: Optional[Exception] = None) -> str:
 
 
 @contextmanager
-def catch_exception(logger_func: Callable[[str], None] = _log_error) -> Generator[None, None, None]:
+def catch_exception(
+        logger_func: Callable[[str], None] = logger.error
+) -> Generator[None, None, None]:
     """
     Diagnostic helper context manager
 
@@ -187,7 +188,7 @@ def catch_exception(logger_func: Callable[[str], None] = _log_error) -> Generato
     try:
         yield
     except Exception as exc:
-        message = format_exception(exc)
+        message = format_exception(exc)  # pylint: disable=logging-not-lazy
         # pylint: disable=line-too-long
         logger_func('\n*********************************** Unhandled exception detected ***********************************\n'
                     + message)

--- a/plugin.video.external.library/libs/json_rpc_api.py
+++ b/plugin.video.external.library/libs/json_rpc_api.py
@@ -16,7 +16,7 @@
 
 import logging
 from pprint import pformat
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from libs import simple_requests as requests
 from libs.exceptions import NoDataError, RemoteKodiError
@@ -36,9 +36,11 @@ class BaseJsonRpcApi:
         request = {
             'jsonrpc': '2.0',
             'method': self.method,
-            'params': self.get_params(),
             'id': '1',
         }
+        params = self.get_params()  # pylint: disable=assignment-from-none
+        if params is not None:
+            request['params'] = params
         logger.debug('JSON-RPC request: %s', pformat(request))
         auth = None
         login = ADDON.getSetting('kodi_login')
@@ -53,9 +55,9 @@ class BaseJsonRpcApi:
         logger.debug('JSON-RPC reply: %s', pformat(json_reply))
         return json_reply
 
-    def get_params(self) -> Dict[str, Any]:
+    def get_params(self) -> Optional[Dict[str, Any]]:
         """Get params to send to Kodi JSON-RPC API"""
-        raise NotImplementedError
+        return None
 
 
 class BaseMediaItemsRetriever(BaseJsonRpcApi):
@@ -259,6 +261,10 @@ class SetMovieDetails(BaseJsonRpcApi):
 
 class SetEpisodeDetails(SetMovieDetails):
     method = 'VideoLibrary.SetEpisodeDetails'
+
+
+class VideoLibraryScan(BaseJsonRpcApi):
+    method = 'VideoLibrary.Scan'
 
 
 SET_DETAILS_API_MAP = {

--- a/plugin.video.external.library/libs/kodi_service.py
+++ b/plugin.video.external.library/libs/kodi_service.py
@@ -186,6 +186,8 @@ def get_remote_kodi_url(with_credentials=False):
     port = ADDON.getSetting('kodi_port')
     login = ADDON.getSetting('kodi_login')
     password = ADDON.getSetting('kodi_password')
+    use_https = ADDON.getSettingBool('use_https')
+    protocol = 'https' if use_https else 'http'
     if not with_credentials or not login:
-        return f'http://{host}:{port}'
-    return f'http://{login}:{password}@{host}:{port}'
+        return f'{protocol}://{host}:{port}'
+    return f'{protocol}://{login}:{password}@{host}:{port}'

--- a/plugin.video.external.library/main.py
+++ b/plugin.video.external.library/main.py
@@ -14,15 +14,13 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import sys
-import logging
 
 from libs.actions import router
 from libs.exception_logger import catch_exception
 from libs.kodi_service import initialize_logging
 
 initialize_logging()
-logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
-    with catch_exception(logger.error):
+    with catch_exception():
         router(sys.argv[2][1:])

--- a/plugin.video.external.library/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.external.library/resources/language/resource.language.en_gb/strings.po
@@ -122,3 +122,15 @@ msgstr ""
 msgctxt "#32028"
 msgid "Recently added music videos"
 msgstr ""
+
+msgctxt "#32029"
+msgid "Use HTTPS"
+msgstr ""
+
+msgctxt "#32030"
+msgid "Update remote videolibrary"
+msgstr ""
+
+msgctxt "#32031"
+msgid "Updating the remote videolibrary started."
+msgstr ""

--- a/plugin.video.external.library/resources/settings.xml
+++ b/plugin.video.external.library/resources/settings.xml
@@ -20,6 +20,11 @@
             <heading>32002</heading>
           </control>
         </setting>
+        <setting id="use_https" type="boolean" label="32029" help="">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
         <setting id="kodi_login" type="string" label="32013" help="">
           <level>0</level>
           <default/>

--- a/plugin.video.external.library/service.py
+++ b/plugin.video.external.library/service.py
@@ -24,7 +24,7 @@ from libs.monitor import PlayMonitor
 initialize_logging()
 logger = logging.getLogger(__name__)
 
-with catch_exception(logger.error):
+with catch_exception():
     logger.debug('Starting playback monitoring service...')
     kodi_monitor = xbmc.Monitor()
     play_monitor = PlayMonitor()


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: External Kodi Videolibrary Client
  - Add-on ID: plugin.video.external.library
  - Version number: 1.1.0
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/romanvm/kodi.external.library
  
A plugin that allows to browse and play items from a video library on an external Kodi instance.

### Description of changes:

1.1.0:
- Add a menu item for updating the remote videolibrary.
- Allow to access the remote videolibary via HTTPS.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
