### PR TITLE
[plugin.video.vrt.nu@krypton] 2.5.30

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.30 (2024-04-16)
+- Fix playing from TV guide (@mediaminister)
+
 ### v2.5.29 (2024-02-12)
 - Fix program listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.29" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.30" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.30 (2024-04-16)
+- Fix playing from TV guide
+
 v2.5.29 (2024-02-12)
 - Fix program listings
 
@@ -72,48 +75,6 @@ v2.5.21 (2023-05-23)
 - Fix 1080p for livestreams
 - Remove All programs menu
 - Fix paging in episode listings
-
-v2.5.20 (2022-12-06)
-- Fix all programs menu
-- Fix latest episode API
-
-v2.5.19 (2022-10-16)
-- Fix categories and channels menu listings
-- Fix resumepoints and Up Next integration
-- Fix playing from VRT MAX url API interface
-
-v2.5.18 (2022-10-07)
-- Fix menu listings
-
-v2.5.17 (2022-09-21)
-- Fix watching VRT MAX abroad
-- Fix 'My Programs' menu
-- Fix login issue on Raspberry Pi
-
-v2.5.16 (2022-09-13)
-- Fix 'My Programs' menu
-- Hide resumepoints error messages
-- Implement new login api
-
-v2.5.15 (2022-08-31)
-- Fix add-on crash
-
-v2.5.14 (2022-08-29)
-- VRT MAX rebranding
-
-v2.5.13 (2022-08-05)
-- Support 1080p video on demand
-
-v2.5.12 (2022-05-25)
-- Fix playing from TV guide
-- Fix listing programs with a single char in their name
-
-v2.5.11 (2022-05-15)
-- Fix "All programs", "Categories","Most recent", "Soon offline" and "Channels" menu
-
-v2.5.10 (2022-04-29)
-- Fix watching from the tv guide
-- Fix season menu labels
     </news>
     <assets>
       <icon>resources/media/icon.png</icon>

--- a/plugin.video.vrt.nu/resources/lib/api.py
+++ b/plugin.video.vrt.nu/resources/lib/api.py
@@ -29,7 +29,7 @@ def get_sort(program_type):
         ascending = False
     elif program_type == 'oneoff':
         sort = 'label'
-    elif program_type in 'reeksoplopend':
+    elif program_type in ('series', 'reeksoplopend'):
         sort = 'episode'
     elif program_type == 'reeksaflopend':
         sort = 'episode'
@@ -793,6 +793,7 @@ def convert_programs(api_data, destination, use_favorites=False, **kwargs):
                     path=url_for(destination, end_cursor=end_cursor, **kwargs),
                     art_dict={'thumb': 'DefaultInProgressShows.png'},
                     info_dict={},
+                    prop_dict={'SpecialSort': 'bottom'},
                 )
             )
     return programs
@@ -952,6 +953,7 @@ def convert_episodes(api_data, destination, use_favorites=False, **kwargs):
                     path=url_for(destination, end_cursor=end_cursor, **kwargs),
                     art_dict={'thumb': 'DefaultInProgressShows.png'},
                     info_dict={},
+                    prop_dict={'SpecialSort': 'bottom'},
                 )
             )
     return episodes, sort, ascending

--- a/plugin.video.vrt.nu/resources/lib/playerinfo.py
+++ b/plugin.video.vrt.nu/resources/lib/playerinfo.py
@@ -197,10 +197,10 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
     def update_position(self):
         """Update the player position, when possible"""
         try:
-            last_pos = self.getTime()
+            pos = self.getTime()
             # Kodi Player sometimes returns a time of 0.0 and this causes unwanted behaviour with VRT MAX Resumepoints API.
-            if last_pos > 0.0:
-                self.last_pos = last_pos
+            if pos > 0.0:
+                self.last_pos = pos
         except RuntimeError:
             pass
 
@@ -244,9 +244,9 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
     def update_total(self):
         """Update the total video time"""
         try:
-            total = self.getTotalTime()
+            tot = self.getTotalTime()
             # Kodi Player sometimes returns a total time of 0.0 and this causes unwanted behaviour with VRT MAX Resumepoints API.
-            if total > 0.0:
-                self.total = total
+            if tot > 0.0:
+                self.total = tot
         except RuntimeError:
             pass


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.30
  - Kodi/repository version: krypton

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.30 (2024-04-16)
- Fix playing from TV guide

v2.5.29 (2024-02-12)
- Fix program listings

v2.5.28 (2024-01-24)
- Fix 'My favorites' listing

v2.5.27 (2023-12-27)
- Fix categories listing

v2.5.26 (2023-09-22)
- Fix program listings
- Add extra content to program listings

v2.5.25 (2023-09-14)
- Fix episode listings and featured menu

v2.5.24 (2023-07-18)
- Fix 1080p quality and playback issue

v2.5.23 (2023-07-11)
- Fix episode and featured listings

v2.5.22 (2023-06-14)
- Fix categories menu
- Fix 1080p

v2.5.21 (2023-05-23)
- Fix 1080p for livestreams
- Remove All programs menu
- Fix paging in episode listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
