### PR TITLE
[plugin.video.nrk@nexus] 4.10.1

### DIFF
--- a/plugin.video.nrk/addon.py
+++ b/plugin.video.nrk/addon.py
@@ -27,6 +27,7 @@ from xbmcgui import ListItem
 import routing
 import nrktv
 import subs
+import inputstreamhelper
 
 plugin = routing.Plugin()
 

--- a/plugin.video.nrk/addon.xml
+++ b/plugin.video.nrk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.nrk"
        name="NRK Nett-TV"
-       version="4.10.0"
+       version="4.10.1"
        provider-name="takoi+a99b">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>

--- a/plugin.video.nrk/changelog.txt
+++ b/plugin.video.nrk/changelog.txt
@@ -1,3 +1,6 @@
+[B]4.10.1[/B]
+- add missing inputstreamhelper import to addon.py
+
 [B]4.10.0[/B]
 - add subtitles to VOD stream
 - enable rewinding in live stream and add subtitles to live stream


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NRK Nett-TV
  - Add-on ID: plugin.video.nrk
  - Version number: 4.10.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/tamland/xbmc-addon-nrk
  
NRK Web TV gives you the opportunity to watch live TV as well as recordings of many shows.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
