### PR TITLE
[plugin.video.sarpur] v5.2.0

### DIFF
--- a/plugin.video.sarpur/addon.xml
+++ b/plugin.video.sarpur/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.sarpur"
        name="Sarpur"
-       version="5.1"
+       version="5.2"
        provider-name="Dagur Páll Ammendrup">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -25,12 +25,11 @@
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>
         </assets>
-        <news>Version 5.1 (2024-03-14)
-- Various fixes because of API changes on ruv.is
-- Formatted code with black
+        <news>Version 5.2(2025-04-26)
+- Fix search by updating api key (indridieinarsson)
 
-Version 5.0 (2021-02-23)
-- Upgraded to Python 3 for Kodi 19 compatibility
-- Fixed podcast scraping</news>
+Version 5.1 (2024-03-14)
+- Various fixes because of API changes on ruv.is
+- Formatted code with black</news>
     </extension>
 </addon>

--- a/plugin.video.sarpur/sarpur/api.py
+++ b/plugin.video.sarpur/sarpur/api.py
@@ -26,7 +26,7 @@ def search(query, type="tv"):
     gql = {
         "operationName": "getSearch",
         "variables": f'{{"type":"{type}","text":"{query}"}}',
-        "extensions": '{"persistedQuery":{"version":1,"sha256Hash":"99be6d8b3c99b265086df4b6d87e72d005bdbf1cf0d50173610632bc0ecf7ff5"}}',
+        "extensions": '{"persistedQuery":{"version":1,"sha256Hash":"823f9e99e09dadeca8896ea9f29374429e6fc3c4be2d2c2a93e7ce6dc65eec41"}}',
     }
     req = requests.get(GRAPHQL_URL, headers={"Content-Type": "text/plain"}, params=gql)
     return req.json()["data"]["Search"]


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
Update api key to fix in-app search
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
