### PR TITLE
[plugin.video.mlbtv@matrix] 2024.8.20+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.8.6+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.8.20+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,7 +22,7 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - Fix highlights
+            - Fix for double headers
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -683,7 +683,16 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
     json_source = r.json()
     # start with just video content, assumed to be at index 0
     #epg = json_source['media']['epg'][0]['items']
-    epg = json_source['dates'][0]['games'][0]['broadcasts']
+    #epg = json_source['dates'][0]['games'][0]['broadcasts']
+    epg = []
+    # loop through dates/games and skip those that have been rescheduled
+    if 'dates' in json_source:
+        for date in json_source['dates']:
+            if 'games' in date:
+                for game in date['games']:
+                    if 'rescheduleDate' not in game:
+                        epg = game['broadcasts']
+                        break
 
     # define some default variables
     selected_content_id = None


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2024.8.20+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - Fix for double headers
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
