### PR TITLE
[plugin.video.cinetree] v2.0.3

### DIFF
--- a/plugin.video.cinetree/addon.py
+++ b/plugin.video.cinetree/addon.py
@@ -1,17 +1,15 @@
 # ------------------------------------------------------------------------------
-#  Copyright (c) 2022 Dimitri Kroon
-#
-#  SPDX-License-Identifier: GPL-2.0-or-later
-#  This file is part of plugin.video.cinetree
+#  Copyright (c) 2022-2025 Dimitri Kroon.
+#  This file is part of plugin.video.cinetree.
+#  SPDX-License-Identifier: GPL-2.0-or-later.
+#  See LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt.
 # ------------------------------------------------------------------------------
 
 import sys
+# Ensure to apply patches before any import of codequick
+from resources.lib import cc_patch
 from resources.lib import main
 from resources.lib.addon_log import logger, shutdown_log
-from resources.lib import cc_patch
-
-
-cc_patch.patch_cc_route()
 
 
 if __name__ == "__main__":

--- a/plugin.video.cinetree/addon.xml
+++ b/plugin.video.cinetree/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.cinetree" name="Cinetree" version="2.0.2" provider-name="Dimitri Kroon">
+<addon id="plugin.video.cinetree" name="Cinetree" version="2.0.3" provider-name="Dimitri Kroon">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="inputstream.adaptive" version="19.0.7"/>
@@ -37,26 +37,9 @@
     </assets>
     <reuselanguageinvoker>true</reuselanguageinvoker>
     <news>
-[B]Version 2.0.2[/B]
-- Fix: Several lists failed to open with 'ParseError' due to some changes at Cinetree.
-- Fix: Add-on failed to open when the user was not logged in to Cinetree.
-
-[B]Version 2.0.1[/B]
-- New logo image.
-- Now possible to directly rent a film with your prepaid credit at Cinetree.
-- Now possible to sort listings on the date the film was added to Cinetree.
-- Sort Genre listings by using the context menu, instead of the side menu.
-- The default sort order of all lists is now the same as the cinetree website.
-- Added a main menu entry for Cinetree Originals.
-- Added a main menu entry for short films.
-- Added a menu entry to your saved watch list in 'My Films'.
-- Added the possibility to add or remove films to your watch list by using the context menu.
-- Properly display films as fully or partially watched.
-- Sync the watched status of films watched on other devices.
-- Better distinguish 'already watched' films from 'continue watching'.
-- Added the possibility to remove films from 'already watched' and 'continue watching' by using the context menu in these lists.
-- Fix: price info missing in the description of some rental films.
-- Several other minor changes and changes under the hood.
+[B]Version 2.0.3[/B]
+- Fixed listing short films
+- Some other small improvements
     </news>
   </extension>
 </addon>

--- a/plugin.video.cinetree/changelog.txt
+++ b/plugin.video.cinetree/changelog.txt
@@ -1,3 +1,7 @@
+v 2.0.3
+- Fixed listing short films
+- Some other small improvements
+
 v 2.0.2
 - Fix: Several lists failed to open with 'ParseError' due to some changes at Cinetree.
 - Fix: Add-on failed to open when the user was not logged in to Cinetree.

--- a/plugin.video.cinetree/resources/lib/cc_patch.py
+++ b/plugin.video.cinetree/resources/lib/cc_patch.py
@@ -3,8 +3,39 @@
 #  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.cinetree.
 #  SPDX-License-Identifier: GPL-2.0-or-later.
-#  See LICENSE.txt
+#  See LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt.
 # ------------------------------------------------------------------------------
+
+import xbmcgui
+
+
+def patch_listitem():
+    """Setting parameter `offscreen` to true when creating `ListItems`
+    can significantly speed up the creation long lists.
+
+    Since codequick doesn't use this parameter, this function monkey
+    patches `xmbcgui.Listitem` with an alternative class that sets
+    `offscreen` to True by default.
+
+    .. note ::
+        To make sure that everything references this patched ListItem apply
+        this patch before codequick is imported, or any other module that
+        uses xbmcgui.ListItem.
+    """
+    class PatchedListItem(xbmcgui.ListItem):
+        def __init__(self,
+                     label: str = '',
+                     label2: str = '',
+                     path: str = '',
+                     offscreen: bool = True):
+            # print("**** Using patched Listitem ****")
+            super().__init__(label, label2, path, offscreen)
+
+    xbmcgui.ListItem = PatchedListItem
+
+
+patch_listitem()
+
 
 from codequick import Route, Listitem
 # noinspection PyProtectedMember
@@ -20,7 +51,7 @@ def patch_cc_route():
     does not lead to the items the callback returns being cached.
 
     This will be fixed if you call ``patch_cc_route()`` in the addon before
-    ``codequick.run()`` is being called.
+    ``codequick.run()`` is called.
 
     """
     original_call = Route.__call__
@@ -33,8 +64,7 @@ def patch_cc_route():
 
 
 def patch_label_prop():
-    """
-    Fixes an annoyance in codequick v1.0.2. by monkey patching
+    """Addresses an annoyance in codequick v1.0.2. by monkey patching
     ``codequick.listing.Listitem.label`` property.
 
     The problem is that setting label on a codequick Listitem will always

--- a/plugin.video.cinetree/resources/lib/main.py
+++ b/plugin.video.cinetree/resources/lib/main.py
@@ -7,6 +7,8 @@
 # ------------------------------------------------------------------------------
 from __future__ import annotations
 
+import xbmcaddon
+
 import xbmc
 import xbmcplugin
 import sys
@@ -28,6 +30,11 @@ from resources.lib import constants
 from resources.lib import utils
 
 
+running_version = utils.addon_info['version']
+
+
+logger.critical('-------------------------------------')
+logger.critical('--- version: %s', running_version)
 logger.critical('-------------------------------------')
 
 TXT_SORT_BY = 30106
@@ -234,11 +241,12 @@ def list_originals(addon):
 @Route.register(content_type='movies')
 def list_shorts(addon, list_films=False):
     if not list_films:
-        # List a submenu of collections of short films
-        collections = ct_api.get_preferred_collections(page='kort')
-        for coll in collections:
-            yield Listitem.from_dict(list_films_by_collection, **coll)
-        yield Listitem.from_dict(list_shorts, addon.localize(TXT_ALL_SHORT_FILMS), params={'list_films': True})
+        # List short films collection, like Cinetree's website.
+        yield from list_films_by_collection(addon, 'collecties/de-korte-filmcollectie')
+        yield Listitem.from_dict(list_shorts,
+                                 addon.localize(TXT_ALL_SHORT_FILMS),
+                                 params={'list_films': True},
+                                 properties={'SpecialSort': "bottom"})
     else:
         # List all short films
         stories, _ = storyblok._get_url_page('stories', params={'starts_with': 'shorts/'})
@@ -462,3 +470,13 @@ def pay_from_ct_credit(title, uuid):
 def run():
     if isinstance(cc_run(), Exception):
         xbmcplugin.endOfDirectory(int(sys.argv[1]), False)
+    # Due to reuselanguageinvoker the addon may have been updated, while it still
+    # keeps running the old version. Exit with non-zero status to force the current
+    # LanguageInvoker thread to end.
+    installed_version = xbmcaddon.Addon().getAddonInfo('version')
+    if running_version != installed_version:
+        logger.warning("Detected add-on upgrade to %s while still running %s. "
+                       "Exiting non-zero now to end this LanguageInvoker thread",
+                       installed_version,
+                       running_version)
+        sys.exit(1)


### PR DESCRIPTION
### Description
<!--- Provide a short summary of submitted add-on in case it's a new addition. -->
<!--- If it's plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalizing your pull-request. -->
Fixed: listing short films failed.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0

Additional information :
- Submitting your add-on to this specific branch makes it available to any Kodi version equal or higher than the branch name with the applicable Kodi dependencies limits.
- [add-on development](http://kodi.wiki/view/Add-on_development) wiki page.
- Kodi [pydocs](http://kodi.wiki/view/PyDocs) provide information about the Python API
- [PEP8](https://www.python.org/dev/peps/pep-0008/) codingstyle which is considered best practice but not mandatory.
- This add-on repository has automated code guideline check which could help you improve your coding. You can find the results of these check at [Codacy](https://www.codacy.com/app/Kodi/repo-plugins/dashboard). You can create your own account as well to continuously monitor your python coding before submitting to repo.
- Development questions can be asked in the [add-on development](http://forum.kodi.tv/forumdisplay.php?fid=26) section on the Kodi forum.
- If you see no activity on your PR after a week (so at least one weekend has passed) then please go to the #kodi-dev freenode IRC channel to reach out to the team
