### PR TITLE
[plugin.video.nrk@nexus] 4.10.0

### DIFF
--- a/plugin.video.nrk/addon.py
+++ b/plugin.video.nrk/addon.py
@@ -82,8 +82,11 @@ def live_resolve(id):
     media_url = nrktv.get_playback_url("/playback/manifest/channel/%s" % id);
     if (media_url):
         success = True
-    li = ListItem(path=media_url)
-    setResolvedUrl(plugin.handle, success, li)
+    is_helper = inputstreamhelper.Helper('hls')
+    if is_helper.check_inputstream():
+        playitem = ListItem(path=media_url)
+        playitem.setProperty('inputstream', is_helper.inputstream_addon)
+        setResolvedUrl(plugin.handle, success, playitem)
 
 
 def set_stream_details(item, li):
@@ -247,16 +250,17 @@ def play(video_id):
     if not urls:
         raise Exception("could not find any streams")
     url = urls[0] if len(urls) == 1 else "stack://" + ' , '.join(urls)
-
-    xbmcplugin.setResolvedUrl(plugin.handle, True, ListItem(path=url))
+    playitem = ListItem(path=url)
+    subtitles = subs.get_subtitles(video_id)
+    if subtitles:
+        playitem.setSubtitles(list(subtitles.values()))
+    xbmcplugin.setResolvedUrl(plugin.handle, True, listitem=playitem)
     player = xbmc.Player()
-    subtitle = subs.get_subtitles(video_id)
-    if subtitle:
+    if subtitles:
         # Wait for stream to start
         start_time = time.time()
         while not player.isPlaying() and time.time() - start_time < 10:
             time.sleep(1.)
-        player.setSubtitles(subtitle)
         if xbmcaddon.Addon().getSetting('showsubtitles') != '1':
             player.showSubtitles(False)
 

--- a/plugin.video.nrk/addon.xml
+++ b/plugin.video.nrk/addon.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.nrk"
        name="NRK Nett-TV"
-       version="4.9.2"
+       version="4.10.0"
        provider-name="takoi+a99b">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.requests" version="1.0.4"/>
     <import addon="script.module.routing" version="0.1.0"/>
+    <import addon="script.module.inputstreamhelper" version="0.8.0" />
   </requires>
   <extension point="xbmc.python.pluginsource" library="main.py">
     <provides>video</provides>

--- a/plugin.video.nrk/changelog.txt
+++ b/plugin.video.nrk/changelog.txt
@@ -1,3 +1,7 @@
+[B]4.10.0[/B]
+- add subtitles to VOD stream
+- enable rewinding in live stream and add subtitles to live stream
+
 [B]4.9.2[/B]
 - use hardcoded username to fix github action
 

--- a/plugin.video.nrk/nrktv.py
+++ b/plugin.video.nrk/nrktv.py
@@ -201,7 +201,7 @@ def _get(path, params=''):
 def get_playback_url(manifest_url):
     playable = _get(manifest_url)['playable']
     if playable:
-        return playable['assets'][0]['url']
+        return playable['assets'][0]['url'].replace("adap=small&", "")
     else:
         return None
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NRK Nett-TV
  - Add-on ID: plugin.video.nrk
  - Version number: 4.10.0
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/tamland/xbmc-addon-nrk
  
NRK Web TV gives you the opportunity to watch live TV as well as recordings of many shows.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
