### PR TITLE
[plugin.video.mlbtv@matrix] 2025.3.30+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.3.18+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.3.30+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,9 +22,11 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - ability to change skip timing adjustment settings during playback
-            - initial 2025 updates
-            - fix for Japan exhibitions
+            - automatic blackout/entitlement detection
+            - support for SNLA and SNY subscriptions
+            - skip timing, game changer, and hide scores ticker updates for 2025
+            - jump to live when skipping start dialog and allowing spoilers
+            - disabled Big Inning schedule scraping
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -162,6 +162,10 @@ elif mode == 300:
 elif mode == 301:
     featured_stream_select(featured_video, name, description, start_inning, game_pk)
 
+# Linear channel stream select
+elif mode == 302:
+    linear_channel_stream_select(featured_video, name, description)
+
 # Logout
 elif mode == 400:
     from resources.lib.account import Account

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -420,4 +420,20 @@ msgctxt "#30439"
 msgid "MLB Network live stream"
 msgstr ""
 
+msgctxt "#30440"
+msgid "SportsNet LA"
+msgstr ""
+
+msgctxt "#30441"
+msgid "SNLA live stream"
+msgstr ""
+
+msgctxt "#30442"
+msgid "SNY"
+msgstr ""
+
+msgctxt "#30443"
+msgid "SNY live stream"
+msgstr ""
+
 

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -70,7 +70,8 @@ CRITICAL ='FFD10D0D'
 FINAL = 'FF666666'
 FREE = 'FF43CD80'
 
-
+#Score ticker network prefix
+SCORES_TICKER_NETWORK = 'FDSN'
 
 #Images
 ICON = os.path.join(ROOTDIR,"icon.png")

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -4,9 +4,9 @@
   <category label="30100">
     <setting id="username" type="text" label="30140" default=""/>
     <setting id="password" type="text" label="30150" option="hidden" default=""/>
-    <setting id="single_team" type="bool" label="30151" default="false"/>
-    <setting id="zip_code" type="number" label="30415" default=""/>
-    <setting id="country" type="labelenum" label="30428" default="USA" values="USA|Angola|Anguilla|Antigua and Barbuda|Argentina|Aruba|Australia|Bahamas|Barbados|Belize|Belize|Benin|Bermuda|Bolivia|Bonaire|Botswana|Brazil|British Virgin Islands|Burkina Faso|Burundi|Canada|Cameroon|Cape Verde|Cayman Islands|Central African Republic|Chad|Chile|Colombia|Comoros|Cook Islands|Costa Rica|Cote d'Ivoire|Curacao|Democratic Republic of the Congo|Djibouti|Dominica|Dominican Republic|Ecuador|El Salvador|England|Equatorial Guinea|Eritrea|Eswatini|Ethiopia|Falkland Islands|Falkland Islands|Fiji|French Guiana|French Guiana|French Polynesia|Gabon|Ghana|Grenada|Guadeloupe|Guatemala|Guinea|Guinea Bissau|Guyana|Guyana|Haiti|Honduras|Ireland|Jamaica|Kenya|Kiribati|Lesotho|Liberia|Madagascar|Malawi|Mali|Marshall Islands|Martinique|Mayotte|Mexico|Micronesia|Montserrat|Mozambique|Namibia|Netherlands|New Zealand|Nicaragua|Niger|Nigeria|Niue|Northern Ireland|Palau Islands|Panama|Paraguay|Peru|Republic of Ireland|Reunion|Rwanda|Saba|Saint Maarten|Samoa|Sao Tome &amp; Principe|Scotland|Senegal|Seychelles|Sierra Leone|Solomon Islands|Somalia|South Africa|St. Barthelemy|St. Eustatius|St. Kitts and Nevis|St. Lucia|St. Martin|St. Vincent and the Grenadines|Sudan|Surinam|Suriname|Tahiti|Tanzania &amp; Zanzibar|The Gambia|The Republic of Congo|Togo|Tokelau|Tonga|Trinidad and Tobago|Turks and Caicos Islands|Tuvalu|Uganda|Uruguay|Venezuela|Wales|Zambia|Zimbabwe|other" />
+    <setting id="single_team" type="bool" label="30151" default="false" visible="false"/>
+    <setting id="zip_code" type="number" label="30415" default="" visible="false"/>
+    <setting id="country" type="labelenum" label="30428" default="USA" values="USA|Angola|Anguilla|Antigua and Barbuda|Argentina|Aruba|Australia|Bahamas|Barbados|Belize|Belize|Benin|Bermuda|Bolivia|Bonaire|Botswana|Brazil|British Virgin Islands|Burkina Faso|Burundi|Canada|Cameroon|Cape Verde|Cayman Islands|Central African Republic|Chad|Chile|Colombia|Comoros|Cook Islands|Costa Rica|Cote d'Ivoire|Curacao|Democratic Republic of the Congo|Djibouti|Dominica|Dominican Republic|Ecuador|El Salvador|England|Equatorial Guinea|Eritrea|Eswatini|Ethiopia|Falkland Islands|Falkland Islands|Fiji|French Guiana|French Guiana|French Polynesia|Gabon|Ghana|Grenada|Guadeloupe|Guatemala|Guinea|Guinea Bissau|Guyana|Guyana|Haiti|Honduras|Ireland|Jamaica|Kenya|Kiribati|Lesotho|Liberia|Madagascar|Malawi|Mali|Marshall Islands|Martinique|Mayotte|Mexico|Micronesia|Montserrat|Mozambique|Namibia|Netherlands|New Zealand|Nicaragua|Niger|Nigeria|Niue|Northern Ireland|Palau Islands|Panama|Paraguay|Peru|Republic of Ireland|Reunion|Rwanda|Saba|Saint Maarten|Samoa|Sao Tome &amp; Principe|Scotland|Senegal|Seychelles|Sierra Leone|Solomon Islands|Somalia|South Africa|St. Barthelemy|St. Eustatius|St. Kitts and Nevis|St. Lucia|St. Martin|St. Vincent and the Grenadines|Sudan|Surinam|Suriname|Tahiti|Tanzania &amp; Zanzibar|The Gambia|The Republic of Congo|Togo|Tokelau|Tonga|Trinidad and Tobago|Turks and Caicos Islands|Tuvalu|Uganda|Uruguay|Venezuela|Wales|Zambia|Zimbabwe|other" visible="false"/>
     <setting id="old_country" type="text" label="" default="" visible="false"/>
     <setting id="old_zip_code" type="number" label="" default="" visible="false"/>
     <setting id="blackout_teams" type="text" label="" default="[]" visible="false"/>
@@ -15,6 +15,7 @@
     <setting id='entitlements' type='text' visible="false" default=''/>
     <setting id='session_key' type='text' visible="false" default=''/>
     <setting id='device_id' type='text' visible="false" default=''/>
+    <setting id='okta_id' type='text' visible="false" default=''/>
     <setting id='login_token' type='text' visible="false" default=''/>
     <setting id='login_token_expiry' type='text' visible="false" default=''/>
   </category>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2025.3.30+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - automatic blackout/entitlement detection
            - support for SNLA and SNY subscriptions
            - skip timing, game changer, and hide scores ticker updates for 2025
            - jump to live when skipping start dialog and allowing spoilers
            - disabled Big Inning schedule scraping
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
