### PR TITLE
[plugin.video.mlbtv@matrix] 2025.6.19+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.4.14+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.6.19+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,7 +22,7 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - Fix play favorite team on launch (thanks thromer and tonywagner)
+            - updated Big Inning schedule
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/lib/mlb.py
+++ b/plugin.video.mlbtv/resources/lib/mlb.py
@@ -608,8 +608,8 @@ def create_big_inning_listitem(game_day):
             big_inning_schedule = {}
             if 'data' in json_source:
                 for entry in json_source['data']:
-                    if 'airings' in entry and len(entry['airings']) > 0 and entry['airings'][0] and 'accessRights' in entry['airings'][0] and 'live' in entry['airings'][0]['accessRights']:
-                        airing = entry['airings'][0]['accessRights']['live']
+                    if 'airings' in entry and len(entry['airings']) > 0 and entry['airings'][0] and 'accessRightsV2' in entry['airings'][0] and 'live' in entry['airings'][0]['accessRightsV2']:
+                        airing = entry['airings'][0]['accessRightsV2']['live']
                         big_inning_date = get_eastern_game_date(parse(airing['startTime']))
                         xbmc.log('Formatted date ' + big_inning_date)
                         # ignore dates in the past


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2025.6.19+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - updated Big Inning schedule
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
