### PR TITLE
[plugin.video.crackle@matrix] 2025.7.31

### DIFF
--- a/plugin.video.crackle/README.md
+++ b/plugin.video.crackle/README.md
@@ -4,3 +4,5 @@
 [![Contributors](https://img.shields.io/github/contributors/eracknaphobia/plugin.video.crackle.svg)](https://github.com/eracknaphobia/plugin.video.crackle/graphs/contributors)
 
 Watch Crackle thru Kodi
+
+*Only on Android Devices*

--- a/plugin.video.crackle/addon.xml
+++ b/plugin.video.crackle/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.crackle" name="Crackle" version="2024.7.22+matrix.1" provider-name="eracknaphobia">
+<addon id="plugin.video.crackle" name="Crackle" version="2025.7.31" provider-name="eracknaphobia">
   <requires>
       <import addon="xbmc.python" version="3.0.0"/>
       <import addon="script.module.requests"/>
@@ -13,12 +13,7 @@
     <platform>android</platform>
     <summary lang="en_GB">Crackle delivers popular, award-winning TV, movies and originals. With no limit to how much you can watch across all your devices, you can binge all you want, wherever you want.</summary>
     <description lang="en_GB">Crackle is a video streaming distributor of original web shows, Hollywood movies, and TV shows. Founded in the early 2000s as Grouper, and rebranded in 2007, Crackle is owned by Sony Pictures Entertainment.</description>
-      <news>
-        - Refactor for upstream changes
-        - Added pagination
-        - Playback is only possible on Android Devices now because of widevine VMP
-        - Added settings for page size and sort by
-      </news>
+    <lifecyclestate type="broken">The upstream service has ended.</lifecyclestate>
     <language>en</language>
     <license>GPL-2.0-or-later</license>
     <forum></forum>


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Crackle
  - Add-on ID: plugin.video.crackle
  - Version number: 2025.7.31
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.crackle
  
Crackle is a video streaming distributor of original web shows, Hollywood movies, and TV shows. Founded in the early 2000s as Grouper, and rebranded in 2007, Crackle is owned by Sony Pictures Entertainment.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
