### PR TITLE
[plugin.video.tv3.cat] v1.4.10 - Mark as broken

### DIFF
--- a/plugin.video.tv3.cat/addon.xml
+++ b/plugin.video.tv3.cat/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.tv3.cat" name="TV3cat" version="1.4.9" provider-name="jqandreu">
+<addon id="plugin.video.tv3.cat" name="TV3cat" version="1.4.10" provider-name="jqandreu">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.beautifulsoup4" version="4.6.3"/>
@@ -10,6 +10,7 @@
     </extension>
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
+        <lifecyclestate type="broken" lang="en_GB">Non compliant with the last and only remote provider API endpoint</lifecyclestate>
         <summary lang="en_GB">Entertainment, news, documentaries, etc from catalan television www.tv3.cat</summary>
         <description lang="en_GB">Entertainment, news, documentaries, etc from catalan television www.tv3.cat. [CR]Featured shows, most viewed, A to Z programs. [CR]Live channels: TV3cat, K33, Super3, News 3/24, Esport3</description>
         <summary lang="ca_ES">Tots els programes de TV3 a la carta.</summary>

--- a/plugin.video.tv3.cat/changelog.txt
+++ b/plugin.video.tv3.cat/changelog.txt
@@ -1,8 +1,11 @@
 
-﻿v1.4.9
+v1.4.10
+- Mark as broken
+
+v1.4.9
 - Fixed server changes
 
-﻿v1.4.8
+v1.4.8
 - Adapted to Kodi 19
 - Fixed errors
 


### PR DESCRIPTION
### Description

Mark [plugin.video.tv3.cat] as broken due "Non compliant with the last and only remote provider API endpoint". 
Notified original developer at [this issue](https://github.com/jqandreu/plugin.video.tv3.cat/issues/35) in his repository.

### Checklist:
- [X] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [X] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
