### PR TITLE
[plugin.video.orftvthek@matrix] 1.0.3

### DIFF
--- a/plugin.video.orftvthek/addon.xml
+++ b/plugin.video.orftvthek/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.orftvthek" name="ORF ON" version="1.0.2" provider-name="s0fak1ng">
+<addon id="plugin.video.orftvthek" name="ORF ON" version="1.0.3" provider-name="s0fak1ng">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.routing" version="0.2.3"/>
@@ -25,13 +25,10 @@
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>
         </assets>
-        <news>v1.0.2
-            - new Livestream (timeshift)
-            - added setting to use old livestream format
-            - LF conversion
-            - list callback fix main menu
-            - add license
-            - forum fix addon.xml
+        <news>v1.0.3
+            - fix Container Update Bug (latest Omega)
+            - fix error on Addon start cause by OrfOn Api Change
+            - remove duplicate livestream item from frontpage
         </news>
     </extension>
 </addon>

--- a/plugin.video.orftvthek/changelog.txt
+++ b/plugin.video.orftvthek/changelog.txt
@@ -1,3 +1,8 @@
+v1.0.3 (2025-12-14)
+- fix Container Update Bug (latest Omega)
+- fix error on Addon start cause by OrfOn Api Change
+- remove duplicate livestream item from frontpage
+
 v1.0.2 (2024-06-08)
 - new Livestream (timeshift)
 - added setting to use old livestream format

--- a/plugin.video.orftvthek/resources/lib/addon.py
+++ b/plugin.video.orftvthek/resources/lib/addon.py
@@ -169,16 +169,10 @@ def get_recently_added():
 def get_schedule_selection():
     kodi_worker.log("Opening Schedule Selection", 'route')
     items, filters = api.get_schedule_dates()
-    selected = kodi_worker.select_dialog(kodi_worker.get_translation(30130, 'Select a date'), items)
-    api.log(selected)
-    if selected is not False and selected > -1:
-        api.log("Loading %s Schedule" % filters[selected])
-        request_url = api.api_endpoint_schedule % filters[selected]
-        target_url = kodi_worker.plugin.url_for_path(request_url)
-        kodi_worker.list_callback()
-        kodi_worker.execute('Container.Update(%s, replace)' % target_url)
-    else:
-        api.log("Canceled selection")
+    for item_iso, item in zip(filters, items):
+        schedule_dir = Directory(item, description=item, link='/schedule/%s' % item_iso, translator=kodi_worker)
+        kodi_worker.render(schedule_dir)
+    kodi_worker.list_callback()
 
 
 @route_plugin.route('/schedule/<scheduledate>')

--- a/plugin.video.orftvthek/resources/lib/orf_on.py
+++ b/plugin.video.orftvthek/resources/lib/orf_on.py
@@ -158,7 +158,11 @@ class OrfOn:
                  Directory(self.translate_string(30112, 'Shows'), '', self.api_endpoint_shows % self.api_pager_limit, '', 'shows', translator=self.kodi_worker),
                  Directory(self.translate_string(30113, 'Livestream'), '', self.api_endpoint_livestreams, '', 'live', translator=self.kodi_worker),
                  Directory(self.translate_string(30114, 'Search'), '', '/search', '', 'search', translator=self.kodi_worker)]
-        items += self.get_frontpage(lanes=False)
+        additional_items = self.get_frontpage(lanes=False)
+        ignore_items = [self.api_endpoint_home, self.api_endpoint_shows, self.api_endpoint_livestreams, '/page/start/orflive']
+        for additional_item in additional_items:
+            if not additional_item.url() in ignore_items:
+                items.append(additional_item)
         return items
 
     def get_sign_language_menu(self):
@@ -577,16 +581,26 @@ class OrfOn:
             link = item['_links']['playlist']['href']
             return self.build_video(item, link)
         if 'id' in item and 'type' in item:
-            return self.build_directory(item)
+            if self.has_valid_link(item):
+                return self.build_directory(item)
         if 'id' in item and 'videos' in item:
-            return self.build_directory(item)
+            if self.has_valid_link(item):
+                return self.build_directory(item)
         if 'video_type' in item:
             video_item = item
             link = item['_links']['self']['href']
             return self.build_video(video_item, link)
+        self.log("Unknown Type or empty item found", 'info')
 
-        self.log("Unknown Type", 'error')
-        self.print_obj(item)
+    @staticmethod
+    def has_valid_link(item):
+        if 'self' in item['_links'] and 'href' in item['_links']['self']:
+            return True
+        if '_self' in item['_links'] and isinstance(item['_links']['_self'], str):
+            return True
+        if 'self' in item['_links'] and isinstance(item['_links']['self'], str):
+            return True
+        return False
 
     def build_directory(self, item) -> Directory:
         self.log("Building Directory %s (%s)" % (item['title'], item['id']))


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: ORF ON
  - Add-on ID: plugin.video.orftvthek
  - Version number: 1.0.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/s0faking/plugin.video.orftvthek
  
ORF ON - This plugin provides access to the Austrian ORF ON streaming service

### Description of changes:

v1.0.3
            - fix Container Update Bug (latest Omega)
            - fix error on Addon start cause by OrfOn Api Change
            - remove duplicate livestream item from frontpage
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
