### PR TITLE
[plugin.video.nhlgcl@matrix] 2024.10.17+matrix.1

### DIFF
--- a/plugin.video.nhlgcl/addon.xml
+++ b/plugin.video.nhlgcl/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2024.4.18+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.nhlgcl" name="NHL TV™" version="2024.10.17+matrix.1" provider-name="eracknaphobia">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />

--- a/plugin.video.nhlgcl/resources/lib/globals.py
+++ b/plugin.video.nhlgcl/resources/lib/globals.py
@@ -255,10 +255,11 @@ def stream_to_listitem(stream_url):
         else:
             listitem.setProperty("inputstreamaddon", "inputstream.adaptive")
         listitem.setProperty("inputstream.adaptive.manifest_type", "hls")
-        listitem.setProperty("inputstream.adaptive.stream_headers",  'User-Agent=%s' % UA_PC)
+        listitem.setProperty("inputstream.adaptive.stream_headers",  'User-Agent=%s' % UA_PC)        
+        listitem.setProperty("inputstream.adaptive.manifest_headers",  'User-Agent=%s' % UA_PC)
         listitem.setProperty("inputstream.adaptive.license_key", '|User-Agent=%s' % UA_PC)
     else:
-        listitem = xbmcgui.ListItem(path=f"{stream_url}|{headers}")
+        listitem = xbmcgui.ListItem(path=f"{stream_url}|{'User-Agent=%s' % UA_PC}")
 
     listitem.setMimeType("application/x-mpegURL")
     return listitem


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NHL TV™
  - Add-on ID: plugin.video.nhlgcl
  - Version number: 2024.10.17+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.nhlgcl
  
With NHL.TV you can access revolutionary 60fps (frames per second) video through Kodi
        

### Description of changes:


            - allow greater flexibility in stream choice
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
