### PR TITLE
[plugin.video.tagesschau] 2.6.0

### DIFF
--- a/plugin.video.tagesschau/addon.xml
+++ b/plugin.video.tagesschau/addon.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
     id="plugin.video.tagesschau"
-    version="2.5.7"
+    version="2.6.0"
     name="Tagesschau"
     provider-name="J.Schumacher, H.Saul, C.Prasch">
   <requires>
     <import addon="xbmc.python" version="3.0.0"></import>
+    <import addon="script.module.infotagger" version="0.0.3" />
   </requires>
   
   <extension point="xbmc.python.pluginsource" library="main.py">
@@ -31,6 +32,16 @@
       <screenshot>resources/assets/screenshot_3.png</screenshot>
     </assets>
     <news>
+version 2.6.0 (2025-12-21)
+ * Searching for "Tagesschau 20 Uhr" broadcasts changed to find more entries. Number of searched entries can be configured in settings.
+ * Updates some internas to prevent warnings in Kodi logfile.
+ 
+version 2.5.9 (2024-11-17)
+ * All livestreams (not only one) are now listed in the subfolder "Livestreams"
+ 
+version 2.5.8 (2024-11-02)
+ * Detection of available livestream changed
+ 
 version 2.5.7 (2024-08-17)
  * Fixed empty news list because of changes in ARD API
  

--- a/plugin.video.tagesschau/libs/tagesschau.py
+++ b/plugin.video.tagesschau/libs/tagesschau.py
@@ -16,12 +16,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import sys, os, urllib, urllib.parse, logging
+import sys, os, urllib, urllib.parse
 import xbmc, xbmcplugin, xbmcgui, xbmcaddon, xbmcvfs
 #import web_pdb
 
-from libs.tagesschau_json_api import VideoContentProvider, JsonSource, addon
+from libs.tagesschau_json_api import VideoContentProvider, addon
 from libs.subtitles import download_subtitles
+from infotagger.listitem import ListItemInfoTag
 
 # -- Constants ----------------------------------------------
 ADDON_ID = 'plugin.video.tagesschau'
@@ -32,9 +33,6 @@ ACTION_PARAM = 'action'
 FEED_PARAM = 'feed'
 ID_PARAM = 'tsid'
 URL_PARAM = 'url'
-
-# -- Settings -----------------------------------------------
-logger = logging.getLogger("plugin.video.tagesschau.api")
 
 # -- Settings -----------------------------------------------
 quality_id = addon.getSetting('quality')
@@ -61,10 +59,13 @@ subtitles_dir  = os.path.join(profile_dir, 'Subtitles')
 def addVideoContentDirectory(title, method):
     url_data = { ACTION_PARAM: 'list_feed', FEED_PARAM: method  }
     url = 'plugin://' + ADDON_ID + '/?' + urllib.parse.urlencode(url_data)
-    li = xbmcgui.ListItem(str(title))
+    li = xbmcgui.ListItem()
     li.setArt({'thumb':ICON_IMG, 'landscape':LOGO_IMG, 'icon':ICON_IMG})
     li.setProperty('Fanart_Image', FANART_IMG)
-    li.setInfo(type="video", infoLabels={ "Title": str(title), "Plot": str(title) })    #"mediatype": "video"
+
+    infoLabels={ "title": str(title), "plot": str(title) }
+    ListItemInfoTag(li, 'video').set_info(infoLabels)
+    
     xbmcplugin.setContent(int(sys.argv[1]), 'files')
     xbmcplugin.addDirectoryItem(handle=int(sys.argv[1]), url=url, listitem=li, isFolder=True)
 
@@ -83,20 +84,20 @@ def getListItem(videocontent):
     li.setArt({'thumb':image_url, 'landscape':image_url})
     li.setProperty('Fanart_Image', fanart_url)
     li.setProperty('IsPlayable', 'true')
-    li.setInfo(type="video",
-               infoLabels={ "Title": str(title),
-                            "Plot": str(videocontent.description),
-                            "Duration": str((videocontent.duration or 0)/60),
-                            "mediatype": "video"
-                          }
-              )
+
+    infoLabels={ "title": str(title),
+                 "plot": str(videocontent.description),
+                 "duration": (videocontent.duration or 0)/60,
+                 "mediatype": "video"
+               }
+    ListItemInfoTag(li, 'video').set_info(infoLabels)
+
     if( videocontent.timestamp ):
-        li.setInfo(type="video",
-                   infoLabels={ "premiered": str(videocontent.timestamp.strftime('%d.%m.%Y')),
-                                "aired": str(videocontent.timestamp.strftime('%d.%m.%Y')),
-                                "date": str(videocontent.timestamp.strftime('%d.%m.%Y'))
-                              }
-                  )
+        infoLabels={ "premiered": str(videocontent.timestamp.strftime('%d.%m.%Y')),
+                     "aired": str(videocontent.timestamp.strftime('%d.%m.%Y')),
+                     "date": str(videocontent.timestamp.strftime('%d.%m.%Y'))
+                   }
+        ListItemInfoTag(li, 'video').set_info(infoLabels)
 
     return li
 
@@ -137,7 +138,7 @@ def tagesschau():
     xbmcplugin.addSortMethod(int(sys.argv[1]), xbmcplugin.SORT_METHOD_NONE)
 
     params = get_params()
-    provider = VideoContentProvider(JsonSource())
+    provider = VideoContentProvider()
 
     if params.get(ACTION_PARAM) == 'play_video':
         subtitles_file = None
@@ -173,21 +174,9 @@ def tagesschau():
         addVideoContentItems(videos, params[FEED_PARAM])
 
     else:
-        # populate root directory
-        # check whether there is a livestream
-        videos = provider.livestreams()
-        if(len(videos) == 1):
-            li = xbmcgui.ListItem(strings['livestreams'])
-            li.setArt({'thumb':ICON_IMG, 'landscape':LOGO_IMG, 'icon':ICON_IMG})
-            li.setProperty('Fanart_Image', FANART_IMG)
-            li.setProperty('IsPlayable', 'true')
-            li.setInfo(type="video", infoLabels={ "Title": strings['livestreams'], "Plot": strings['livestreams'] })
-            url = getUrl(videos[0], "livestreams")
-            xbmcplugin.setContent(int(sys.argv[1]), 'videos')
-            xbmcplugin.addDirectoryItem(int(sys.argv[1]), url, li, False)
-
         # add directories for other feeds
         add_named_directory = lambda x: addVideoContentDirectory(strings[x], x)
+        add_named_directory('livestreams')
         add_named_directory('latest_videos')
         add_named_directory('latest_broadcasts')
         add_named_directory('tagesschau_20')

--- a/plugin.video.tagesschau/libs/tagesschau_json_api.py
+++ b/plugin.video.tagesschau/libs/tagesschau_json_api.py
@@ -18,19 +18,18 @@
 
 try: import json
 except ImportError: import simplejson as json
-import logging, datetime, re, urllib.request, xbmc, xbmcaddon
+import datetime, re, urllib.request, xbmc, xbmcaddon
 #import web_pdb
 #web_pdb.set_trace()
 
 # -- Constants ----------------------------------------------
 ADDON_ID = 'plugin.video.tagesschau'
-
-logger = logging.getLogger("plugin.video.tagesschau.api")
 base_url = "https://www.tagesschau.de/api2u/"
 
 addon = xbmcaddon.Addon(id=ADDON_ID)
 showage = addon.getSettingBool('ShowAge')
 tt_listopt = addon.getSetting('tt_list')
+ts20_count = int(addon.getSetting('ts20_count'))
 hide_europadruck = addon.getSettingBool('hide_europadruck')
 hide_wolkenfilm = addon.getSettingBool('hide_wolkenfilm')
 
@@ -176,13 +175,23 @@ class VideoContentParser(object):
 
     def parse_livestream(self, jsonlivestream):
         """Parses the video JSON into a VideoContent object."""
-        tsid = "livestream"
-        title = "Livestream"
-        timestamp = None
+        tsid = jsonlivestream["sophoraId"]
+        title = jsonlivestream["title"]
+
+        if( "date" in jsonlivestream ): 
+            timestamp = self._parse_date(jsonlivestream["date"])
+        else:
+            timestamp = datetime.datetime.now()
+            
+        if( title.lower() == "tagesschau" ):
+            title = title + timestamp.strftime(' vom %d.%m.%Y  %H:%M')
+            
         imageurls = {}
         imageurls = self._parse_image_urls(jsonlivestream["teaserImage"]["imageVariants"])
         videourls = self.parse_video_urls(jsonlivestream["streams"])
-        return VideoContent(tsid, title, timestamp, videourls, imageurls)
+        duration = int(jsonlivestream["tracking"][1]["length"])
+        description = title
+        return VideoContent(tsid, title, timestamp, videourls, imageurls, duration, description)
 
     def parse_video_urls(self, jsonvariants):
         """Parses the video mediadata JSON into a dict mapping variant name to URL."""
@@ -210,10 +219,8 @@ class VideoContentParser(object):
 class VideoContentProvider(object):
     """Provides access to the VideoContent offered by the tagesschau JSON API."""
 
-    def __init__(self, jsonsource):
-        self._jsonsource = jsonsource
+    def __init__(self):
         self._parser = VideoContentParser()
-        self._logger = logging.getLogger("plugin.video.tagesschau.api.VideoContentProvider")
 
     def livestreams(self):
         """Retrieves the livestream(s) currently on the air.
@@ -221,13 +228,14 @@ class VideoContentProvider(object):
             Returns:
                 A list of VideoContent object for livestream(s) on the air.
         """
-        self._logger.info("retrieving livestream(s)")
         videos = []
-        data = self._jsonsource.livestreams()
+
+        url = base_url + "channels"
+        data = json.loads( urllib.request.urlopen(url).read() )
+
         for jsonstream in data["channels"]:
-            if( not "date" in jsonstream ): # livestream has no date
-                video = self._parser.parse_livestream(jsonstream)
-                videos.append(video)
+            video = self._parser.parse_livestream(jsonstream)
+            videos.append(video)
 
         return videos
 
@@ -237,10 +245,11 @@ class VideoContentProvider(object):
             Returns:
                 A list of VideoContent items.
         """
-        self._logger.info("retrieving videos")
-
         videos = []
-        data = self._jsonsource.latest_videos()
+        
+        url = base_url + "news"
+        data = json.loads( urllib.request.urlopen(url).read() )
+
         for jsonvideo in data["news"]:
             try:
                 if( (jsonvideo["type"] == "video") and (jsonvideo["tracking"][0]["src"] == "tagesschau") ):
@@ -252,9 +261,8 @@ class VideoContentProvider(object):
                         video = self._parser.parse_video(jsonvideo)
                         videos.append(video)
             except:
-                self._logger.info("ignoring")
+                pass
 
-        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
     def latest_broadcasts(self):
@@ -263,18 +271,19 @@ class VideoContentProvider(object):
             Returns:
                 A list of VideoContent items.
         """
-        self._logger.info("retrieving broadcasts")
         videos = []
-        data = self._jsonsource.latest_broadcasts()
+
+        url = base_url + "channels"
+        data = json.loads( urllib.request.urlopen(url).read() )
+
         for jsonbroadcast in data["channels"]:
             try:
                 if( ("date" in jsonbroadcast) and ("title" in jsonbroadcast) ):  # Filter out livestream which has no date
                     video = self._parser.parse_broadcast(jsonbroadcast)
                     videos.append(video)
             except:
-                self._logger.info("ignoring")
+                pass
 
-        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
     def tagesschau_20(self):
@@ -283,20 +292,24 @@ class VideoContentProvider(object):
             Returns:
                 A list of VideoContent items.
         """
-        self._logger.info("retrieving tagesschau 20:00")
         videos = []
-        data = self._jsonsource.tagesschau_20()
-        for jsonvideo in data["searchResults"]:
-            try:
-                if( jsonvideo["type"] == "video" ):
-                    length = int(jsonvideo["tracking"][1]["length"])
-                    if( (length >= 890) and (length <= 910) ):
-                        video = self._parser.parse_broadcast(jsonvideo, "Tagesschau")
-                        videos.append(video)
-            except:
-                self._logger.info("ignoring")
+        
+        page = 0
+        while (len(videos) < ts20_count) and (page < 10):
+            url = base_url + "search/?searchText=Tagesschau+20+Uhr&pageSize=30&resultPage=" + str(page)
+            data = json.loads( urllib.request.urlopen(url).read() )
+            page += 1
+            
+            for jsonvideo in data["searchResults"]:
+                try:
+                    if( jsonvideo["type"] == "video" ):
+                        length = int(jsonvideo["tracking"][1]["length"])
+                        if( (length >= 890) and (length <= 910) ):
+                            video = self._parser.parse_broadcast(jsonvideo, "Tagesschau")
+                            videos.append(video)
+                except:
+                    pass
 
-        self._logger.info("found " + str(len(videos)) + " videos")
         return videos
 
     def tagesthemen(self):
@@ -305,55 +318,27 @@ class VideoContentProvider(object):
             Returns:
                 A list of VideoContent items.
         """
-        self._logger.info("retrieving tagesthemen")
         videos = []
-        data = self._jsonsource.tagesthemen()
-        for jsonvideo in data["searchResults"]:
-            try:
-                if( jsonvideo["type"] == "video" ):
-                    length = int(jsonvideo["tracking"][1]["length"])
-                    video = self._parser.parse_broadcast(jsonvideo)
 
-                    if( tt_listopt == "0" ):
-                        if( length >= 1100 ):
-                            videos.append(video)
-                    elif( tt_listopt == "1" ):
-                        if( length < 1100 ):
-                            videos.append(video)
-                    else:
-                        videos.append(video)
-            except:
-                self._logger.info("ignoring")
+        for page in range(2):        
+            url = base_url + "search/?searchText=tagesthemen&pageSize=50&resultPage=" + str(page)
+            data = json.loads( urllib.request.urlopen(url).read() )
 
-        self._logger.info("found " + str(len(videos)) + " videos")
+            for jsonvideo in data["searchResults"]:
+                try:
+                    if( jsonvideo["type"] == "video" ):
+                        length = int(jsonvideo["tracking"][1]["length"])
+                        video = self._parser.parse_broadcast(jsonvideo)
+
+                        if( tt_listopt == "0" ):
+                            if( length >= 1100 ):
+                                videos.append(video)
+                        elif( tt_listopt == "1" ):
+                            if( length < 1100 ):
+                                videos.append(video)
+                        else:
+                            videos.append(video)
+                except:
+                    pass
+
         return videos
-
-
-class JsonSource(object):
-    """Provides access to the raw objects parsed from the TS JSON API.
-        Can be replaced for unittesting purposes."""
-
-    def livestreams(self):
-        """Returns the parsed JSON structure for livestreams."""
-        handle = urllib.request.urlopen(base_url + "channels")
-        return json.loads(handle.read())
-
-    def latest_videos(self):
-        """Returns the parsed JSON structure for the latest videos."""
-        handle = urllib.request.urlopen(base_url + "news")
-        return json.loads(handle.read())
-
-    def latest_broadcasts(self):
-        """Returns the parsed JSON structure for the latest broadcasts."""
-        handle = urllib.request.urlopen(base_url + "channels")
-        return json.loads(handle.read())
-
-    def tagesschau_20(self):
-        """Returns the parsed JSON structure for 20:00 tagesschau"""
-        handle = urllib.request.urlopen(base_url + "search/?searchText=Tagesschau+20+Uhr")
-        return json.loads(handle.read())
-
-    def tagesthemen(self):
-        """Returns the parsed JSON structure for tagesthemen"""
-        handle = urllib.request.urlopen(base_url + "search/?searchText=tagesthemen")
-        return json.loads(handle.read())

--- a/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.de_de/strings.po
@@ -52,6 +52,14 @@ msgctxt "#30009"
 msgid "Show preview image also as fanart"
 msgstr "Vorschaubild auch als Fanart zeigen"
 
+msgctxt "#30010"
+msgid "General"
+msgstr "Allgemein"
+
+msgctxt "#30011"
+msgid "Number of elements for Tagesschau 20 Uhr"
+msgstr "Anzahl Einträge \"Tagesschau 20 Uhr\""
+
 msgctxt "#30100"
 msgid "News"
 msgstr "Nachrichten"
@@ -61,8 +69,8 @@ msgid "Broadcasts"
 msgstr "Sendungen"
 
 msgctxt "#30102"
-msgid "Livestream"
-msgstr "Livestream"
+msgid "Livestreams"
+msgstr "Livestreams"
 
 msgctxt "#30103"
 msgid "ago"

--- a/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.tagesschau/resources/language/resource.language.en_gb/strings.po
@@ -52,6 +52,14 @@ msgctxt "#30009"
 msgid "Show preview image also as fanart"
 msgstr ""
 
+msgctxt "#30010"
+msgid "General"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Number of elements for Tagesschau 20 Uhr"
+msgstr ""
+
 msgctxt "#30100"
 msgid "News"
 msgstr ""
@@ -61,7 +69,7 @@ msgid "Broadcasts"
 msgstr ""
 
 msgctxt "#30102"
-msgid "Livestream"
+msgid "Livestreams"
 msgstr ""
 
 msgctxt "#30103"

--- a/plugin.video.tagesschau/resources/settings.xml
+++ b/plugin.video.tagesschau/resources/settings.xml
@@ -1,9 +1,73 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-  <setting id="quality" type="enum" label="30001" values="Small (480x272)|Medium (640x368)|Large (1280x720)" default="2" />
-  <setting id="ShowAge" type="bool" label="30002" default="true" />
-  <setting id="tt_list" type="enum" label="30003" lvalues="30004|30005|30006" default="2" />
-  <setting id="hide_europadruck" type="bool" label="30007" default="true" />
-  <setting id="hide_wolkenfilm"  type="bool" label="30008" default="true" />
-  <setting id="show_fanart"      type="bool" label="30009" default="true" />
+<?xml version="1.0" ?>
+<settings version="1">
+  <section id="plugin.video.tagesschau">
+    <category id="general" label="30010" help="">
+      <group id="1">
+
+        <setting id="quality" type="integer" label="30001" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label="Small (480x272)">0</option>
+              <option label="Medium (640x368)">1</option>
+              <option label="Large (1280x720)">2</option>
+            </options>
+          </constraints>          
+          <control type="spinner" format="string"/>
+        </setting>
+
+        <setting id="ShowAge" type="boolean" label="30002" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+
+        <setting id="tt_list" type="integer" label="30003" help="">
+          <level>0</level>
+          <default>2</default>
+          <constraints>
+            <options>
+              <option label=30004>0</option>
+              <option label=30005>1</option>
+              <option label=30006>2</option>
+            </options>
+          </constraints>          
+          <control type="spinner" format="string"/>
+        </setting>
+
+        <setting id="ts20_count" type="integer" label="30011" help="">
+          <level>0</level>
+          <default>3</default>
+          <constraints>
+            <minimum>2</minimum>
+            <step>1</step>
+            <maximum>7</maximum>
+          </constraints>
+          <control type="slider" format="integer">
+            <popup>false</popup>
+          </control>
+        </setting>
+
+        <setting id="hide_europadruck" type="boolean" label="30007" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+
+        <setting id="hide_wolkenfilm" type="boolean" label="30008" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+
+        <setting id="show_fanart" type="boolean" label="30009" help="">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle"/>
+        </setting>
+
+      </group>
+    </category>
+  </section>
 </settings>


### PR DESCRIPTION
### Description
 * Searching for "Tagesschau 20 Uhr" broadcasts changed to find more entries. Number of searched entries can be configured in settings.
 * Updates some internas to prevent warnings in Kodi logfile.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [ X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [ X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0