### PR TITLE
[plugin.video.vrt.nu@matrix] 2.5.50+matrix.1

### DIFF
--- a/plugin.video.vrt.nu/README.md
+++ b/plugin.video.vrt.nu/README.md
@@ -57,6 +57,12 @@ You can report issues at [our GitHub issues page](https://github.com/add-ons/plu
 </table>
 
 ## Releases
+### v2.5.50 (2026-01-20)
+- Fix season menu listings (@mediaminister)
+
+### v2.5.49 (2026-01-14)
+- Fix season menu listings (@mediaminister)
+
 ### v2.5.48 (2026-01-08)
 - Fix menu listings after api change (@mediaminister)
 

--- a/plugin.video.vrt.nu/addon.xml
+++ b/plugin.video.vrt.nu/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.48+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
+<addon id="plugin.video.vrt.nu" name="VRT MAX" version="2.5.50+matrix.1" provider-name="Martijn Moreel, dagwieers, mediaminister">
   <requires>
     <import addon="resource.images.studios.white" version="0.0.30"/>
     <import addon="script.module.dateutil" version="2.8.2"/>
@@ -41,6 +41,12 @@
     <website>https://github.com/add-ons/plugin.video.vrt.nu/wiki</website>
     <source>https://github.com/add-ons/plugin.video.vrt.nu</source>
     <news>
+v2.5.50 (2026-01-20)
+- Fix season menu listings
+
+v2.5.49 (2026-01-14)
+- Fix season menu listings
+
 v2.5.48 (2026-01-08)
 - Fix menu listings after api change
 

--- a/plugin.video.vrt.nu/resources/lib/api.py
+++ b/plugin.video.vrt.nu/resources/lib/api.py
@@ -9,7 +9,7 @@ from urllib.parse import quote, quote_plus, unquote
 from data import CHANNELS
 from helperobjects import TitleItem
 from kodiutils import (colour, delete_cached_thumbnail, get_cache, get_setting_bool, get_setting_int, get_url_json, has_addon, has_credentials,
-                       localize, localize_datelong, localize_from_data, log, update_cache, url_for)
+                       localize, localize_datelong, localize_from_data, log, log_error, update_cache, url_for)
 from utils import find_entry, parse_duration, reformat_image_url, shorten_link, url_to_program, youtube_to_plugin_url
 from graphql_data import EPISODE, EPISODE_TILE, PROGRAM_TILE
 
@@ -321,73 +321,13 @@ def get_single_episode_data(episode_id):
             __typename
             ... on EpisodePage {
               episode {
-                ...ep
+                ...episode
               }
             }
           }
         }
-        fragment ep on Episode {
-          __typename
-          id
-          title
-          description
-          episodeNumberRaw
-          durationSeconds
-          offTimeRaw
-          onTimeRaw
-          image {
-            alt
-            templateUrl
-          }
-          analytics {
-            airDate
-            categories
-            contentBrand
-            episode
-            mediaSubtype
-            mediaType
-            name
-            pageName
-            season
-            show
-          }
-          program {
-            id
-            title
-            link
-            programType
-            image {
-              alt
-              templateUrl
-            }
-            posterImage {
-              alt
-              templateUrl
-            }
-          }
-          season {
-            titleRaw
-          }
-          shareAction {
-            url
-          }
-          favoriteAction {
-            favorite
-            id
-            title
-          }
-          nextUp {
-            title
-            autoPlay
-            countdown
-            tile {
-              __typename
-              ...episodeTileFragment
-            }
-          }
-        }
         %s
-    """ % EPISODE_TILE
+    """ % EPISODE
     operation_name = 'OnePlayerData'
     variables = {
         'id': episode_id,
@@ -577,23 +517,6 @@ def get_seasons_data(program_name):
                     icon
                     action {
                       __typename
-                      ... on EpisodeWatchAction {
-                        avodUrl
-                        completed
-                        episodeId
-                        playlistUrl
-                        publicationId
-                        resumePoint
-                        resumePointProgress
-                        resumePointTitle
-                        resumePointTotal
-                        resumePointUpdated
-                        streamId
-                        videoId
-                        videoType
-                        videoUrl
-                        __typename
-                      }
                       ... on ShowComponentAction {
                         component {
                           __typename
@@ -2251,7 +2174,7 @@ def convert_seasons(api_data, program_name):
         if season.get('path'):
             episode_tile = season.get('episode_tile')
             if not episode_tile:
-                episode_tile = get_single_episode_data(season.get('path')).get('data').get('page')
+                episode_tile = get_single_episode_data(season.get('path')).get('data', {}).get('page', {})
 
             _, _, _, title_item = convert_episode(episode_tile)
             if len(api_data) > 1:
@@ -2363,7 +2286,7 @@ def get_seasons(program_name):
         tile = program.get('mostRelevantEpisodeTile')
         if tile:
             episode = (tile.get('tile', {}).get('episode', {}))
-            path = episode.get('shareAction', {}).get('url')
+            path = episode.get('shareAction', {}).get('url', '')
 
             # Build entry
             entry = {
@@ -2400,6 +2323,8 @@ def api_req(graphql_query, operation_name, variables, client='WEB'):
             'x-vrt-client-version': '1.5.12',
         }
         data_json = get_url_json(url=GRAPHQL_URL, cache=None, headers=headers, data=data)
+        if data_json.get('errors'):
+            log_error(dumps(data_json, indent=2))
     return data_json
 
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: VRT MAX
  - Add-on ID: plugin.video.vrt.nu
  - Version number: 2.5.50+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/add-ons/plugin.video.vrt.nu
  
VRT MAX is the video-on-demand platform of the Flemish public broadcaster (VRT).

  - Track the programs you like
  - List all videos alphabetically by program, category, channel or feature
  - Watch live streams from VRT 1, Canvas, Ketnet, Ketnet Junior and Sporza
  - Discover recently added or soon offline content
  - Browse the online TV guides or search VRT MAX

[I]The VRT MAX add-on is not endorsed by VRT, and is provided 'as is' without any warranty of any kind.[/I]

### Description of changes:


v2.5.50 (2026-01-20)
- Fix season menu listings

v2.5.49 (2026-01-14)
- Fix season menu listings

v2.5.48 (2026-01-08)
- Fix menu listings after api change

v2.5.47 (2025-12-21)
- Fix IPTV Manager EPG

v2.5.46 (2025-11-26)
- Fix TV guide menu listings
- Improve season menu listings

v2.5.45 (2025-10-29)
- Fix TV guide menu listings

v2.5.44 (2025-10-10)
- Improve TV guide menu listings
- Fix api requests for long episode lists

v2.5.43 (2025-09-15)
- Fix TV guide menu listings

v2.5.42 (2025-08-29)
- Fix api calls

v2.5.41 (2025-08-28)
- Updated various api calls

v2.5.40 (2025-08-13)
- Fixed incorrect item count in menu listings

v2.5.39 (2025-07-20)
- Fix category menu listings

v2.5.38 (2025-05-12)
- Fix Ketnet Jr livestream

v2.5.37 (2025-04-04)
- Fix DRM streams

v2.5.36 (2025-03-03)
- Fix program listings

v2.5.35 (2025-02-26)
- Fix episode listings

v2.5.34 (2025-02-04)
- Fix watching VRT MAX abroad
- Fix Sporza IPTV Manager EPG

v2.5.33 (2024-12-01)
- Fix search
- Fix category menu listings

v2.5.32 (2024-05-21)
- Fix search
- Fix program menu listings

v2.5.31 (2024-04-21)
- Fix program menu listings

v2.5.30 (2024-04-16)
- Fix playing from TV guide
    

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
