### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.31+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,9 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.31 (2024-04-21)
+- Fix program menu listings (@mediaminister)
+
 ### v2.5.30 (2024-04-16)
 - Fix playing from TV guide (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.30+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.31+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,9 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.31 (2024-04-21)
+- Fix program menu listings
+
 v2.5.30 (2024-04-16)
 - Fix playing from TV guide
 

--- a/plugin.video.vrt.nu/resources/lib/api.py
+++ b/plugin.video.vrt.nu/resources/lib/api.py
@@ -1014,27 +1014,30 @@ def get_programs(category=None, channel=None, keywords=None, end_cursor=''):
     from json import dumps
     page_size = get_setting_int('itemsperpage', default=50)
     query_string = None
+    facets = []
     if category:
         facet_name = 'genre'
         # VRT MAX uses 'contenttype' facet name instead of 'genre' for some categories
         if category in ('docu', 'films', 'series', 'talkshows'):
             facet_name = 'contenttype'
         destination = 'categories'
-        facets = [{
+        facets.append({
             'name': facet_name,
-            'values': [category]
-        }]
+            'values': [category],
+        })
     elif channel:
         destination = 'channels'
-        facets = [{
+        facets.append({
             'name': 'brand',
             'values': [channel]
-        }]
+        })
     elif keywords:
         destination = 'search_query'
-        facets = None
         query_string = keywords
-
+    facets.append({
+        'name': 'entitytype',
+        'values': ['video-program'],
+    })
     search_dict = {
         'queryString': query_string,
         'facets': facets,


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.31+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.31 (2024-04-21)
- Fix program menu listings

v2.5.30 (2024-04-16)
- Fix playing from TV guide

v2.5.29 (2024-02-12)
- Fix program listings

v2.5.28 (2024-01-24)
- Fix 'My favorites' listing

v2.5.27 (2023-12-27)
- Fix categories listing

v2.5.26 (2023-09-22)
- Fix program listings
- Add extra content to program listings

v2.5.25 (2023-09-14)
- Fix episode listings and featured menu

v2.5.24 (2023-07-18)
- Fix 1080p quality and playback issue

v2.5.23 (2023-07-11)
- Fix episode and featured listings

v2.5.22 (2023-06-14)
- Fix categories menu
- Fix 1080p

v2.5.21 (2023-05-23)
- Fix 1080p for livestreams
- Remove All programs menu
- Fix paging in episode listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
