### PR TITLE
[plugin.video.formula1] 2.0.7

### DIFF
--- a/plugin.video.formula1/addon.xml
+++ b/plugin.video.formula1/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.formula1" name="Formula 1" version="2.0.6" provider-name="jaylinski">
+<addon id="plugin.video.formula1" name="Formula 1" version="2.0.7" provider-name="jaylinski">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.29.0"/>
@@ -16,7 +16,10 @@
         <forum>https://forum.kodi.tv/showthread.php?tid=352138</forum>
         <website>https://www.formula1.com</website>
         <source>https://github.com/jaylinski/kodi-addon-formula1</source>
-        <news>2.0.6 (2025-07-20)
+        <news>2.0.7 (2025-10-26)
+Fixed sorting of driver standings
+
+2.0.6 (2025-07-20)
 Updated player API key
 
 2.0.5 (2025-06-17)

--- a/plugin.video.formula1/resources/lib/f1/api.py
+++ b/plugin.video.formula1/resources/lib/f1/api.py
@@ -134,6 +134,7 @@ class Api:
             items = json_obj.get("videos")
         elif "drivers" in json_obj:
             items = json_obj.get("drivers")
+            items.sort(key=lambda driver_obj: int(driver_obj.get("positionNumber", 99)))
             item_type = "drivers"
         elif "constructors" in json_obj:
             items = json_obj.get("constructors")


### PR DESCRIPTION
### Description

* Fixed sorting of driver standings (https://github.com/jaylinski/kodi-addon-formula1/commit/565ef1a936f92c59297061d5ba2c08dcdc20e007)

Details: https://github.com/jaylinski/kodi-addon-formula1/compare/v2.0.6...v2.0.7

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
