### PR TITLE
[plugin.whereareyou]v0.6.1

### DIFF
--- a/plugin.whereareyou/README.md
+++ b/plugin.whereareyou/README.md
@@ -6,11 +6,44 @@ Where Are You is a plugin for Kodi that accepts a URL from a stream file and the
 
 ## Usage
 
+### Standard
+
 The stream file is just a text file with a URL in it.  The format of the URL is:
 
 ```
     plugin://plugin.whereareyou?empty=pad&title=Available+streaming&message=This+is+available+via+the+Netflix+app+on+the+TV
 ```
+
+### Deep Linking with AppleTV and Home Assistant
+
+If you are using an AppleTV as your streaming device and Home Assistant control, you can include a URL in the streaming file to directly launch the episode or movie.  This doesn't work on every streaming service, but it does for a bunch of them.  For more details on this and how to get the URL, see the [Home Assistant AppleTV integration documention](https://www.home-assistant.io/integrations/apple_tv) and look for the section on deep links.
+
+You'll need to create a script called "Launch Streaming Video."  Make sure it has an entity ID of `script.launch_streaming_video`.  This is the script:
+
+```
+alias: Launch Streaming Video
+fields:
+  the_url:
+    description: The URL to the episode or movie
+    example: https://www.disneyplus.com/video/afdc98f1-26bf-48d8-8866-af185ba5d5ac
+sequence:
+  - service: media_player.play_media
+    data:
+      media_content_type: url
+      media_content_id: "{{ the_url }}"
+    target:
+      device_id: <CHANGE TO THE DEVICE ID FOR YOUR APPLETV>
+mode: single
+icon: mdi:television
+```
+
+The URL for the streaming file needs one more thing, the_url passed as an argument, like this:
+
+```
+    plugin://plugin.whereareyou?empty=pad&title=Available+Streaming&message=Available+on+Disney%2B&the_url=https://www.disneyplus.com/video/618050a1-5dbf-4b4f-91ca-3299fb077be1
+```
+
+## Naming
 
 The stream file should be named in a way that Kodi can scrape it as a TV show:
 

--- a/plugin.whereareyou/addon.xml
+++ b/plugin.whereareyou/addon.xml
@@ -1,4 +1,4 @@
-<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.5.1">
+<addon id="plugin.whereareyou" name="Where Are You" provider-name="pkscout" version="0.6.1">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0" />
 		<import addon="script.module.requests" version="2.22.0+matrix.1" />
@@ -8,17 +8,15 @@
 		<provides>executable</provides>
 	</extension>
 	<extension point="xbmc.addon.metadata">
-		<news>v.0.5.1
-- added option to use Home Assistant script to launch external app
-- changed IP entry in settings to string to allow for domain name
-- added settings option to enable SSL (HA only)
-- Harmony Hub option now shows list of activites from which to pick
+		<news>v.0.6.1
+- added option to bypass dialog asking if you want to launch the streaming service
+- if using HA control and an AppleTV, can pass video URL to launch episode/movie directly
 		</news>
 		<assets>
 			<icon>icon.png</icon>
 		</assets>
 		<summary lang="en_GB">Plugin module to display a custom dialog box when playing external media.</summary>
-		<description lang="en_GB">Where Are You is a plugin for Kodi that accepts a URL from a stream file and then displays a dialog box with the title and message from the stream file URL.  After the dialog is dismissed a black video plays for 2 seconds.  This is basically to do what the media stub file does (which is display a title and a message for a given file), but for streaming files because the media stub only works if you have an optical drive attached to the device running Kodi.
+		<description lang="en_GB">Where Are You is a plugin for Kodi that accepts a URL from a stream file and then displays a dialog box with the title and message from the stream file URL.  Can also trigger Home Assistant script (including passing a URL to HA to directly launch a streaming app on an AppleTV or Andriod device) or Harmony Remote actions.  After the dialog is dismissed a black video plays for 2 seconds.  This is basically to do what the media stub file does (which is display a title and a message for a given file), but for streaming files because the media stub only works if you have an optical drive attached to the device running Kodi.
 		</description>
 		<platform>all</platform>
 		<license>GPL-2.0-only</license>

--- a/plugin.whereareyou/changelog.txt
+++ b/plugin.whereareyou/changelog.txt
@@ -1,3 +1,10 @@
+v.0.6.1
+- accept URL encoded URL and decode it before passing to Home Assistant
+
+v.0.6.0
+- added option to bypass dialog asking if you want to launch the streaming service
+- if using Home Assistan control and an AppleTV, can pass video URL to launch episode/movie directly
+
 v.0.5.1
 - settings fixes for better backwards compatibility
 - changed IP entry in settings to string to allow for domain name

--- a/plugin.whereareyou/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.whereareyou/resources/language/resource.language.en_gb/strings.po
@@ -75,6 +75,11 @@ msgctxt "#32112"
 msgid "Use secure connection to Home Assistant"
 msgstr ""
 
+#: Settings
+msgctxt "#32113"
+msgid "Don't show confirmation dialog"
+msgstr ""
+
 #: Dialog Heading
 msgctxt "#32200"
 msgid "Select action"

--- a/plugin.whereareyou/resources/lib/waysettings.py
+++ b/plugin.whereareyou/resources/lib/waysettings.py
@@ -3,6 +3,7 @@ from resources.lib.kodisettings import *
 
 SETTINGSLIST = [{'name': 'mappings', 'default': ''},
                 {'name': 'harmonycontrol', 'default': False},
+                {'name': 'bypassdialog', 'default': False},
                 {'name': 'controltype', 'default': 2},
                 {'name': 'hub_ip', 'default': ''},
                 {'name': 'hub_port', 'default': '8123'},

--- a/plugin.whereareyou/resources/settings.xml
+++ b/plugin.whereareyou/resources/settings.xml
@@ -38,6 +38,16 @@
 					<default>false</default>
 					<control type="toggle"/>
 				</setting>
+				<setting help="" id="bypassdialog" label="32113" parent="harmonycontrol" type="boolean">
+					<level>0</level>
+					<default>false</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="harmonycontrol">true</condition>
+						</dependency>
+					</dependencies>
+					<control type="toggle"/>
+				</setting>
 				<setting id="controltype" type="integer" parent="harmonycontrol" label="32107" help="">
 					<level>0</level>
 					<default>2</default>


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
- added option to bypass dialog asking if you want to launch the streaming service
- if using Home Assistant control and an AppleTV, can pass video URL to launch episode/movie directly
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
