### PR TITLE
[plugin.video.roosterteeth] 1.5.2+matrix.1 marking addon as BROKEN due to website being discontinued

### DIFF
--- a/plugin.video.roosterteeth/addon.xml
+++ b/plugin.video.roosterteeth/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.roosterteeth"
        name="Rooster Teeth"
-       version="1.5.1+matrix.1"
+       version="1.5.2+matrix.1"
        provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="3.0.0"/>
@@ -24,12 +24,13 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=235071</forum>
     <website>https://roosterteeth.com</website>
     <source>https://github.com/skipmodea1/plugin.video.roosterteeth.python3</source>
-    <news>1.5.1 (2021-03-18)
-    - website change
+    <news>1.5.2 (2024-08-13)
+    - website is discontinued
     </news>
     <assets>
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.jpg</fanart>
     </assets>
+    <broken>Marked addon BROKEN due to website being discontinued</broken>
   </extension>
 </addon>

--- a/plugin.video.roosterteeth/changelog.txt
+++ b/plugin.video.roosterteeth/changelog.txt
@@ -1,3 +1,6 @@
+1.5.2 (2024-08-13)
+- website is discontinued
+
 1.5.1 (2021-03-18)
 - website change
 


### PR DESCRIPTION
### Description
1.5.2 (2024-08-13)
- website is discontinued
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0