### PR TITLE
[plugin.video.retrospect] v5.7.13

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.7.12"
+        version="5.7.13"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -123,21 +123,20 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.7.12 - Changelog - 2024-05-27[/B]
+        <news>[B]Retrospect v5.7.13 - Changelog - 2024-06-14[/B]
 
-Fixed another issue with Kodi Favourites and content views.
+Fixed a number of Swedish channel issues.
 
 [B]Framework related[/B]
-* Fixed: Case-insensitive comparison of logged on users (Fixes #1791).
-* Fixed: Rootfolders of channels could not be added to Kodi favourites as they broke fast (Fixes #1794).
-* Fixed: Don&#x27;t replace PickleStore items but append new items (Fixes #1794) and keep favourites in the store on clean (Fixes #1797).
+* Added: Fallback format option to DateHelper.
 
 [B]GUI/Settings/Language related[/B]
 _None_
 
 [B]Channel related[/B]
-_None_
-
+* Fixed: ONS TV season/episode issue.
+* Fixed: Playback of some SVT streams (Fixes #1801).
+* Fixed: Some timestamps are with and some without milliseconds (Fixes #1800).
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
+++ b/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
@@ -977,7 +977,7 @@ class Channel(chn_class.Channel):
         if "playableFrom" in result_set:
             from_date = result_set["playableFrom"]["isoString"]
             # isoString=2022-07-27T22:01:00.000Z
-            time_stamp = DateHelper.get_date_from_string(from_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+            time_stamp = DateHelper.get_date_from_string(from_date, "%Y-%m-%dT%H:%M:%S.%fZ", fallback_format="%Y-%m-%dT%H:%M:%SZ")
             item.set_date(*time_stamp[0:6])
 
             # Playable to
@@ -988,7 +988,7 @@ class Channel(chn_class.Channel):
 
         elif "liveEventEnd" in result_set and result_set["liveEventEnd"]:
             until_data = result_set["liveEventEnd"]["isoString"]
-            time_stamp = DateHelper.get_date_from_string(until_data, "%Y-%m-%dT%H:%M:%S.%fZ")
+            time_stamp = DateHelper.get_date_from_string(until_data, "%Y-%m-%dT%H:%M:%S.%fZ", fallback_format="%Y-%m-%dT%H:%M:%SZ")
             time_value = time.strftime('%Y-%m-%d %H:%M:%S', time_stamp)
             expires = "[COLOR gold]{}: {}[/COLOR]".format(MediaItem.ExpiresAt, time_value)
             item.description = f"{expires}\n\n{item.description}"

--- a/plugin.video.retrospect/channels/channel.videos/ons/chn_ons.py
+++ b/plugin.video.retrospect/channels/channel.videos/ons/chn_ons.py
@@ -95,6 +95,8 @@ class Channel(chn_class.Channel):
                 continue
             if param["name"].lower() == "episode":
                 episode = param["values"][0]["name"]
+                if "-" in episode:
+                    episode = episode.split("-")[0]
             elif param["name"].lower() == "season":
                 season = param["values"][0]["name"]
 

--- a/plugin.video.retrospect/resources/lib/chn_class.py
+++ b/plugin.video.retrospect/resources/lib/chn_class.py
@@ -1071,7 +1071,7 @@ class Channel:
         if not data_parsers:
             # Let's use a fallback
             key = "*"
-            data_parsers = self.dataParsers.get(key, None)
+            data_parsers = self.dataParsers.get(key, [])
 
         if parser_label:
             data_parsers = [d for d in data_parsers if d.Label == parser_label]

--- a/plugin.video.retrospect/resources/lib/helpers/datehelper.py
+++ b/plugin.video.retrospect/resources/lib/helpers/datehelper.py
@@ -183,7 +183,7 @@ class DateHelper(object):
         return aware_datetime
 
     @staticmethod
-    def get_date_from_string(value, date_format="%Y-%m-%dT%H:%M:%S+00:00"):
+    def get_date_from_string(value: str, date_format: str = "%Y-%m-%dT%H:%M:%S+00:00", fallback_format: str = None) -> time.struct_time:
         """ Converts a formatted date-time string to a time struct.
 
         time.struct_time values:
@@ -208,7 +208,12 @@ class DateHelper(object):
 
         """
 
-        return time.strptime(value, date_format)
+        try:
+            return time.strptime(value, date_format)
+        except:
+            if fallback_format:
+                return time.strptime(value, fallback_format)
+            raise
 
     @staticmethod
     def __get_month_from_name(month, language, short=True):


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Fixed a number of Swedish channel issues.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
