### PR TITLE
[plugin.audio.theaudiodb.helper] New addon submission v1.0.3

### DIFF
--- a/plugin.audio.theaudiodb.helper/addon.xml
+++ b/plugin.audio.theaudiodb.helper/addon.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<addon id="plugin.audio.theaudiodb.helper" name="TheAudioDB Helper" version="1.0.3" provider-name="manfeed, black_eagle">
+	<requires>
+		<import addon="xbmc.python" version="3.0.0"/>
+	</requires>
+	<!-- Script entry point -->
+	<extension point="xbmc.python.script" library="default.py">
+		<provides>audio</provides>
+	</extension>
+	<!-- Plugin entry point for video lists (hidden from menu) -->
+	<extension point="xbmc.python.pluginsource" library="plugin.py"/>
+	<extension point="xbmc.addon.metadata">
+		<platform>all</platform>
+		<summary lang="en_GB">TheAudioDB Helper - Music metadata and video links powered by TheAudioDB</summary>
+		<summary lang="es_ES">TheAudioDB Helper - Metadatos musicales y enlaces de vídeo de TheAudioDB</summary>
+		<description lang="en_GB">Search TheAudioDB for video links, biographies, similar artists, and metadata for artists in your music database. Provides artist DBID resolution, biography retrieval from multiple sources (TheAudioDB, Wikipedia, Last.fm), and similar artists with images. Needs skin support and a working YouTube plugin.</description>
+		<description lang="es_ES">Busca videoclips, biografías, artistas similares y metadatos en TheAudioDB para los artistas de tu biblioteca musical. Proporciona resolución de DBID del artista, obtención de biografías desde múltiples fuentes (TheAudioDB, Wikipedia, Last.fm) y artistas similares con imágenes. Requiere soporte en el skin y el plugin de YouTube funcionando.</description>
+		<license>GPL-3.0-or-later</license>
+		<source>https://github.com/manfeed/plugin.audio.theaudiodb.helper</source>
+		<news>v1.0.2 - Code quality improvements, duplicate code refactored, crash fix in get_songs_for_artist, Kodi repo compliance.</news>
+		<assets>
+			<icon>resources/art/icon.png</icon>
+			<fanart>resources/art/fanart.jpg</fanart>
+		</assets>
+	</extension>
+</addon>

--- a/plugin.audio.theaudiodb.helper/addon.xml
+++ b/plugin.audio.theaudiodb.helper/addon.xml
@@ -17,7 +17,7 @@
 		<description lang="es_ES">Busca videoclips, biografías, artistas similares y metadatos en TheAudioDB para los artistas de tu biblioteca musical. Proporciona resolución de DBID del artista, obtención de biografías desde múltiples fuentes (TheAudioDB, Wikipedia, Last.fm) y artistas similares con imágenes. Requiere soporte en el skin y el plugin de YouTube funcionando.</description>
 		<license>GPL-3.0-or-later</license>
 		<source>https://github.com/manfeed/plugin.audio.theaudiodb.helper</source>
-		<news>v1.0.2 - Code quality improvements, duplicate code refactored, crash fix in get_songs_for_artist, Kodi repo compliance.</news>
+		<news>v1.0.3 - Initial release. Code quality improvements, duplicate code refactored, crash fix in get_songs_for_artist, Kodi repo compliance.</news>
 		<assets>
 			<icon>resources/art/icon.png</icon>
 			<fanart>resources/art/fanart.jpg</fanart>


### PR DESCRIPTION
## New Music Addon: TheAudioDB Helper
**Addon Name**: TheAudioDB Helper
**Version**: 1.0.3
**Type**: Music metadata and video links helper
**License**: GPL-3.0-or-later
**Kodi Version**: Omega (v21) and newer
### Description
TheAudioDB Helper enriches music libraries with metadata, artwork, biographies, and video links from TheAudioDB, Last.fm, and Wikipedia. Designed to be called from skins through Window properties and plugin directories.
### Key Features
Artist biographies from multiple sources (TheAudioDB, Last.fm, Wikipedia)- High-quality artwork (fanart, logos, banners, album covers)- Album descriptions and metadata- Similar artists with images- Video link integration with YouTube plugin- Multi-language support (8 languages)
### Links
**Source Code**: https://github.com/manfeed/plugin.audio.theaudiodb.helper- 
**Forum Thread**: https://forum.kodi.tv/showthread.php?tid=385177 - 
**Documentation**: https://github.com/manfeed/plugin.audio.theaudiodb.helper/blob/main/readme.md- 
**Latest Release**: https://github.com/manfeed/plugin.audio.theaudiodb.helper/releases/tag/v1.0.3
### Requirements
Kodi Omega (v21) or newer- plugin.video.youtube (for video playback)- Skin support (originally built for Aeon Tajo)
### Checklist
[x] Forum thread created with community feedback
[x] Source code publicly available on GitHub
[x] All code follows Kodi addon guidelines
[x] No compiled files (.pyc, __pycache__) included
[x] GPL-3.0 compatible license
[x] Comprehensive README documentation
[x] Multi-language support (8 languages)
[x] Tested on Kodi Omega (v21)
### Additional Notes
This addon is designed to work with skins. Full integration guide and property reference available in the README.
Thank you for reviewing this submission!