### PR TITLE
[plugin.video.external.library@nexus] 1.1.2

### DIFF
--- a/plugin.video.external.library/addon.xml
+++ b/plugin.video.external.library/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.external.library"
-    version="1.1.1"
+    version="1.1.2"
     name="External Kodi Videolibrary Client"
     provider-name="Roman V.M.">
   <requires>
@@ -21,9 +21,8 @@
       <icon>icon.png</icon>
     </assets>
     <source>https://github.com/romanvm/kodi.external.library</source>
-    <news>1.1.1:
-- Replaced addon icon.
-- Internal changes.</news>
+    <news>1.1.2:
+- Refresh movies/episodes list after resume/playback state has been updated.</news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>
 </addon>

--- a/plugin.video.external.library/libs/monitor.py
+++ b/plugin.video.external.library/libs/monitor.py
@@ -58,14 +58,14 @@ class PlayMonitor(xbmc.Player):
         logger.debug('Started monitoring %s', self._playing_file)
 
     def onPlayBackStopped(self):
-        self._send_played_file_state()
-        self._clear_state()
+        self._send_played_file_state(refresh_list=True)
         logger.debug('Stopped monitoring %s. Playback stopped.', self._playing_file)
+        self._clear_state()
 
     def onPlayBackEnded(self):
-        self._send_played_file_state()
-        self._clear_state()
+        self._send_played_file_state(refresh_list=True)
         logger.debug('Stopped monitoring %s. Playback ended.', self._playing_file)
+        self._clear_state()
 
     def onPlayBackPaused(self):
         if self._should_send_resume():
@@ -115,8 +115,10 @@ class PlayMonitor(xbmc.Player):
         json_rpc_api.update_resume(item_id_param, self._item_info[item_id_param],
                                    self._current_time, self._total_time)
 
-    def _send_played_file_state(self):
+    def _send_played_file_state(self, refresh_list=False):
         if self._should_send_playcount():
             self._send_playcount()
         elif self._should_send_resume():
             self._send_resume()
+        if refresh_list:
+            xbmc.executebuiltin('Container.Refresh')


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: External Kodi Videolibrary Client
  - Add-on ID: plugin.video.external.library
  - Version number: 1.1.2
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/romanvm/kodi.external.library
  
A plugin that allows to browse and play items from a video library on an external Kodi instance.

### Description of changes:

1.1.2:
- Refresh movies/episodes list after resume/playback state has been updated.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
