### PR TITLE
[plugin.video.retrospect] v5.7.26

### DIFF
--- a/plugin.video.retrospect/addon.xml
+++ b/plugin.video.retrospect/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon  id="plugin.video.retrospect"
-        version="5.7.25"
+        version="5.7.26"
         name="Retrospect"
         provider-name="Bas Rieter">
 
@@ -133,9 +133,9 @@
         <platform>all</platform>
         <license>GPL-3.0-or-later</license>
         <language>en nl de sv no lt lv fi</language>
-        <news>[B]Retrospect v5.7.25 - Changelog - 2025-04-09[/B]
+        <news>[B]Retrospect v5.7.26 - Changelog - 2025-04-26[/B]
 
-Just some minor channel fixes for NPO and Videoland.
+A small fix for the Vier.be channel.
 
 [B]Framework related[/B]
 _None_
@@ -144,8 +144,7 @@ _None_
 _None_
 
 [B]Channel related[/B]
-* Fixed: NPO &quot;news&quot; and &quot;populair&quot; categories.
-* Fixed: VideoLand video playback (Fixes #1894).
+* Fixed: Vier.be not listing shows (Fixes #1897).
 
         </news>
         <assets>

--- a/plugin.video.retrospect/channels/channel.be/vier/chn_vier.py
+++ b/plugin.video.retrospect/channels/channel.be/vier/chn_vier.py
@@ -107,7 +107,7 @@ class Channel(chn_class.Channel):
                               parser=[], creator=self.create_typed_nextjs_item)
 
         self._add_data_parser("https://www.goplay.be/", json=True, name="Main show parser",
-                              preprocessor=NextJsParser(r"{\"playlists\":(.+)}\]}\]\][\r\n]"),
+                              preprocessor=NextJsParser(r"{\"playlists\":(.+}\]).+?}\]}\]\][\r\n]"),
                               parser=[], creator=self.create_season_item,
                               postprocessor=self.show_single_season)
 


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
A small fix for the Vier.be channel.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
