### PR TITLE
[plugin.video.mlbtv@matrix] 2025.4.8+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.3.18+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.4.8+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,9 +22,12 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - ability to change skip timing adjustment settings during playback
-            - initial 2025 updates
-            - fix for Japan exhibitions
+            - automatic blackout/entitlement detection
+            - support for SNLA and SNY subscriptions
+            - skip timing, game changer, and hide scores ticker updates for 2025
+            - jump to live when skipping start dialog and allowing spoilers
+            - restored Big Inning schedule
+            - fixed Catch Up option
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/main.py
+++ b/plugin.video.mlbtv/main.py
@@ -162,6 +162,10 @@ elif mode == 300:
 elif mode == 301:
     featured_stream_select(featured_video, name, description, start_inning, game_pk)
 
+# Linear channel stream select
+elif mode == 302:
+    linear_channel_stream_select(featured_video, name, description)
+
 # Logout
 elif mode == 400:
     from resources.lib.account import Account

--- a/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.mlbtv/resources/language/resource.language.en_gb/strings.po
@@ -420,4 +420,20 @@ msgctxt "#30439"
 msgid "MLB Network live stream"
 msgstr ""
 
+msgctxt "#30440"
+msgid "SportsNet LA"
+msgstr ""
+
+msgctxt "#30441"
+msgid "SNLA live stream"
+msgstr ""
+
+msgctxt "#30442"
+msgid "SNY"
+msgstr ""
+
+msgctxt "#30443"
+msgid "SNY live stream"
+msgstr ""
+
 

--- a/plugin.video.mlbtv/resources/lib/globals.py
+++ b/plugin.video.mlbtv/resources/lib/globals.py
@@ -70,7 +70,8 @@ CRITICAL ='FFD10D0D'
 FINAL = 'FF666666'
 FREE = 'FF43CD80'
 
-
+#Score ticker network prefix
+SCORES_TICKER_NETWORK = 'FDSN'
 
 #Images
 ICON = os.path.join(ROOTDIR,"icon.png")

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -76,10 +76,8 @@ def todays_games(game_day, start_inning='False', sport=MLB_ID, teams='None'):
     game_changer_start = None
     game_changer_end = None
     inprogress_exists = False
+    nonentitlement_data = get_nonentitlement_data(game_day)
     blackouts = []
-    regional_fox_games_exist = False
-    if game_day >= today:
-        regional_fox_games_exist = check_regional_fox_games(games)
 
     # loop through games to find favorite team
     for game in games:
@@ -89,36 +87,36 @@ def todays_games(game_day, start_inning='False', sport=MLB_ID, teams='None'):
             remaining_games.append(game)
 
         game['scheduled_innings'] = get_scheduled_innings(game)
+            
+        # while looping through today's games, also count in progress, non-blackout MLB games for Game Changer
+        if str(game['gamePk']) in nonentitlement_data:
+            blackouts.append(str(game['gamePk']))
+        else:
+            if game['teams']['home']['team']['sport']['id'] == 1 and 'rescheduleDate' not in game:
+                game_changer_starts.append(game['gameDate'])
 
-        # while looping through today or future games, check blackout status
-        if game_day >= today:
-            game['blackout_type'], game['blackout_time'] = get_blackout_status(game, regional_fox_games_exist)
-            if game_day == today:
-                # while looping through today's games, also count in progress, non-blackout MLB games for Game Changer
-                if game['blackout_type'] != 'False':
-                    blackouts.append(str(game['gamePk']))
-                else:
-                    if game['teams']['home']['team']['sport']['id'] == 1 and 'rescheduleDate' not in game:
-                        game_changer_starts.append(game['gameDate'])
-
-                    if not inprogress_exists and game['status']['detailedState'] == 'In Progress':
-                        inprogress_exists = True
+            if not inprogress_exists and game['status']['detailedState'] == 'In Progress':
+                inprogress_exists = True
 
     try:
         for game in favorite_games:
-            create_game_listitem(game, game_day, start_inning, today)
+            create_game_listitem(game, game_day, start_inning, today, nonentitlement_data)
     except:
         pass
 
     # Big Inning and game changer only available for non-free accounts (and not in minor league lists)
     if ONLY_FREE_GAMES != 'true' and sport == MLB_ID:
         # if the requested date is today,
-        # then show the MLB Network listitem
+        # then show any entitled linear channel listitems
         from .account import Account
         account = Account()
         entitlements = json.loads(account.get_entitlements())
         if today == game_day and ('MLBN' in entitlements or 'MLBALL' in entitlements or 'MLBTVMLBNADOBEPASS' in entitlements or 'EXECMLB' in entitlements):
-            create_mlb_network_listitem()
+            create_linear_channel_listitem('MLBN')
+        if today == game_day and 'SNLA_119' in entitlements:
+            create_linear_channel_listitem('SNLA')
+        if today == game_day and 'SNY_121' in entitlements:
+            create_linear_channel_listitem('SNY')
             
         # if the requested date is not in the past, we have games for this date, and it's a regular season date,
         # then show the Big Inning listitem
@@ -135,7 +133,7 @@ def todays_games(game_day, start_inning='False', sport=MLB_ID, teams='None'):
 
     try:
         for game in remaining_games:
-            create_game_listitem(game, game_day, start_inning, today)
+            create_game_listitem(game, game_day, start_inning, today, nonentitlement_data)
     except:
         pass
 
@@ -143,7 +141,7 @@ def todays_games(game_day, start_inning='False', sport=MLB_ID, teams='None'):
     addDir('[B]%s >>[/B]' % LOCAL_STRING(30011), 101, NEXT_ICON, FANART, next_day.strftime("%Y-%m-%d"), start_inning, sport, teams)
 
 
-def create_game_listitem(game, game_day, start_inning, today):
+def create_game_listitem(game, game_day, start_inning, today, nonentitlement_data):
     game_pk = game['gamePk']
     xbmc.log(str(game_pk))
 
@@ -411,19 +409,19 @@ def create_game_listitem(game, game_day, start_inning, today):
     if len(broadcast_list) > 0:
         desc += '[CR]' + ", ".join(broadcast_list)
 
-    # Check local/national blackout status
+    # Check entitlement/blackout status
     blackout = 'False'
     try:
-        if game_day >= today and game_state != 'Postponed':
-            if 'blackout_type' in game and game['blackout_type'] != 'False':
-                name = blackoutString(name)
-                desc += '[CR]' + game['blackout_type'] + ' video blackout until approx. 2.5 hours after the game'
-                if 'blackout_time' not in game or game['blackout_time'] is None:
-                    blackout = 'True'
-                else:
-                    blackout = game['blackout_time']
-                    blackout_display_time = get_display_time(UTCToLocal(game['blackout_time']))
-                    desc += ' (~' + blackout_display_time + ')'
+        if str(game['gamePk']) in nonentitlement_data:
+            blackout = 'True'
+            name = blackoutString(name)
+            if nonentitlement_data[str(game['gamePk'])] != '':
+                blackout = nonentitlement_data[str(game['gamePk'])]
+                blackout_display_time = get_display_time(UTCToLocal(blackout))
+                desc += '[CR]Live video blackout until approx. 2.5 hours after the game (~' + blackout_display_time + ')'
+            else:
+                desc += '[CR]Your account may not be entitled to stream this game'
+                
     except:
         pass
 
@@ -531,19 +529,36 @@ def featured_videos(featured_video=None):
                 xbmcplugin.setContent(addon_handle, 'episodes')
 
 
-# display a MLB Network item within a game list
-def create_mlb_network_listitem():
+# display a linear channel item within a game list
+def create_linear_channel_listitem(network):
     try:
-        title = LOCAL_STRING(30367) + LOCAL_STRING(30438)
+        if network == 'MLBN':
+            title = LOCAL_STRING(30367) + LOCAL_STRING(30438)
+            description = LOCAL_STRING(30439)
+            video_url = 'https://falcon.mlbinfra.com/api/v1/linear/mlbn'
+            icon = 'https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcQRgC2JdbtFplKjfhXm5_vzpkUQ3XyDT91SEnHmuB0p5tReQ3Ez'
+            fanart = 'https://img.mlbstatic.com/mlb-images/image/private/ar_16:9,g_auto,q_auto:good,w_1536,c_fill,f_jpg/mlb/i138wzlhv79dq3xvo1ti'
+            mode = 301
+        elif network == 'SNLA':
+            title = LOCAL_STRING(30367) + LOCAL_STRING(30440)
+            description = LOCAL_STRING(30441)
+            video_url = 'SNLA_LIVE'
+            icon = 'https://img.mlbstatic.com/mlb-images/image/upload/t_w640/mlb/fnwk2k0kgn1j8r8vvx3d.png'
+            fanart = FANART
+            mode = 302
+        elif network == 'SNY':
+            title = LOCAL_STRING(30367) + LOCAL_STRING(30442)
+            description = LOCAL_STRING(30443)
+            video_url = 'SNY_LIVE'
+            icon = 'https://img.mlbstatic.com/mlb-images/image/upload/t_w640/mlb/le5jifzo6oylxtnuf0m1.png'
+            fanart = FANART
+            mode = 302
+        
         liz=xbmcgui.ListItem(title)
-        description = LOCAL_STRING(30439)
         liz.setInfo( type="Video", infoLabels={ "Title": title, "plot": description } )
-        video_url = 'https://falcon.mlbinfra.com/api/v1/linear/mlbn'
-        icon = 'https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcQRgC2JdbtFplKjfhXm5_vzpkUQ3XyDT91SEnHmuB0p5tReQ3Ez'
-        fanart = 'https://img.mlbstatic.com/mlb-images/image/private/ar_16:9,g_auto,q_auto:good,w_1536,c_fill,f_jpg/mlb/i138wzlhv79dq3xvo1ti'
         liz.setArt({'icon': icon, 'thumb': icon, 'fanart': fanart})
         liz.setProperty("IsPlayable", "true")
-        u=sys.argv[0]+"?mode="+str(301)+"&featured_video="+urllib.quote_plus(video_url)+"&name="+urllib.quote_plus(title)
+        u=sys.argv[0]+"?mode="+str(mode)+"&featured_video="+urllib.quote_plus(video_url)+"&name="+urllib.quote_plus(title)
         isFolder=False
 
         xbmcplugin.addDirectoryItem(handle=addon_handle,url=u,listitem=liz,isFolder=isFolder)
@@ -568,10 +583,9 @@ def create_big_inning_listitem(game_day):
         else:
             xbmc.log('Fetching Big Inning schedule')
             settings.setSetting(id='big_inning_date', value=today)
-            url = 'https://www.mlb.com/live-stream-games/help-center/subscription-access-big-inning'
+            url = 'https://api.fubo.tv/gg/series/123881219/live-programs?limit=14&languages=en&countrySlugs=USA'
 
             headers = {
-                'authority': 'www.mlb.com',
                 'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
                 'accept-language': 'en-US,en;q=0.9',
                 'cache-control': 'no-cache',
@@ -588,27 +602,21 @@ def create_big_inning_listitem(game_day):
             r = requests.get(url,headers=headers, verify=VERIFY)
             #xbmc.log(r.text)
 
-            # parse the schedule table
-            table = re.findall('<td>([^<]*)<\/td>', r.text)
-            xbmc.log('Number of fields in Big Inning schedule table: ' + str(len(table)))
-
-            counter = 0
-            table_iter = iter(table)
-            columns_in_table = 3
+            # parse the response
+            json_source = r.json()
+            
             big_inning_schedule = {}
-            for field in table_iter:
-                date_display = table[counter]
-                xbmc.log('Checking date ' + date_display + ' from Big Inning schedule')
-                big_inning_date = parse(date_display).strftime('%Y-%m-%d')
-                xbmc.log('Formatted date ' + big_inning_date)
-                # ignore dates in the past
-                if big_inning_date >= today:
-                    big_inning_start = str(UTCToLocal(easternToUTC(parse(big_inning_date + ' ' + table[counter+1]))))
-                    big_inning_end = str(UTCToLocal(easternToUTC(parse(big_inning_date + ' ' + table[counter+2]))))
-                    big_inning_schedule[big_inning_date] = {'start': big_inning_start, 'end': big_inning_end}
-                counter = counter + columns_in_table
-                for i in range(columns_in_table - 1):
-                    next(table_iter, None)
+            if 'data' in json_source:
+                for entry in json_source['data']:
+                    if 'airings' in entry and len(entry['airings']) > 0 and entry['airings'][0] and 'accessRights' in entry['airings'][0] and 'live' in entry['airings'][0]['accessRights']:
+                        airing = entry['airings'][0]['accessRights']['live']
+                        big_inning_date = get_eastern_game_date(parse(airing['startTime']))
+                        xbmc.log('Formatted date ' + big_inning_date)
+                        # ignore dates in the past
+                        if big_inning_date >= today:
+                            big_inning_start = str(UTCToLocal(parse(airing['startTime'])))
+                            big_inning_end = str(UTCToLocal(parse(airing['endTime'])))
+                            big_inning_schedule[big_inning_date] = {'start': big_inning_start, 'end': big_inning_end}
             # save the scraped schedule
             settings.setSetting(id='big_inning_schedule', value=json.dumps(big_inning_schedule))
 
@@ -755,7 +763,7 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
 
     # if coming from the game changer, just return a flag to indicate whether we need to start an overlay
     if overlay_check == 'True':
-        if HIDE_SCORES_TICKER == 'true' and stream_type == 'video' and selected_call_letters.startswith('BS'):
+        if HIDE_SCORES_TICKER == 'true' and stream_type == 'video' and selected_call_letters.startswith(SCORES_TICKER_NETWORK):
             return True
         else:
             return False
@@ -838,8 +846,12 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
                         pass
                     title += ' (' + suspended_label + ')'
 
+                # display non-entitlement status for a stream, if applicable
+                if blackout == 'True':
+                    title = blackoutString(title)
+                    title += ' (not entitled)'
                 # display blackout status for video, if available
-                if item['type'] == 'TV' and blackout != 'False':
+                elif item['type'] == 'TV' and blackout != 'False':
                     title = blackoutString(title)
                     title += ' (blackout until ~'
                     if blackout == 'True':
@@ -934,7 +946,7 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
                     # create an item for the video stream
                     listitem = stream_to_listitem(stream_url, headers, description, name, icon, fanart)
                     # pass along the highlights and the video stream item to play as a playlist and stop processing here
-                    highlight_select_stream(json_source['highlights']['highlights']['items'], catchup=listitem)
+                    highlight_select_stream(json_source['dates'][0]['games'][0]['content']['highlights']['highlights']['items'], catchup=listitem)
                     sys.exit()
                 # beginning or inning
                 elif p == 1 or p > 2:
@@ -980,7 +992,12 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
                 # cancel will exit
                 elif p == -1:
                     sys.exit()
-
+        
+        # join live and hide the skip dialog if not using Kodi's resume, we didn't show the catch up / start point dialog, the game is live and is already spoiled
+        elif sys.argv[3] != 'resume:true' and is_live is True and spoiler == 'True':
+        	broadcast_start_offset = '-1'
+        	skip_possible = False
+        
         # show automatic skip dialog, if possible, enabled, and we're not looking to autoplay
         if skip_possible is True and ASK_TO_SKIP == 'true' and autoplay is False:
             # automatic skip dialog with options to skip nothing, breaks, breaks + idle time, breaks + idle time + non-action pitches
@@ -1009,25 +1026,25 @@ def stream_select(game_pk, spoiler='True', suspended='False', start_inning='Fals
             # start the monitor if a skip type or start inning has been requested and we have a broadcast start timestamp
             # or if an overlay is required (overlay enabled for a Bally video stream)
             # or if we want to disable captions
-            if gamechanger == 'False' and stream_type == 'video' and (((skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None) or (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith('BS')) or DISABLE_CLOSED_CAPTIONS == 'true'):
+            if gamechanger == 'False' and stream_type == 'video' and (((skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None) or (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith(SCORES_TICKER_NETWORK)) or DISABLE_CLOSED_CAPTIONS == 'true'):
                 from .mlbmonitor import MLBMonitor
                 mlbmonitor = MLBMonitor()
 
                 # wait for stream start to be detected before proceeding
                 if mlbmonitor.wait_for_stream(game_pk) is True:
 
-                    if (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith('BS')) or DISABLE_CLOSED_CAPTIONS == 'true':
+                    if (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith(SCORES_TICKER_NETWORK)) or DISABLE_CLOSED_CAPTIONS == 'true':
                         # wait an extra second
                         xbmc.sleep(1000)
 
-                        if HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith('BS'):
+                        if HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith(SCORES_TICKER_NETWORK):
                             mlbmonitor.start_overlay(game_pk)
 
                         if DISABLE_CLOSED_CAPTIONS == 'true':
                             mlbmonitor.stop_captions(game_pk)
 
                     # call the game monitor for skips and/or to stop the overlay
-                    if ((skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None) or (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith('BS')):
+                    if ((skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None) or (HIDE_SCORES_TICKER == 'true' and selected_call_letters.startswith(SCORES_TICKER_NETWORK)):
                         mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, stream_url, is_live, start_inning, start_inning_half)
 
         # otherwise exit
@@ -1054,8 +1071,6 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
     # define a dialog that we can use as needed
     dialog = xbmcgui.Dialog()
 
-    from .account import Account
-    account = Account()
     video_url = None
     # check if our request video is a URL
     if featured_video.startswith('http'):
@@ -1092,40 +1107,14 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
 
     xbmc.log('video url : ' + video_url)
     video_stream_url = None
+    from .account import Account
+    account = Account()
     # if it's not a Big Inning stream and it is HLS (M3U8) or MP4, we can simply stream the URL we already have
     if (not name.startswith('LIVE') or (name.startswith('LIVE') and 'Big Inning' not in name)) and (video_url.endswith('.m3u8') or video_url.endswith('.mp4')):
         video_stream_url = video_url
     # otherwise we need to authenticate and get the stream URL
     else:
-        xbmc.log('fetching video stream from url')
-        # need a login token for Big Inning + MiLB games
-        login_token = account.login_token()
-        if login_token is None:
-            xbmc.log('failed to get necessary login token')
-            sys.exit()
-
-        headers = {
-            'User-Agent': UA_PC,
-            'Authorization': 'Bearer ' + login_token,
-            'Accept': '*/*',
-            'Origin': 'https://www.mlb.com',
-            'Referer': 'https://www.mlb.com'
-        }
-        r = requests.get(video_url, headers=headers, verify=VERIFY)
-
-        text_source = r.text
-        #xbmc.log(text_source)
-
-        # sometimes the returned content is already a stream playlist
-        if text_source.startswith('#EXTM3U'):
-            xbmc.log('video url is already a stream playlist')
-            video_stream_url = video_url
-        # otherwise it is JSON containing the stream URL
-        else:
-            json_source = r.json()
-            if 'data' in json_source and len(json_source['data']) > 0 and 'value' in json_source['data'][0]:
-                video_stream_url = json_source['data'][0]['value']
-                xbmc.log('found video stream url : ' + video_stream_url)
+        video_stream_url = account.get_event_stream(video_url)
 
     if video_stream_url is not None:
         # add start / skip menus for MiLB games
@@ -1188,9 +1177,28 @@ def featured_stream_select(featured_video, name, description, start_inning=None,
         if game_pk is not None and (skip_type > 0 or start_inning > 0) and broadcast_start_timestamp is not None:
             from .mlbmonitor import MLBMonitor
             mlbmonitor = MLBMonitor()
-            mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, video_stream_url, is_live, start_inning, start_inning_half)
+            mlbmonitor.game_monitor(skip_type, game_pk, broadcast_start_timestamp, video_stream_url, is_live, start_inning, start_inning_half, True)
     else:
         xbmc.log('unable to find stream for featured video')
+
+
+# select a stream for a linear channel
+def linear_channel_stream_select(featured_video, name, description):
+    xbmc.log('linear channel select')
+
+    start = '-1' # offset to pass to inputstream adaptive
+
+    from .account import Account
+    account = Account()
+    video_stream_url = account.get_linear_stream(featured_video)
+    xbmc.log('video url : ' + video_stream_url)
+    headers = {
+        'accept': 'application/json, text/plain, */*',
+        'accept-encoding': 'identity',
+        'accept-language': 'en-US,en;q=0.5',
+        'connection': 'keep-alive'
+    }
+    play_stream(video_stream_url, headers, description, name)
 
 
 def list_highlights(game_pk, icon, fanart):
@@ -1418,84 +1426,56 @@ def get_airings_data(content_id=None, game_pk=None):
     return json_source
 
 
-# check blackout status for a game
-def get_blackout_status(game, regional_fox_games_exist):
-    blackout_type = 'False'
-    blackout_time = None
-    usa_blackout = re.match('^[0-9]{5}$', ZIP_CODE) and COUNTRY == 'USA'
+# get nonentitlement data for a date
+def get_nonentitlement_data(game_date):
+    nonentitlement_data = {}
+    
+    from .account import Account
+    account = Account()
+    login_token = account.login_token()
+    okta_id = account.okta_id()
+    
+    url = 'https://mastapi.mobile.mlbinfra.com/api/epg/v3/search?exp=MLB&date=' + game_date
+    headers = {
+        'accept': '*/*',
+        'accept-language': 'en-US,en;q=0.9',
+        'cache-control': 'no-cache',
+        'content-type': 'application/json',
+        'origin': 'https://www.mlb.com', 
+        'pragma': 'no-cache',
+        'priority': 'u=1, i', 
+        'referer': 'https://www.mlb.com/', 
+        'sec-ch-ua': '"Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133"', 
+        'sec-ch-ua-mobile': '?0', 
+        'sec-ch-ua-platform': '"macOS"', 
+        'sec-fetch-dest': 'empty', 
+        'sec-fetch-mode': 'cors', 
+        'sec-fetch-site': 'same-site', 
+        'user-agent': UA_PC
+    }
+    if login_token is not None and okta_id is not None:
+        headers['authorization'] = 'Bearer ' + login_token
+        headers['x-okta-id'] = okta_id
+    r = requests.get(url,headers=headers, verify=VERIFY)
+    json_source = r.json()
 
-    # Check if "national" broadcast
-    if 'content' in game and 'media' in game['content'] and 'epg' in game['content']['media'] and len(game['content']['media']['epg']) > 0 and 'items' in game['content']['media']['epg'][0] and len(game['content']['media']['epg'][0]['items']) > 0 and 'mediaFeedType' in game['content']['media']['epg'][0]['items'][0] and ((game['content']['media']['epg'][0]['items'][0]['mediaFeedType'] == 'NATIONAL') or check_pay_tv(game['content']['media']['epg'][0]['items'])):
-        # Make sure it's not a regional FOX broadcast
-        if (game['content']['media']['epg'][0]['items'][0]['callLetters'] != 'FOX') or (game['content']['media']['epg'][0]['items'][0]['callLetters'] == 'FOX' and regional_fox_games_exist == False):
-            # International blackouts according to https://www.mlb.com/live-stream-games/help-center/blackouts-available-games
-            # Apple TV+ games are blacked out everywhere
-            # ESPN Sunday Night games are blacked out in a list of countries
-            if game['content']['media']['epg'][0]['items'][0]['callLetters'] == 'Apple TV+':
-                blackout_type = 'Full International'
-            elif game['content']['media']['epg'][0]['items'][0]['callLetters'] == 'ESPN' and parse(game['gameDate']).weekday() == 6 and COUNTRY in ESPN_SUNDAY_NIGHT_BLACKOUT_COUNTRIES:
-                blackout_type = 'Partial International'
-            # USA national blackouts
-            elif usa_blackout:
-                blackout_type = 'National'
-
-    # Check local blackouts
-    if game['teams']['away']['team']['abbreviation'] in BLACKOUT_TEAMS or game['teams']['home']['team']['abbreviation'] in BLACKOUT_TEAMS:
-        if blackout_type == 'False' and game['seriesDescription'] != 'Spring Training':
-            blackout_type = 'Local'
-
-    # also calculate a blackout time for non-suspended, non-TBD games
-    if blackout_type != 'False' and 'resumeGameDate' not in game and 'resumedFromDate' not in game and game['status']['startTimeTBD'] is False:
-        blackout_wait_minutes = 150
-        if 'scheduled_innings' not in game:
-            game['scheduled_innings'] = get_scheduled_innings(game)
-        innings = max(game['scheduled_innings'], get_current_inning(game))
-        # avg 9 inning game is 2:40 in 2023, or 17.78 minutes per inning
-        gameDurationMinutes = 17.78 * innings
-        # default to assuming the scheduled game time is the first pitch time
-        firstPitch = parse(game['gameDate'])
-        if 'gameInfo' in game:
-            # check if firstPitch has been updated with a valid time (later than the scheduled game time)
-            if 'firstPitch' in game['gameInfo'] and game['gameInfo']['firstPitch'] >= game['gameDate']:
-                firstPitch = parse(game['gameInfo']['firstPitch'])
-            # for completed games, get the duration too
-            if 'gameDurationMinutes' in game['gameInfo']:
-                gameDurationMinutes = game['gameInfo']['gameDurationMinutes']
-                # add any delays
-                if 'delayDurationMinutes' in game['gameInfo']:
-                    gameDurationMinutes += game['gameInfo']['delayDurationMinutes']
-        gameDurationMinutes += blackout_wait_minutes
-        blackout_time = firstPitch + timedelta(minutes=gameDurationMinutes)
-
-    return blackout_type, blackout_time
-
-
-# check if regional fox games exist for a date
-def check_regional_fox_games(games):
-    fox_start_time = None
-    regional_fox_games_exist = False
-    try:
-        for game in games:
-            for broadcast in game['broadcasts']:
-                if broadcast['callSign'] == 'FOX':
-                    if fox_start_time is not None and game['gameDate'] == fox_start_time:
-                        regional_fox_games_exist = True
-                    else:
-                        fox_start_time = game['gameDate']
-            break
-    except:
-        pass
-
-    return regional_fox_games_exist
-
-
-# check if any broadcast requires pay TV credentials
-def check_pay_tv(items):
-    for item in items:
-        if ('abcAuthRequired' in item and item['abcAuthRequired'] is True) or ('espnAuthRequired' in item and item['espnAuthRequired'] is True) or ('espn2AuthRequired' in item and item['espn2AuthRequired'] is True) or ('foxAuthRequired' in item and item['foxAuthRequired'] is True) or ('fs1AuthRequired' in item and item['fs1AuthRequired'] is True) or ('mlbnAuthRequired' in item and item['mlbnAuthRequired'] is True) or ('tbsAuthRequired' in item and item['tbsAuthRequired'] is True):
-            return True
-
-    return False
+    games = []
+    if 'results' in json_source and len(json_source['results']) > 0:
+        for game in json_source['results']:
+            if game['entitledVideo'] == False:
+                nonentitlement_data[game['gamePk']] = ''
+            elif game['blackedOutVideo'] == True:
+                blackout_wait_minutes = 150
+                innings = max(game['gameData']['scheduledInnings'], game['gameData']['currentInning'])
+                # avg 9 inning game was 2:36 in 2024, or 17.33 minutes per inning
+                gameDurationMinutes = 17.33 * innings
+                # default to assuming the scheduled game time is the first pitch time
+                firstPitch = parse(game['gameData']['gameDate'])
+                gameDurationMinutes += blackout_wait_minutes
+                blackout_time = firstPitch + timedelta(minutes=gameDurationMinutes)
+                nonentitlement_data[game['gamePk']] = blackout_time
+                            
+    return nonentitlement_data
 
 
 def get_scheduled_innings(game):
@@ -1552,15 +1532,15 @@ def live_fav_game():
 
                 if 'dates' in json_source and len(json_source['dates']) > 0 and 'games' in json_source['dates'][0]:
                     games = json_source['dates'][0]['games']
-                    regional_fox_games_exist = check_regional_fox_games(games)
+                    nonentitlement_data = get_nonentitlement_data()
                     for game in games:
                         try:
                             # only check games that include our fav team
                             if fav_team_id in [str(game['teams']['home']['team']['id']), str(game['teams']['away']['team']['id'])]:
                                 # only check games that aren't final
                                 if game['status']['abstractGameState'] != 'Final':
-                                    # only check games that aren't blacked out
-                                    if get_blackout_status(game, regional_fox_games_exist)[0] == 'False':
+                                    # only check games that are entitled and not blacked out
+                                    if str(game['gamePk']) not in nonentitlement_data:
                                         if 'content' in game and 'media' in game['content'] and 'epg' in game['content']['media'] and len(game['content']['media']['epg']) > 0 and 'items' in game['content']['media']['epg'][0]:
                                             for epg in game['content']['media']['epg'][0]['items']:
                                                 # if media is off, assume it is still upcoming

--- a/plugin.video.mlbtv/resources/lib/mlbmonitor.py
+++ b/plugin.video.mlbtv/resources/lib/mlbmonitor.py
@@ -23,13 +23,19 @@ class MLBMonitor(xbmc.Monitor):
     BREAK_TYPES = ['Game Advisory', 'Pitching Substitution', 'Offensive Substitution', 'Defensive Sub', 'Defensive Switch', 'Runner Placed On Base', 'Injury']
     #These are the action events to keep, in addition to the last event of each at-bat, if we're skipping non-decision pitches
     ACTION_TYPES = ['Wild Pitch', 'Passed Ball', 'Stolen Base', 'Caught Stealing', 'Pickoff', 'Error', 'Out', 'Balk', 'Defensive Indiff', 'Other Advance']
+    #These are some idle events to skip
+    IDLE_TYPES = ['Mound Visit', 'Batter Timeout', 'Pitcher Step Off', 'challenge']
     #Pad events at both start (-) and end (+)
     EVENT_START_PADDING = -6
-    EVENT_END_PADDING = 5
-    #Also use pitch start padding for idle time / specific player skipping
-    PITCH_START_PADDING = -1
+    PITCH_END_PADDING = 0
+    ACTION_END_PADDING = 5
     #Only skip if a break is at least this long
     MINIMUM_BREAK_DURATION = 5
+    #Additional padding for MLB games (2025)
+    MLB_PADDING = 2
+    
+    #Additional Game Changer padding for MLB games, in increments of 10
+    MLB_GAMECHANGER_PADDING = 10
 
     #Change monitor
     MAX_LEVERAGE = 11
@@ -928,7 +934,7 @@ class MLBMonitor(xbmc.Monitor):
         player.showSubtitles(False)
         xbmc.log(monitor_name + " captions disabled")
 
-    def game_monitor(self, skip_type, game_pk, broadcast_start_timestamp, stream_url, is_live, start_inning, start_inning_half):
+    def game_monitor(self, skip_type, game_pk, broadcast_start_timestamp, stream_url, is_live, start_inning, start_inning_half, milb=False):
         xbmc.log("Game monitor for " + game_pk + " starting")
 
         self.mlb_monitor_started = str(datetime.now())
@@ -958,7 +964,7 @@ class MLBMonitor(xbmc.Monitor):
 
             # fetch skip markers
             self.skip_to_players = None
-            skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, 0, start_inning, start_inning_half)
+            skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, 0, start_inning, start_inning_half, milb)
             xbmc.log(monitor_name + ' skip markers : ' + str(skip_markers))
 
             while not self.monitor.abortRequested():
@@ -991,6 +997,7 @@ class MLBMonitor(xbmc.Monitor):
                         while len(skip_markers) > 0 and current_time > current_break_end:
                             xbmc.log(monitor_name + " removed skip marker at " + str(current_break_end) + ", before current time " + str(current_time))
                             skip_markers.pop(0)
+                            current_break_end = skip_markers[0][1] + self.skip_adjust_start
                         # seek to end of break if we fall within skip marker range, then remove marker so user can seek backward freely
                         if len(skip_markers) > 0 and current_time >= current_break_start and current_time < current_break_end:
                             xbmc.log(monitor_name + " processed skip marker at " + str(current_break_end))
@@ -1003,7 +1010,7 @@ class MLBMonitor(xbmc.Monitor):
                             # refresh current time, and look ahead slightly
                             current_time = player.getTime() + 10
                             xbmc.log(monitor_name + ' refreshing skip markers from ' + str(current_time))
-                            skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, current_time)
+                            skip_markers, self.skip_to_players = self.get_skip_markers(skip_type, game_pk, broadcast_start_timestamp, monitor_name, self.skip_to_players, stream_url, current_time, milb)
                             xbmc.log(monitor_name + ' refreshed skip markers : ' + str(skip_markers))
 
         # continue monitoring if overlay is still active
@@ -1059,7 +1066,7 @@ class MLBMonitor(xbmc.Monitor):
 
 
     # calculate skip markers from gameday events
-    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, monitor_name, skip_to_players, stream_url, current_time=0, start_inning=0, start_inning_half='top'):
+    def get_skip_markers(self, skip_type, game_pk, broadcast_start_timestamp, monitor_name, skip_to_players, stream_url, current_time=0, start_inning=0, start_inning_half='top', milb=False):
         xbmc.log(monitor_name + ' getting skip markers for skip type ' + str(skip_type))
         if current_time > 0:
             xbmc.log(monitor_name + ' searching beyond ' + str(current_time))
@@ -1073,12 +1080,15 @@ class MLBMonitor(xbmc.Monitor):
 
         # calculate total skip time (for fun)
         total_skip_time = 0
-
-        # for skip types 3 (idle time) and 4 (specific players), use pitch start padding
-        if skip_type == 3 or skip_type == 4:
-            event_start_padding = self.PITCH_START_PADDING
-        else:
-            event_start_padding = self.EVENT_START_PADDING
+        
+        event_start_padding = self.EVENT_START_PADDING
+        pitch_end_padding = self.PITCH_END_PADDING
+        action_end_padding = self.ACTION_END_PADDING
+        #extra padding for MLB games (2025)
+        if milb is False:
+        	event_start_padding += self.MLB_PADDING
+        	pitch_end_padding += self.MLB_PADDING
+        	action_end_padding += self.MLB_PADDING
 
         # make sure we have play data
         if 'liveData' in json_source and 'plays' in json_source['liveData'] and 'allPlays' in json_source['liveData']['plays']:
@@ -1199,18 +1209,26 @@ class MLBMonitor(xbmc.Monitor):
 
                     # loop through events within each play
                     for index, playEvent in enumerate(play['playEvents']):
+                        # use action end padding by default, but we'll adjust this to pitch end padding as necessary for break types 3 and 4
+                        this_event_end_padding = action_end_padding
                         # always exclude break types
                         if 'event' in playEvent['details'] and playEvent['details']['event'] in self.BREAK_TYPES:
                             # if we're in the process of skipping all breaks, treat the first break type we find as another inning break
                             if skip_type == 2 and previous_inning > 0:
-                                break_start = (parse(playEvent['startTime']) - broadcast_start_timestamp).total_seconds() + self.EVENT_END_PADDING
+                                break_start = (parse(playEvent['startTime']) - broadcast_start_timestamp).total_seconds() + action_end_padding
                                 previous_inning = 0
                             continue
                         else:
                             action_index = None
-                            # skip type 2 (all breaks), 3 (idle time), and 4 (specific batters/pitchers) will look at all plays with an endTime
-                            if skip_type <= 4 and 'endTime' in playEvent:
+                            # skip type 2 (all breaks) will look at all plays with an endTime
+                            if skip_type == 2 and 'endTime' in playEvent:
                                 action_index = index
+                            # skip type 3 (idle time) and 4 (specific batters/pitchers) will look at all non-idle plays with an endTime
+                            elif skip_type <= 4 and 'endTime' in playEvent and ('details' not in playEvent or 'description' not in playEvent['details'] or not any(substring in playEvent['details']['description'] for substring in self.IDLE_TYPES)):
+                                action_index = index
+                                # use pitch end padding for non-action plays
+                                if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in self.ACTION_TYPES)):
+                                    this_event_end_padding = pitch_end_padding
                             elif skip_type == 5:
                                 # skip type 5 excludes non-action pitches (events that aren't last in the at-bat and don't fall under action types)
                                 if index < (len(play['playEvents'])-1) and ('details' not in playEvent or 'event' not in playEvent['details'] or not any(substring in playEvent['details']['event'] for substring in self.ACTION_TYPES)):
@@ -1249,7 +1267,7 @@ class MLBMonitor(xbmc.Monitor):
                                     # exit loop after found inning, if not skipping breaks
                                     if skip_type == 0:
                                         break
-                                break_start = (parse(play['playEvents'][action_index]['endTime']) - broadcast_start_timestamp).total_seconds() + self.EVENT_END_PADDING
+                                break_start = (parse(play['playEvents'][action_index]['endTime']) - broadcast_start_timestamp).total_seconds() + this_event_end_padding
                                 # add extra padding for overturned review plays
                                 if 'reviewDetails' in play:
                                     isOverturned = play['reviewDetails']['isOverturned']
@@ -1282,7 +1300,7 @@ class MLBMonitor(xbmc.Monitor):
         stream_refresh_sec = 1
         # check games every `refresh_sec` but return data from `delay_sec` ago to account for stream delay/buffering
         refresh_sec = game_refresh_sec
-        delay_sec = GAME_CHANGER_DELAY
+        delay_sec = GAME_CHANGER_DELAY + self.MLB_GAMECHANGER_PADDING
         games_buffer = deque(maxlen=int((delay_sec / refresh_sec) + 1))
         players_buffer = deque(maxlen=int((delay_sec / refresh_sec) + 1))
         innings_buffer = deque(maxlen=int((delay_sec / refresh_sec) + 1))

--- a/plugin.video.mlbtv/resources/settings.xml
+++ b/plugin.video.mlbtv/resources/settings.xml
@@ -4,9 +4,9 @@
   <category label="30100">
     <setting id="username" type="text" label="30140" default=""/>
     <setting id="password" type="text" label="30150" option="hidden" default=""/>
-    <setting id="single_team" type="bool" label="30151" default="false"/>
-    <setting id="zip_code" type="number" label="30415" default=""/>
-    <setting id="country" type="labelenum" label="30428" default="USA" values="USA|Angola|Anguilla|Antigua and Barbuda|Argentina|Aruba|Australia|Bahamas|Barbados|Belize|Belize|Benin|Bermuda|Bolivia|Bonaire|Botswana|Brazil|British Virgin Islands|Burkina Faso|Burundi|Canada|Cameroon|Cape Verde|Cayman Islands|Central African Republic|Chad|Chile|Colombia|Comoros|Cook Islands|Costa Rica|Cote d'Ivoire|Curacao|Democratic Republic of the Congo|Djibouti|Dominica|Dominican Republic|Ecuador|El Salvador|England|Equatorial Guinea|Eritrea|Eswatini|Ethiopia|Falkland Islands|Falkland Islands|Fiji|French Guiana|French Guiana|French Polynesia|Gabon|Ghana|Grenada|Guadeloupe|Guatemala|Guinea|Guinea Bissau|Guyana|Guyana|Haiti|Honduras|Ireland|Jamaica|Kenya|Kiribati|Lesotho|Liberia|Madagascar|Malawi|Mali|Marshall Islands|Martinique|Mayotte|Mexico|Micronesia|Montserrat|Mozambique|Namibia|Netherlands|New Zealand|Nicaragua|Niger|Nigeria|Niue|Northern Ireland|Palau Islands|Panama|Paraguay|Peru|Republic of Ireland|Reunion|Rwanda|Saba|Saint Maarten|Samoa|Sao Tome &amp; Principe|Scotland|Senegal|Seychelles|Sierra Leone|Solomon Islands|Somalia|South Africa|St. Barthelemy|St. Eustatius|St. Kitts and Nevis|St. Lucia|St. Martin|St. Vincent and the Grenadines|Sudan|Surinam|Suriname|Tahiti|Tanzania &amp; Zanzibar|The Gambia|The Republic of Congo|Togo|Tokelau|Tonga|Trinidad and Tobago|Turks and Caicos Islands|Tuvalu|Uganda|Uruguay|Venezuela|Wales|Zambia|Zimbabwe|other" />
+    <setting id="single_team" type="bool" label="30151" default="false" visible="false"/>
+    <setting id="zip_code" type="number" label="30415" default="" visible="false"/>
+    <setting id="country" type="labelenum" label="30428" default="USA" values="USA|Angola|Anguilla|Antigua and Barbuda|Argentina|Aruba|Australia|Bahamas|Barbados|Belize|Belize|Benin|Bermuda|Bolivia|Bonaire|Botswana|Brazil|British Virgin Islands|Burkina Faso|Burundi|Canada|Cameroon|Cape Verde|Cayman Islands|Central African Republic|Chad|Chile|Colombia|Comoros|Cook Islands|Costa Rica|Cote d'Ivoire|Curacao|Democratic Republic of the Congo|Djibouti|Dominica|Dominican Republic|Ecuador|El Salvador|England|Equatorial Guinea|Eritrea|Eswatini|Ethiopia|Falkland Islands|Falkland Islands|Fiji|French Guiana|French Guiana|French Polynesia|Gabon|Ghana|Grenada|Guadeloupe|Guatemala|Guinea|Guinea Bissau|Guyana|Guyana|Haiti|Honduras|Ireland|Jamaica|Kenya|Kiribati|Lesotho|Liberia|Madagascar|Malawi|Mali|Marshall Islands|Martinique|Mayotte|Mexico|Micronesia|Montserrat|Mozambique|Namibia|Netherlands|New Zealand|Nicaragua|Niger|Nigeria|Niue|Northern Ireland|Palau Islands|Panama|Paraguay|Peru|Republic of Ireland|Reunion|Rwanda|Saba|Saint Maarten|Samoa|Sao Tome &amp; Principe|Scotland|Senegal|Seychelles|Sierra Leone|Solomon Islands|Somalia|South Africa|St. Barthelemy|St. Eustatius|St. Kitts and Nevis|St. Lucia|St. Martin|St. Vincent and the Grenadines|Sudan|Surinam|Suriname|Tahiti|Tanzania &amp; Zanzibar|The Gambia|The Republic of Congo|Togo|Tokelau|Tonga|Trinidad and Tobago|Turks and Caicos Islands|Tuvalu|Uganda|Uruguay|Venezuela|Wales|Zambia|Zimbabwe|other" visible="false"/>
     <setting id="old_country" type="text" label="" default="" visible="false"/>
     <setting id="old_zip_code" type="number" label="" default="" visible="false"/>
     <setting id="blackout_teams" type="text" label="" default="[]" visible="false"/>
@@ -15,6 +15,7 @@
     <setting id='entitlements' type='text' visible="false" default=''/>
     <setting id='session_key' type='text' visible="false" default=''/>
     <setting id='device_id' type='text' visible="false" default=''/>
+    <setting id='okta_id' type='text' visible="false" default=''/>
     <setting id='login_token' type='text' visible="false" default=''/>
     <setting id='login_token_expiry' type='text' visible="false" default=''/>
   </category>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2025.4.8+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - automatic blackout/entitlement detection
            - support for SNLA and SNY subscriptions
            - skip timing, game changer, and hide scores ticker updates for 2025
            - jump to live when skipping start dialog and allowing spoilers
            - restored Big Inning schedule
            - fixed Catch Up option
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
