### PR TITLE
[plugin.video.retrospect] v5.7.24

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.7.23"
+        version="5.7.24"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -133,20 +133,21 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.7.23 - Changelog - 2025-01-25[/B]
+        <news>[B]Retrospect v5.7.24 - Changelog - 2025-02-08[/B]
 
-Some small channel bugfixes and Python 3.13 support.
+Fixed some minor issues with channels.
 
 [B]Framework related[/B]
-* Fixed: Import issue with Python 3.13 and above.
-* Fixed: Remove search history item with space or special chars.
+_None_
 
 [B]GUI/Settings/Language related[/B]
 _None_
 
 [B]Channel related[/B]
-* Fixed: Video land duplicate entries.
-* Fixed: TV4 Latest News.
+* Fixed: NPO Luister radio stations.
+* Fixed: SRF Channel.
+* Fixed: TV4 Play Channel needs POSTs now (Fixes #1886).
+* Fixed: item &#x27;ondek meer genres&#x27; missing in NPO&#x27;s &#x27;TV shows&#x27;
 
         </news>
         <assets>

--- a/plugin.video.retrospect/channels/channel.de/srf/chn_srf.py
+++ b/plugin.video.retrospect/channels/channel.de/srf/chn_srf.py
@@ -50,7 +50,7 @@ class Channel(chn_class.Channel):
                               creator=self.create_video_item)
 
         # Generic updater
-        self._add_data_parser("https://il.srgssr.ch/integrationlayer/2.0/mediaComposition/byUrn", updater=self.update_video_item)
+        self._add_data_parser("https://il.srf.ch/integrationlayer/2.0/mediaComposition/byUrn", updater=self.update_video_item)
 
         # ===============================================================================================================
         # Test cases:
@@ -131,7 +131,7 @@ class Channel(chn_class.Channel):
 
         Logger.trace(result_set)
         video_urn = result_set["urn"]
-        url = "https://il.srgssr.ch/integrationlayer/2.0/mediaComposition/byUrn/{}.json?onlyChapters=false&vector=portalplay".format(video_urn)
+        url = "https://il.srf.ch/integrationlayer/2.0/mediaComposition/byUrn/{}.json?onlyChapters=false&vector=portalplay".format(video_urn)
         item = MediaItem(result_set["title"], url)
 
         item.media_type = mediatype.EPISODE
@@ -174,7 +174,7 @@ class Channel(chn_class.Channel):
 
         Logger.trace(result_set)
         video_urn = result_set["livestreamUrn"]
-        url = "https://il.srgssr.ch/integrationlayer/2.0/mediaComposition/byUrn/{}.json?onlyChapters=false&vector=portalplay".format(video_urn)
+        url = "https://il.srf.ch/integrationlayer/2.0/mediaComposition/byUrn/{}.json?onlyChapters=false&vector=portalplay".format(video_urn)
         station = result_set["title"]
         description = []
 

--- a/plugin.video.retrospect/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/plugin.video.retrospect/channels/channel.nos/nos2010/chn_nos2010.py
@@ -151,6 +151,10 @@ class Channel(chn_class.Channel):
                               name="Bare pages layout", json=True,
                               parser=["collections"], creator=self.create_api_page_layout)
 
+        self._add_data_parser("https://npo.nl/start/api/domain/page-collection?type=dynamic_page&guid=",
+                              name="Categories layout", json=True,
+                              parser=["items"], creator=self.create_api_category_item)
+
         # Favourites (not yet implemented in the site).
         self._add_data_parser("https://npo.nl/start/api/domain/user-profiles",
                               match_type=ParserData.MatchExact, json=True,
@@ -167,7 +171,7 @@ class Channel(chn_class.Channel):
         # live radio, the folders and items
         self._add_data_parser(
             "https://www.npoluister.nl/", name="Live Radio Streams",
-            parser=Regexer.from_expresso('<li><a[^>]+href="(?<url>https:[^"]+)"[^>]*><img[^>]+src="(?<thumb>https:[^"]+)[^>]+alt="(?<title>[^"]+)"'),
+            parser=Regexer.from_expresso('<li><a[^>]+href="(?<url>https:[^"]+)"[^>]*>(?<title>[^<]+)'),
             creator=self.create_live_radio
         )
         self._add_data_parser(
@@ -593,6 +597,8 @@ class Channel(chn_class.Channel):
             content_type = contenttype.TVSHOWS
         elif page_type == "PROGRAM":
             content_type = contenttype.EPISODES
+        elif page_type == "DYNAMIC_PAGE":
+            content_type = contenttype.VIDEOS
         else:
             Logger.error(f"Missing for page type: {page_type}")
             return None
@@ -1126,11 +1132,9 @@ class Channel(chn_class.Channel):
         if "blend" in url:
             return None
         title = result_set["title"]
-        logo = result_set["thumb"]
         item = MediaItem(title, url, media_type=mediatype.VIDEO)
         item.isLive = True
         item.complete = False
-        item.thumb = logo
         item.isLive = True
         item.metaData["retrospect:parser"] = "liveRadio"
         return item

--- a/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
+++ b/plugin.video.retrospect/channels/channel.se/tv4se/chn_tv4se.py
@@ -197,8 +197,7 @@ class Channel(chn_class.Channel):
         tvshow_url, tvshow_data = self.__get_api_query(
             "MediaIndex",
             {"input": {"letterFilters": list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-                       "limit": self.__max_page_size, "offset": 0}},
-            use_get=True)
+                       "limit": self.__max_page_size, "offset": 0}})
         items.append(__create_item(LanguageHelper.TvShows, tvshow_url, tvshow_data))
 
         recent_url, recent_data = self.__get_api_query("Panel", {"panelId": "2K0BCBpDDfhpW1NRLY0jET", "limit": self.__max_page_size, "offset": 0})
@@ -242,11 +241,11 @@ class Channel(chn_class.Channel):
 
                 tvshow_url, tvshow_data = self.__get_api_query(
                     "MediaIndex",
-                    {"input": {
-                        "letterFilters": list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
-                        "limit": self.__max_page_size, "offset": next_offset}
-                    },
-                    use_get=True
+                    {
+                        "input": {
+                            "letterFilters": list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+                            "limit": self.__max_page_size, "offset": next_offset}
+                    }
                 )
                 new_data = UriHandler.open(
                     tvshow_url, additional_headers=self.httpHeaders, json=tvshow_data,
@@ -400,7 +399,6 @@ class Channel(chn_class.Channel):
         url, data = self.__get_api_query(
             operation="ContentDetailsPage",
             variables={"mediaId": series_id, "panelsInput": {"offset": 0, "limit": 20}},
-            use_get=True
         )
         title = result_set["title"]
         if not title:
@@ -432,7 +430,6 @@ class Channel(chn_class.Channel):
         url, data = self.__get_api_query(
             operation="Page",
             variables={"pageId": page_id, "input": {"limit": self.__max_page_size, "offset": 0}},
-            use_get=False
         )
 
         item = FolderItem(title, url, content_type=contenttype.TVSHOWS, media_type=mediatype.FOLDER)
@@ -458,8 +455,7 @@ class Channel(chn_class.Channel):
         title = result_set["title"]
         url, data = self.__get_api_query(
             operation="LivePanel",
-            variables={"panelId": panel_id, "limit": self.__max_page_size, "offset": 0},
-            use_get=True
+            variables={"panelId": panel_id, "limit": self.__max_page_size, "offset": 0}
         )
 
         item = FolderItem(title, url, content_type=contenttype.VIDEOS)
@@ -928,7 +924,7 @@ class Channel(chn_class.Channel):
             return base_url, data
 
         # For GETs (but the request URLs become to long!)
-        url =  f"{base_url}query={HtmlEntityHelper.url_encode(query)}&variables={HtmlEntityHelper.url_encode(json.dumps(variables))}"
+        url = f"{base_url}query={HtmlEntityHelper.url_encode(query)}&variables={HtmlEntityHelper.url_encode(json.dumps(variables))}"
         return url, None
 
     def __update_dash_video(self, item, stream_info):


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Fixed some minor issues with channels.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
