### PR TITLE
[plugin.video.nrk@nexus] 4.11.1

### DIFF
--- a/plugin.video.nrk/addon.xml
+++ b/plugin.video.nrk/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.nrk"
        name="NRK Nett-TV"
-       version="4.11.0"
+       version="4.11.1"
        provider-name="takoi+a99b">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>

--- a/plugin.video.nrk/changelog.txt
+++ b/plugin.video.nrk/changelog.txt
@@ -1,3 +1,6 @@
+[B]4.11.1[/B]
+- restore python 3.11 compatibility for addon
+
 [B]4.11.0[/B]
 - add on-demand radio categories
 

--- a/plugin.video.nrk/nrk.py
+++ b/plugin.video.nrk/nrk.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, override
+from typing import Any
 
 
 from requests.models import Response
@@ -76,7 +76,6 @@ class Base(object):
 
 
 class BasePage(Base):
-    @override
     def add_images(self, images) -> None:
         self.thumb = deep_get_str(images, 0, "uri")
         self.fanart = deep_get_str(images, -1, "uri")

--- a/plugin.video.nrk/nrkradio.py
+++ b/plugin.video.nrk/nrkradio.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Self, override
+from typing import Any, Self
 import nrk
 from nrk import deep_get_str, deep_get_dict, deep_get_list
 
@@ -144,7 +144,6 @@ class ChannelPlug(BasePlug):
 
 
 class PodcastEpisodePlug(BasePlug):
-    @override
     def _extract(self) -> PlugInfo:
         podcastEpisode: dict[Any, Any] = deep_get_dict(self.response, "podcastEpisode")
         podcast_title: str | None = deep_get_str(
@@ -171,14 +170,12 @@ class PodcastEpisodePlug(BasePlug):
             images=images,
         )
 
-    @override
     def add_images(self, images: str) -> None:
         self.thumb = images
         self.fanart = images
 
 
 class StandaloneProgramPlug(BasePlug):
-    @override
     def _extract(self) -> PlugInfo:
         standaloneProgram: dict[Any, Any] = deep_get_dict(self.response, "program")
         program_title: str | None = deep_get_str(standaloneProgram, "titles", "title")
@@ -204,7 +201,6 @@ class StandaloneProgramPlug(BasePlug):
 
 
 class PodcastPlug(BasePlug):
-    @override
     def _extract(self) -> PlugInfo:
         podcast: dict[Any, Any] = deep_get_dict(self.response, "podcast")
         podcast_title: str | None = deep_get_str(podcast, "titles", "title")
@@ -224,14 +220,12 @@ class PodcastPlug(BasePlug):
             images=images,
         )
 
-    @override
     def add_images(self, images: str) -> None:
         self.thumb = images
         self.fanart = images
 
 
 class EpisodePlug(BasePlug):
-    @override
     def _extract(self) -> PlugInfo:
         episode: dict[Any, Any] = deep_get_dict(self.response, "episode")
         series_title: str | None = deep_get_str(episode, "series", "titles", "title")
@@ -442,7 +436,6 @@ class Season(nrk.Base):  # can be podcast or series season
         return cls(title, url, images)
 
     @property
-    @override
     def children(self) -> list[nrk.Base]:
         if self.manifest_url and not super().children:
             response: dict[str, Any] = nrk.get(path=f"{self.manifest_url}")


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: NRK Nett-TV
  - Add-on ID: plugin.video.nrk
  - Version number: 4.11.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/tamland/xbmc-addon-nrk
  
NRK Web TV gives you the opportunity to watch live TV as well as recordings of many shows.

### Description of changes:



### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
