### PR TITLE
[plugin.video.nlhardwareinfo] 1.0.9+matrix.1

### DIFF
--- a/plugin.video.nlhardwareinfo/addon.xml
+++ b/plugin.video.nlhardwareinfo/addon.xml
@@ -2,7 +2,7 @@
 <addon 
 	id="plugin.video.nlhardwareinfo" 
 	name="Hardware.Info TV" 
-	version="1.0.8+matrix.1"
+	version="1.0.9+matrix.1"
 	provider-name="Skipmode A1">
   <requires>
     <import addon="xbmc.python"                     version="3.0.0"/>
@@ -29,9 +29,14 @@
     <forum>http://forum.kodi.tv/showthread.php?tid=162123</forum>
     <website>http://nl.hardware.info/</website>
     <source>https://github.com/skipmodea1/plugin.video.nlhardwareinfo.python3</source>
+    <lifecyclestate type="broken" lang="en_GB">Website has been discontinued</lifecyclestate>	
+    <lifecyclestate type="broken" lang="nl_NL">Website is stopgezet</lifecyclestate>		
+    <news>v1.0.9 (2026-05-11)
+    - marked addon BROKEN because website is discontinued
+    </news>
     <assets>
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.jpg</fanart>
     </assets>
-  </extension>
+  </extension>	
 </addon>

--- a/plugin.video.nlhardwareinfo/changelog.txt
+++ b/plugin.video.nlhardwareinfo/changelog.txt
@@ -1,3 +1,6 @@
+v1.0.9 (2026-05-11)
+- marked addon BROKEN because website is discontinued
+
 v1.0.8 (2018-01-20) :
 - addon now works in kode python 2 and should also work in python 3 (!!) once all dependencies work in python 3.
 Kudo's to the python future package for making this possible. Kudo's to RomanVM for the help.

--- a/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_const.py
+++ b/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_const.py
@@ -15,8 +15,8 @@ SETTINGS = xbmcaddon.Addon()
 LANGUAGE = SETTINGS.getLocalizedString
 IMAGES_PATH = os.path.join(xbmcaddon.Addon().getAddonInfo('path'), 'resources')
 HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-DATE = "2018-01-20"
-VERSION = "1.0.8"
+DATE = "2026-05-11"
+VERSION = "1.0.9"
 
 
 if sys.version_info[0] > 2:

--- a/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_list_play.py
+++ b/plugin.video.nlhardwareinfo/resources/lib/nlhardwareinfo_list_play.py
@@ -17,7 +17,7 @@ from time import strptime
 import xbmcgui
 import xbmcplugin
 
-from .nlhardwareinfo_const import LANGUAGE, IMAGES_PATH, HEADERS, convertToUnicodeString, log, getSoup
+from resources.lib.nlhardwareinfo_const import LANGUAGE, IMAGES_PATH, HEADERS, convertToUnicodeString, log, getSoup
 
 
 #

--- a/plugin.video.nlhardwareinfo/resources/settings.xml
+++ b/plugin.video.nlhardwareinfo/resources/settings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-
-</settings>


### PR DESCRIPTION
v1.0.9 (2026-05-11)
- marked addon BROKEN because website is discontinued

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-plugins/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0