### PR TITLE
[plugin.video.powerunlimited] 1.0.9+matrix.1 Marked addon BROKEN because website does not contain videos anymore

### DIFF
--- a/plugin.video.powerunlimited/addon.xml
+++ b/plugin.video.powerunlimited/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.powerunlimited" 
 	name="PowerUnlimited Tv" 
-	version="1.0.8+matrix.1"
+	version="1.0.9+matrix.1"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="3.0.0"/>
@@ -29,12 +29,13 @@
     <forum>http://forum.xbmc.org/showthread.php?tid=203211</forum>
     <website>https://www.pu.nl/</website>
     <source>https://github.com/skipmodea1/plugin.video.powerunlimited.python3</source>
-    <news>v1.0.8 (2024-10-04)
-    - updated the addon to use the changed website
+    <news>v1.0.9 (2026-05-03)
+    - Marked addon BROKEN because website does not contain videos anymore
     </news>
     <assets>
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.jpg</fanart>
     </assets>
+	<broken>Marked addon BROKEN due to website not containing videos anymore</broken>
   </extension>
 </addon>

--- a/plugin.video.powerunlimited/changelog.txt
+++ b/plugin.video.powerunlimited/changelog.txt
@@ -1,3 +1,6 @@
+v1.0.9 (2026-05-03)
+- Marked addon BROKEN because website does not contain videos anymore
+
 v1.0.8 (2024-10-04)
 - updated the addon to use the changed website
 

--- a/plugin.video.powerunlimited/resources/lib/powerunlimited_const.py
+++ b/plugin.video.powerunlimited/resources/lib/powerunlimited_const.py
@@ -16,8 +16,8 @@ LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources')
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
 VIDEO_LIST_PAGE_URL = "https://pu.nl/artikelen/videos/"
-DATE = "2024-10-04"
-VERSION = "1.0.8"
+DATE = "2026-05-03"
+VERSION = "1.0.9"
 
 
 if sys.version_info[0] > 2:


### PR DESCRIPTION
### Description
+v1.0.9 (2026-05-03)
+- Marked addon BROKEN because website does not contain videos anymore
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0