### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.32+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -59,6 +59,10 @@ leave a message at [our Facebook page](https://facebook.com/kodivrtnu/).
 </table>
 
 ## Releases
+### v2.5.32 (2024-05-21)
+- Fix search (@mediaminister)
+- Fix program menu listings (@mediaminister)
+
 ### v2.5.31 (2024-04-21)
 - Fix program menu listings (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.31+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.32+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.22"/>
     <import addon="script.module.beautifulsoup4" version="4.6.2"/>
@@ -42,6 +42,10 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.32 (2024-05-21)
+- Fix search
+- Fix program menu listings
+
 v2.5.31 (2024-04-21)
 - Fix program menu listings
 

--- a/plugin.video.vrt.nu/resources/lib/api.py
+++ b/plugin.video.vrt.nu/resources/lib/api.py
@@ -1014,6 +1014,7 @@ def get_programs(category=None, channel=None, keywords=None, end_cursor=''):
     from json import dumps
     page_size = get_setting_int('itemsperpage', default=50)
     query_string = None
+    destination = None
     facets = []
     if category:
         facet_name = 'genre'
@@ -1039,14 +1040,16 @@ def get_programs(category=None, channel=None, keywords=None, end_cursor=''):
         'values': ['video-program'],
     })
     search_dict = {
-        'queryString': query_string,
         'facets': facets,
         'resultType': 'watch',
     }
+    if query_string:
+        search_dict['q'] = query_string
     encoded_search = base64.b64encode(dumps(search_dict).encode('utf-8'))
-    list_id = 'uisearch:searchdata@{}'.format(encoded_search.decode('utf-8'))
+    list_id = 'tl-pag-srch|watch#{}'.format(encoded_search.decode('utf-8'))
+    list_id = '#{}'.format(base64.b64encode(list_id.encode('utf-8')).decode('utf-8'))
 
-    api_data = get_paginated_programs(list_id=list_id, page_size=page_size, end_cursor=end_cursor, client='MobileAndroid')
+    api_data = get_paginated_programs(list_id=list_id, page_size=page_size, end_cursor=end_cursor)
     programs = convert_programs(api_data, destination=destination, category=category, channel=channel, keywords=keywords)
     return programs
 

--- a/plugin.video.vrt.nu/resources/lib/apihelper.py
+++ b/plugin.video.vrt.nu/resources/lib/apihelper.py
@@ -36,6 +36,7 @@ class ApiHelper:
     def get_tvshows(self, category=None, channel=None, feature=None):
         """Get all TV shows for a given category, channel or feature, optionally filtered by favorites"""
         params = {}
+        cache_file = None
 
         # Facet-selection
         if category:
@@ -95,6 +96,7 @@ class ApiHelper:
     def tvshow_to_listitem(self, tvshow, program_name, cache_file):
         """Return a ListItem based on a Suggests API result"""
         label = self._metadata.get_label(tvshow)
+        context_menu = None
 
         if program_name:
             context_menu, favorite_marker = self._metadata.get_context_menu(tvshow, program_name, cache_file)
@@ -146,6 +148,8 @@ class ApiHelper:
         sort = 'episode'
         ascending = True
         content = 'episodes'
+        favorite_programs = []
+
         if use_favorites:
             favorite_programs = self._favorites.programs()
 
@@ -224,6 +228,7 @@ class ApiHelper:
     def __map_tvshows(self, tvshows, oneoffs, use_favorites=False, cache_file=None):
         """Construct a list of TV show and Oneoff TitleItems and filtered by favorites"""
         items = []
+        favorite_programs = []
 
         if use_favorites:
             favorite_programs = self._favorites.programs()
@@ -249,7 +254,7 @@ class ApiHelper:
 
     def episode_to_listitem(self, episode, program, cache_file, titletype):
         """Return a ListItem based on a Search API result"""
-
+        context_menu = None
         label, sort, ascending = self._metadata.get_label(episode, titletype, return_sort=True)
 
         if program:
@@ -700,6 +705,7 @@ class ApiHelper:
 
             context_menu = []
             art_dict = {}
+            path = None
 
             # Try to use the white icons for thumbnails (used for icons as well)
             if has_addon('resource.images.studios.white'):

--- a/plugin.video.vrt.nu/resources/lib/metadata.py
+++ b/plugin.video.vrt.nu/resources/lib/metadata.py
@@ -56,6 +56,9 @@ class Metadata:
         from addon import plugin
         favorite_marker = ''
         context_menu = []
+        follow_enabled = False
+        follow_suffix = ''
+        program_id = None
 
         # FOLLOW PROGRAM
         if self._favorites.is_activated():
@@ -73,7 +76,6 @@ class Metadata:
                 # FIXME: No program_id in Suggest API
                 program_id = None
                 program_title = api_data.get('title')
-                follow_suffix = ''
                 follow_enabled = True
 
             # VRT MAX Schedule API (some are missing vrt.whatson-id)
@@ -684,6 +686,8 @@ class Metadata:
     @staticmethod
     def get_label(api_data, titletype=None, return_sort=False):
         """Get an appropriate label string matching the type of listing and VRT MAX provided displayOptions from single item json api data"""
+        sort = 'unsorted'
+        ascending = True
 
         # VRT MAX Search API
         if api_data.get('episodeType'):
@@ -693,8 +697,6 @@ class Metadata:
                 titletype = program_type
 
             label = html_to_kodi(api_data.get('title', '') or api_data.get('shortDescription', ''))
-            sort = 'unsorted'
-            ascending = True
 
             if titletype == 'mixed_episodes':
                 ascending = False


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.32+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.32 (2024-05-21)
- Fix search
- Fix program menu listings

v2.5.31 (2024-04-21)
- Fix program menu listings

v2.5.30 (2024-04-16)
- Fix playing from TV guide

v2.5.29 (2024-02-12)
- Fix program listings

v2.5.28 (2024-01-24)
- Fix 'My favorites' listing

v2.5.27 (2023-12-27)
- Fix categories listing

v2.5.26 (2023-09-22)
- Fix program listings
- Add extra content to program listings

v2.5.25 (2023-09-14)
- Fix episode listings and featured menu

v2.5.24 (2023-07-18)
- Fix 1080p quality and playback issue

v2.5.23 (2023-07-11)
- Fix episode and featured listings

v2.5.22 (2023-06-14)
- Fix categories menu
- Fix 1080p

v2.5.21 (2023-05-23)
- Fix 1080p for livestreams
- Remove All programs menu
- Fix paging in episode listings
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
