### PR TITLE
[plugin.video.mlbtv@matrix] 2026.2.27+matrix.1

### DIFF
--- a/plugin.video.mlbtv/addon.xml
+++ b/plugin.video.mlbtv/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2025.7.18+matrix.1" provider-name="eracknaphobia, tonywagner">
+<addon id="plugin.video.mlbtv" name="MLB.TV®" version="2026.2.27+matrix.1" provider-name="eracknaphobia, tonywagner">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.pytz" />
@@ -22,11 +22,11 @@
         </description>
         <disclaimer lang="en_GB">Requires an MLB.tv account</disclaimer>
         <news>
-            - updated Big Inning schedule
-            - fix for disable captions on catch up
-            - fix and improvements for play all recaps option
-            - support for single team packages in stream selection
-            - support for Stream Finder (auto-switching based on custom criteria)
+            - bypass skip adjust settings when skipping commercials
+            - stream finder extra innings LI correction
+            - skip bugfix at end-of-game
+            - auto upload Stream Finder form
+            - proxy playback fix (used for stream length padding)
         </news>
         <language>en</language>
         <platform>all</platform>

--- a/plugin.video.mlbtv/resources/lib/mlbmonitor.py
+++ b/plugin.video.mlbtv/resources/lib/mlbmonitor.py
@@ -1017,19 +1017,24 @@ class MLBMonitor(xbmc.Monitor):
                     # make sure we're not paused, and current time is valid (less than 10 hours) -- sometimes Kodi was returning a crazy large current time as the stream was starting
                     if current_time > 0 and current_time != last_time and current_time < 36000:
                         last_time = current_time
-                        if skip_markers[0][0] > 0:
+                        # apply current skip adjust settings to non-commercial skipping
+                        if skip_markers[0][0] > 0 and skip_type != 1:
                             current_break_start = skip_markers[0][0] + self.skip_adjust_end
                         else:
                             current_break_start = skip_markers[0][0]
-                        current_break_end = skip_markers[0][1] + self.skip_adjust_start
+                        if skip_type != 1:
+                            current_break_end = skip_markers[0][1] + self.skip_adjust_start
+                        else:
+                            current_break_end = skip_markers[0][1]
                         # remove any past skip markers so user can seek backward freely
                         while len(skip_markers) > 0 and current_time > current_break_end:
                             xbmc.log(monitor_name + " removed skip marker at " + str(current_break_end) + ", before current time " + str(current_time))
                             skip_markers.pop(0)
-                            current_break_end = skip_markers[0][1] + self.skip_adjust_start
+                            if len(skip_markers) > 0:
+                                current_break_end = skip_markers[0][1] + self.skip_adjust_start
                         # seek to end of break if we fall within skip marker range, then remove marker so user can seek backward freely
                         if len(skip_markers) > 0 and current_time >= current_break_start and current_time < current_break_end:
-                            xbmc.log(monitor_name + " processed skip marker at " + str(current_break_end))
+                            xbmc.log(monitor_name + " current time " + str(current_time) + " falls within skip time from " + str(current_break_start) + " - "  + str(current_break_end))
                             player.seekTime(current_break_end)
                             skip_markers.pop(0)
                             # since we just processed a skip marker, we can delay further processing a little bit
@@ -1878,7 +1883,7 @@ class MLBMonitor(xbmc.Monitor):
                     third = game['linescore']['offense']['third']['id']
                 
                 basesit = self.basesit(first, second, third)
-                innbaseout = str(currentInning) + str(half) + str(basesit) + str(outs)
+                innbaseout = str(currentInning if currentInning <= 9 else 9) + str(half) + str(basesit) + str(outs)
                 
                 games.append({
                   'gamePk': game['gamePk'],

--- a/plugin.video.mlbtv/service.py
+++ b/plugin.video.mlbtv/service.py
@@ -73,7 +73,7 @@ class RequestHandler(BaseHTTPRequestHandler):
           self.send_response(200)
           self.send_header('Content-type', 'text/html')
           self.end_headers()
-          content = '<h1>Stream Finder</h1><p><a download="KodiStreamFinder.txt" href="/downloadsettings">Click to Download Currently Stored Settings</a></p><h2>Settings update</h2><p><b><u>Step 1</b></u><br/>Export and download your desired Stream Finder settings at this link:<br/><a href="https://www.baseball-reference.com/stream-finder.shtml" target="_blank">https://www.baseball-reference.com/stream-finder.shtml</a></p><form method="POST" enctype="multipart/form-data"><p><b><u>Step 2</b></u><br/>Click this button and select the settings file you just downloaded:<br/><input name="file" type="file"/></p><p><p><b><u>Step 3</b></u><br/>Click this button to upload the selected settings file to Kodi:<br/><input type="submit" value="Upload"/></p></form>'
+          content = '<h1>Stream Finder</h1><p><a download="KodiStreamFinder.txt" href="/downloadsettings">Click to Download Currently Stored Settings</a></p><h2>Settings update</h2><p><b><u>Step 1</b></u><br/>Export and download your desired Stream Finder settings at this link:<br/><a href="https://www.baseball-reference.com/stream-finder.shtml" target="_blank">https://www.baseball-reference.com/stream-finder.shtml</a></p><form method="POST" enctype="multipart/form-data"><p><b><u>Step 2</b></u><br/>Click this button and select the settings file you just downloaded:<br/><input name="file" type="file" onchange="form.submit()"/></p></form>'
         elif self.path == '/downloadsettings':
           self.send_response(200)
           self.send_header('Content-type', 'text/plain')
@@ -113,7 +113,7 @@ class RequestHandler(BaseHTTPRequestHandler):
 
           self.end_headers()
 
-          content = response.content.decode('utf8')
+          content = response.content.decode('utf8', errors='ignore')
         
           # remove subtitles and extraneous lines for Kodi Inputstream Adaptive compatibility
           content = re.sub(r"(?:#EXT-X-MEDIA:TYPE=SUBTITLES[\S]+\n)", r"", content, flags=re.M)
@@ -135,7 +135,7 @@ class RequestHandler(BaseHTTPRequestHandler):
           for line in line_array:
               if line.startswith('#'):
                   # look for uri parameters within non-key "#" lines
-                  if playlist_type == 'master' and KEY_TEXT not in line and URI_START_DELIMETER in line:
+                  if (playlist_type == 'master' and KEY_TEXT not in line and URI_START_DELIMETER in line) or (KEY_TEXT in line and URI_START_DELIMETER in line):
                       line_split = line.split(URI_START_DELIMETER)
                       url_split = line_split[1].split(URI_END_DELIMETER, 1)
                       absolute_url = urljoin(url, url_split[0])


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: MLB.TV®
  - Add-on ID: plugin.video.mlbtv
  - Version number: 2026.2.27+matrix.1
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/eracknaphobia/plugin.video.mlbtv
  
Watch every out-of-market regular season game in the office or on the go. The #1 LIVE
            Streaming Sports Service
        

### Description of changes:


            - bypass skip adjust settings when skipping commercials
            - stream finder extra innings LI correction
            - skip bugfix at end-of-game
            - auto upload Stream Finder form
            - proxy playback fix (used for stream length padding)
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
