### PR TITLE
[plugin.video.mlbtv@matrix] 2025.3.18+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2024.8.20+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.3.18+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,7 +22,9 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - Fix for double headers
+            - ability to change skip timing adjustment settings during playback
+            - initial 2025 updates
+            - fix for Japan exhibitions
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -93,7 +93,7 @@ MLB_ID = '1'
 MILB_IDS = '11,12,13,14'
 MLB_TEAM_IDS = '108,109,110,111,112,113,114,115,116,117,118,119,120,121,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,158,159,160'
 
-AFFILIATE_TEAM_IDS = {"Arizona Diamondbacks": "419,516,2310,5368", "Atlanta Braves": "430,431,432,478", "Baltimore Orioles": "418,488,548,568", "Boston Red Sox": "414,428,533,546", "Chicago Cubs": "451,521,550,553", "Chicago White Sox": "247,487,494,580", "Cincinnati Reds": "416,450,459,498", "Cleveland Guardians": "402,437,445,481", "Colorado Rockies": "259,342,486,538", "Detroit Tigers": "106,512,570,582", "Houston Astros": "482,573,3712,5434", "Kansas City Royals": "541,565,1350,3705", "Los Angeles Angels": "401,460,559,561", "Los Angeles Dodgers": "238,260,456,526", "Miami Marlins": "479,554,564,4124", "Milwaukee Brewers": "249,556,572,5015", "Minnesota Twins": "492,509,1960,3898", "New York Mets": "453,505,507,552", "New York Yankees": "531,537,587,1956", "Oakland Athletics": "237,400,499,524", "Philadelphia Phillies": "427,522,566,1410", "Pittsburgh Pirates": "452,477,484,3390", "San Diego Padres": "103,510,584,4904", "San Francisco Giants": "105,461,476,3410", "Seattle Mariners": "403,515,529,574", "St. Louis Cardinals": "235,279,440,443", "Tampa Bay Rays": "233,234,421,2498", "Texas Rangers": "102,448,485,540", "Toronto Blue Jays": "422,424,435,463", "Washington Nationals": "426,436,534,547"}
+AFFILIATE_TEAM_IDS = {"Arizona Diamondbacks": "419,516,2310,5368", "Athletics": "237,400,499,524", "Atlanta Braves": "431,432,478,6325", "Baltimore Orioles": "418,488,548,568", "Boston Red Sox": "414,428,533,546", "Chicago Cubs": "451,521,550,553", "Chicago White Sox": "247,487,494,580", "Cincinnati Reds": "416,450,459,498", "Cleveland Guardians": "402,437,445,481", "Colorado Rockies": "259,342,486,538", "Detroit Tigers": "106,512,570,582", "Houston Astros": "482,573,3712,5434", "Kansas City Royals": "541,565,1350,3705", "Los Angeles Angels": "401,460,559,561", "Los Angeles Dodgers": "238,260,456,526", "Miami Marlins": "479,554,564,4124", "Milwaukee Brewers": "249,556,572,5015", "Minnesota Twins": "492,509,1960,3898", "New York Mets": "453,505,507,552", "New York Yankees": "531,537,587,1956", "Philadelphia Phillies": "427,522,566,1410", "Pittsburgh Pirates": "452,477,484,3390", "San Diego Padres": "103,510,584,4904", "San Francisco Giants": "105,461,476,3410", "Seattle Mariners": "403,515,529,574", "St. Louis Cardinals": "235,279,440,443", "Tampa Bay Rays": "233,234,421,2498", "Texas Rangers": "102,448,540,6324", "Toronto Blue Jays": "422,424,435,463", "Washington Nationals": "426,436,534,547"}
 
 ESPN_SUNDAY_NIGHT_BLACKOUT_COUNTRIES = ["Angola", "Anguilla", "Antigua and Barbuda", "Argentina", "Aruba", "Australia", "Bahamas", "Barbados", "Belize", "Belize", "Benin", "Bermuda", "Bolivia", "Bonaire", "Botswana", "Brazil", "British Virgin Islands", "Burkina Faso", "Burundi", "Cameroon", "Cape Verde", "Cayman Islands", "Central African Republic", "Chad", "Chile", "Colombia", "Comoros", "Cook Islands", "Costa Rica", "Cote d'Ivoire", "Curacao", "Democratic Republic of the Congo", "Djibouti", "Dominica", "Dominican Republic", "Ecuador", "El Salvador", "England", "Equatorial Guinea", "Eritrea", "Eswatini", "Ethiopia", "Falkland Islands", "Falkland Islands", "Fiji", "French Guiana", "French Guiana", "French Polynesia", "Gabon", "Ghana", "Grenada", "Guadeloupe", "Guatemala", "Guinea", "Guinea Bissau", "Guyana", "Guyana", "Haiti", "Honduras", "Ireland", "Jamaica", "Kenya", "Kiribati", "Lesotho", "Liberia", "Madagascar", "Malawi", "Mali", "Marshall Islands", "Martinique", "Mayotte", "Mexico", "Micronesia", "Montserrat", "Mozambique", "Namibia", "Netherlands", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Northern Ireland", "Palau Islands", "Panama", "Paraguay", "Peru", "Republic of Ireland", "Reunion", "Rwanda", "Saba", "Saint Maarten", "Samoa", "Sao Tome & Principe", "Scotland", "Senegal", "Seychelles", "Sierra Leone", "Solomon Islands", "Somalia", "South Africa", "St. Barthelemy", "St. Eustatius", "St. Kitts and Nevis", "St. Lucia", "St. Martin", "St. Vincent and the Grenadines", "Sudan", "Surinam", "Suriname", "Tahiti", "Tanzania & Zanzibar", "The Gambia", "The Republic of Congo", "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Uruguay", "Venezuela", "Wales", "Zambia", "Zimbabwe"]
 
@@ -309,6 +309,7 @@ def addPlaylist(name,game_day,mode,icon,fanart=None):
 def getFavTeamColor():
     #Hex code taken from http://jim-nielsen.com/teamcolors/    
     team_colors = {'Arizona Diamondbacks': 'FFA71930',
+                   'Athletics': 'FFEFB21E',
                    'Atlanta Braves': 'FFCE1141',
                    'Baltimore Orioles': 'FFDF4601',
                    'Boston Red Sox': 'FFBD3039',
@@ -327,7 +328,6 @@ def getFavTeamColor():
                    'Minnesota Twins': 'FFD31145',
                    'New York Mets': 'FFFF5910',
                    'New York Yankees': 'FFE4002B',
-                   'Oakland Athletics': 'FFEFB21E',
                    'Philadelphia Phillies': 'FFE81828',
                    'Pittsburgh Pirates': 'FFFDB827',
                    'St. Louis Cardinals': 'FFC41E3A',
@@ -348,6 +348,7 @@ def getFavTeamId():
     #possibly use the xml file in the future
     #http://mlb.mlb.com/shared/properties/mlb_properties.xml  
     team_ids = {'Arizona Diamondbacks': '109',
+                'Athletics': '133',
                 'Atlanta Braves': '144',
                 'Baltimore Orioles': '110',
                 'Boston Red Sox': '111',
@@ -366,7 +367,6 @@ def getFavTeamId():
                 'Minnesota Twins': '142',
                 'New York Mets': '121',
                 'New York Yankees': '147',
-                'Oakland Athletics': '133',
                 'Philadelphia Phillies': '143',
                 'Pittsburgh Pirates': '134',
                 'St. Louis Cardinals': '138',

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -150,7 +150,7 @@ def create_game_listitem(game, game_day, start_inning, today):
     milb = None
     level_abbr = ''
     # MiLB titles and graphics
-    if game['teams']['home']['team']['sport']['id'] != 1:
+    if game['teams']['away']['team']['sport']['id'] != 1 and game['teams']['home']['team']['sport']['id'] != 1:
         # Skip MiLB games without any broadcast
         milb_broadcast = None
         if 'broadcasts' in game:
@@ -222,8 +222,12 @@ def create_game_listitem(game, game_day, start_inning, today):
 
         title = away_team + ' at ' + home_team
 
-        icon = 'https://img.mlbstatic.com/mlb-photos/image/upload/ar_167:215,c_crop/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':fill:spot.png,w_1.0,h_1,x_0.5,y_0,fl_no_overflow,e_distort:100p:0:200p:0:200p:100p:0:100p/fl_relative,l_team:' + str(game['teams']['away']['team']['id']) + ':logo:spot:current,w_0.38,x_-0.25,y_-0.16/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':logo:spot:current,w_0.38,x_0.25,y_0.16/w_750/team/' + str(game['teams']['away']['team']['id']) + '/fill/spot.png'
-        fanart = 'http://cd-images.mlbstatic.com/stadium-backgrounds/color/light-theme/1920x1080/%s.png' % game['venue']['id']
+        if game['teams']['away']['team']['sport']['id'] == 1 and game['teams']['home']['team']['sport']['id'] == 1:
+            icon = 'https://img.mlbstatic.com/mlb-photos/image/upload/ar_167:215,c_crop/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':fill:spot.png,w_1.0,h_1,x_0.5,y_0,fl_no_overflow,e_distort:100p:0:200p:0:200p:100p:0:100p/fl_relative,l_team:' + str(game['teams']['away']['team']['id']) + ':logo:spot:current,w_0.38,x_-0.25,y_-0.16/fl_relative,l_team:' + str(game['teams']['home']['team']['id']) + ':logo:spot:current,w_0.38,x_0.25,y_0.16/w_750/team/' + str(game['teams']['away']['team']['id']) + '/fill/spot.png'
+            fanart = 'http://cd-images.mlbstatic.com/stadium-backgrounds/color/light-theme/1920x1080/%s.png' % game['venue']['id']
+        else:
+            icon = ICON
+            fanart = FANART
 
         desc = ''
 
@@ -705,7 +709,6 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
     stream_type = 'video'
     skip_possible = True # to determine if possible to show skip options dialog
     skip_type = 0
-    skip_adjust = 0 # only used for MiLB games
     is_live = False # to pass to skip monitor
     # convert start inning values to integers
     if start_inning == 'False':
@@ -1025,7 +1028,7 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
 
                     # call the game monitor for skips and/or to stop the overlay
                     if ((skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None) or (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith('BS')):
-                        mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, skip_adjust, stream_url, is_live, start_inning, start_inning_half)
+                        mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, stream_url, is_live, start_inning, start_inning_half)
 
         # otherwise exit
         else:
@@ -1040,8 +1043,6 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
     broadcast_start_timestamp = None # to pass to skip monitor
     skip_possible = True # to determine if possible to show skip options dialog
     skip_type = 0
-    settings = xbmcaddon.Addon(id='plugin.video.mlbtv')
-    skip_adjust = settings.getSetting(id="milb_skip_adjust")
     is_live = False # to pass to skip monitor
     # convert start inning values to integers
     if start_inning == 'False':
@@ -1173,19 +1174,6 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
                 elif skip_type > 1:
                     skip_type += 1
 
-                if skip_type > 0 or start_inning > 0:
-                    if skip_adjust == 'Always Ask':
-                        # skip adjust dialog
-                        skip_adjust_options = ['-15', '-10', '-5', '0', '5', '10', '15']
-                        p = dialog.select(LOCAL_STRING(30434), skip_adjust_options)
-                        # cancel will exit
-                        if p == -1:
-                            sys.exit()
-                        else:
-                            skip_adjust = int(skip_adjust_options[p])
-                    else:
-                        skip_adjust = int(skip_adjust)
-
 
         headers = 'User-Agent=' + UA_PC
         if '.m3u8' in video_stream_url and QUALITY == 'Always Ask':
@@ -1200,7 +1188,7 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
         if game_pk is not None and (skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None:
             from .mlbmonitor import MLBMonitor
             mlbmonitor = MLBMonitor()
-            mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, skip_adjust, video_stream_url, is_live, start_inning, start_inning_half)
+            mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, video_stream_url, is_live, start_inning, start_inning_half)
     else:
         xbmc.log('unable to find stream for featured video')
 

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -26,7 +26,7 @@
     <setting id="hide_scores_ticker" type="bool" label="30436" default="false" />
     <setting id="disable_video_padding" type="bool" label="30416" default="false" />
     <setting id="disable_closed_captions" type="bool" label="30437" default="false" />
-    <setting id="fav_team" type="select" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|Oakland Athletics|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Arizona Diamondbacks" />
+    <setting id="fav_team" type="select" label="30180" default="None" values="None|Washington Nationals|Toronto Blue Jays|Texas Rangers|Tampa Bay Rays|St. Louis Cardinals|Seattle Mariners|San Francisco Giants|San Diego Padres|Pittsburgh Pirates|Philadelphia Phillies|New York Yankees|New York Mets|Minnesota Twins|Milwaukee Brewers|Miami Marlins|Los Angeles Dodgers|Los Angeles Angels|Kansas City Royals|Houston Astros|Detroit Tigers|Colorado Rockies|Cleveland Guardians|Cincinnati Reds|Chicago White Sox|Chicago Cubs|Boston Red Sox|Baltimore Orioles|Atlanta Braves|Athletics|Arizona Diamondbacks" />
     <setting id="include_fav_affiliates" type="bool" label="30427" default="true" />
 
     <setting id="team_names" type="select" label="30190" lvalues="30191|30192" default="0" />
@@ -34,9 +34,9 @@
     <setting id="auto_select_stream" type="bool" label="30307" default="false" />
     <setting id="catch_up" type="bool" label="30304" default="true" />
     <setting id="ask_to_skip" type="bool" label="30306" default="true" />
-    <setting id="skip_adjust_start" type="slider" label="30424" default="0" range="-10,1,10" />
-    <setting id="skip_adjust_end" type="slider" label="30425" default="0" range="-10,1,10" />
-    <setting id="milb_skip_adjust" type="slider" label="30435" default="-5" values="Always Ask|-15|-10|-5|0|5|10|15" />
+    <setting id="skip_adjust_start" type="slider" label="30424" default="0" range="-99,1,99" />
+    <setting id="skip_adjust_end" type="slider" label="30425" default="0" range="-99,1,99" />
+    <setting id="milb_skip_adjust" type="slider" label="30435" default="0" range="-99,1,99" visible="false" />
     <setting id="auto_play_fav" type="bool" label="30412" default="false" />
     <setting id="only_free_games" type="bool" label="30305" default="false" />
     <setting id="game_changer_delay" type="slider" label="30420" default="0" range="0,5,20" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2025.3.18+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - ability to change skip timing adjustment settings during playback
            - initial 2025 updates
            - fix for Japan exhibitions
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
