### PR TITLE
[plugin.video.arteplussept@matrix] 1.4.3

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog also available in file ./addon.xml xpath /addon/extension/news following Kodi guidelines https://kodi.wiki/view/Add-on_structure#changelog.txt
 
+v1.4.3 (2025-8-4)
+- Fix playing live stream (disabling HLS).
+
 v1.4.2 (2024-1-3)
 - Rename quality parameter.
 - Use https to get HBB TV Stream info.

--- a/plugin.video.arteplussept/addon.py
+++ b/plugin.video.arteplussept/addon.py
@@ -154,13 +154,14 @@ def streams(program_id):
     return plugin.finish(view.build_video_streams(plugin, settings, program_id))
 
 
-@plugin.route('/play_live/<stream_url>', name='play_live')
-def play_live(stream_url):
-    """Play live content."""
-    return plugin.set_resolved_url({'path': stream_url})
-
 # Cannot read video new arte tv program API. Blocked by FFMPEG issue #10149
 # @plugin.route('/play_artetv/<program_id>', name='play_artetv')
+#
+# @plugin.route('/play_live/<stream_url>', name='play_live')
+# def play_live(stream_url):
+#    """Play live content."""
+#    return plugin.set_resolved_url({'path': stream_url})
+#
 # def play_artetv(program_id):
 #     item = api.player_video(settings.language, program_id)
 #     attr = item.get('attributes')

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.2" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.4.3" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -56,6 +56,8 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
         <news>
+v1.4.3 (2025-8-4)
+- Fix playing live stream (disabling HLS).
 v1.4.2 (2024-1-3)
 - Rename quality parameter.
 - Use https to get HBB TV Stream info.

--- a/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
@@ -59,7 +59,7 @@ class ArteVideoItem(ArteItem):
         return {
             'label': label,
             'path': path,
-            'thumbnail': self._get_image_url(),
+            'thumbnail': self._get_image_url('480x270', True),
             'is_playable': is_playable,
             'info_type': 'video',
             'info': {
@@ -70,7 +70,7 @@ class ArteVideoItem(ArteItem):
                 'aired': self._get_air_date()
             },
             'properties': {
-                'fanart_image': self._get_image_url(),
+                'fanart_image': self._get_image_url('1920x1080', False),
                 'TotalTime': str(self._get_duration()),
             },
             'context_menu': [
@@ -109,7 +109,7 @@ class ArteVideoItem(ArteItem):
         """
         return None
 
-    def _get_image_url(self):
+    def _get_image_url(self, wished_res, wished_text):
         """
         Abstract method to be implemented in child classes.
         Return url to image to display for the current item.
@@ -208,7 +208,7 @@ class ArteTvVideoItem(ArteVideoItem):
                     'playcount': '1' if progress >= 0.95 else '0',
                 },
                 'properties': {
-                    'fanart_image': self._get_image_url(),
+                    'fanart_image': self._get_image_url('1920x1080', False),
                     # ResumeTime and TotalTime deprecated.
                     # Use InfoTagVideo.setResumePoint() instead.
                     'ResumeTime': str(self._get_time_offset()),
@@ -238,20 +238,27 @@ class ArteTvVideoItem(ArteVideoItem):
             date = None
         return date
 
-    def _get_image_url(self):
+    def _get_image_url(self, wished_res, wished_text):
         item = self.json_dict
         image_url = None
+        # extracting image from arte tv player endpoint
         if item.get('images') and item.get('images')[0] and item.get('images')[0].get('url'):
-            # Remove query param type=TEXT to avoid title embeded in image
-            image_url = item.get('images')[0].get('url').replace('?type=TEXT', '')
-            # Set same image for fanart and thumbnail to spare network bandwidth
-            # and business logic easier to maintain
-            # if item.get('images')[0].get('alternateResolutions'):
-            #    smallerImage = item.get('images')[0].get('alternateResolutions')[3]
-            #    if smallerImage and smallerImage.get('url'):
-            #        thumbnailUrl = smallerImage.get('url').replace('?type=TEXT', '')
-        if not image_url:
-            image_url = item.get('mainImage').get('url').replace('__SIZE__', '1920x1080')
+            image_url = item.get('images')[0].get('url')
+        # extracting image from content data from arte tv home page or zone endpoint
+        if item.get('mainImage') and item.get('mainImage').get('url'):
+            image_url = item.get('mainImage').get('url')
+
+        # post processing
+        if isinstance(image_url, str):
+            if wished_text is False:
+                # Remove query param type=TEXT to avoid title embeded in image
+                image_url = image_url.replace('?type=TEXT', '')
+            if isinstance(wished_res, str):
+                # 940x530 is the most common size from player endpoint
+                # __SIZE__ is the size from home page or zone endpoint
+                for from_str in ['/940x530', '/__SIZE__']:
+                    image_url = image_url.replace(from_str, f"/{wished_res}")
+
         return image_url
 
     def _get_kind(self):
@@ -300,7 +307,7 @@ class ArteHbbTvVideoItem(ArteVideoItem):
                 # year is not correctly used by kodi :(
                 # the aired year will be used by kodi for production year :(
                 # 'year': int(config.get('productionYear')),
-                'country': [country.get('label') for country in \
+                'country': [country.get('label') for country in
                             item.get('productionCountries', [])],
                 'director': item.get('director'),
             },
@@ -326,7 +333,8 @@ class ArteHbbTvVideoItem(ArteVideoItem):
                 level=xbmc.LOGWARNING)
         return date
 
-    def _get_image_url(self):
+    def _get_image_url(self, wished_res, wished_text):
+        # parameter are ignored in HBB TV, but needed for abstraction | inheritance
         return self.json_dict.get('imageUrl')
 
     def _get_kind(self):

--- a/plugin.video.arteplussept/resources/lib/mapper/live.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/live.py
@@ -5,7 +5,6 @@ for map_playable and match_hbbtv
 
 import html
 # the goal is to break/limit this dependency as much as possible
-from resources.lib.mapper import mapper
 from resources.lib.mapper.arteitem import ArteTvVideoItem
 
 
@@ -27,10 +26,11 @@ class ArteLiveItem(ArteTvVideoItem):
             label += f" - {html.unescape(subtitle)}"
         return label
 
-    def build_item_live(self, quality, audio_slot):
+    def build_item_live(self):
         """Return menu entry to watch live content from Arte TV API"""
-        # program_id = item.get('id')
         item = self.json_dict
+        # Remove language at the end e.g. _fr, _de
+        program_id = item.get('id')[:-3]
         attr = item.get('attributes')
         meta = attr.get('metadata')
 
@@ -48,12 +48,10 @@ class ArteLiveItem(ArteTvVideoItem):
             #    smallerImage = item.get('images')[0].get('alternateResolutions')[3]
             #    if smallerImage and smallerImage.get('url'):
             #        thumbnailUrl = smallerImage.get('url').replace('?type=TEXT', '')
-        stream_url = mapper.map_playable(
-            attr.get('streams'), quality, audio_slot, mapper.match_artetv).get('path')
 
         return {
             'label': self.format_title_and_subtitle(),
-            'path': self.plugin.url_for('play_live', stream_url=stream_url),
+            'path': self.plugin.url_for('play', kind='SHOW', program_id=program_id),
             # playing the stream from program id makes the live starts from the beginning
             # while it starts the video like the live tv, with the above
             #  'path': plugin.url_for('play', kind='SHOW', program_id=programId.replace('_fr', '')),

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -20,7 +20,7 @@ def build_home_page(plugin, settings, cached_categories):
     try:
         addon_menu.append(
             ArteLiveItem(plugin, api.player_video(settings.language, 'LIVE'))
-            .build_item_live(settings.quality, '1'))
+            .build_item_live())
     # pylint: disable=broad-exception-caught
     # Could be improve. possible exceptions are limited to auth. errors
     except Exception as error:


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.4.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:


v1.4.3 (2025-8-4)
- Fix playing live stream (disabling HLS).
v1.4.2 (2024-1-3)
- Rename quality parameter.
- Use https to get HBB TV Stream info.
- Fix bug preventing to open series menu
v1.4.1 (2023-10-10)
- Fix playing videos with siblings.
v1.4.0 (2023-8-14)
- Add support for content over multiple pages.
- Refactor most of the code in OO style
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
