### PR TITLE
[plugin.video.arteplussept@matrix] 1.5.2

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.5.2 (2026-7-16)
+
+Fix page navigation and keep version in api header user_agent aligned with addon version
+
 v1.5.1 (2026-7-15)
 
 

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.5.1" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.5.2" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -55,9 +55,8 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <license>MIT</license>
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
-<news>1.5.1 (2026-7-15)
-
-Isolate plugin source from scripts and tests</news>
+<news>1.5.2 (2026-7-16)
+Fix page navigation and keep version in api header user_agent aligned with addon version</news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -8,7 +8,7 @@ from resources.lib import hof
 from resources.lib import logger
 
 _PLUGIN_NAME = "Arte +7"
-_PLUGIN_VERSION = "1.5.1"
+_PLUGIN_VERSION = "1.5.2"
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'https://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
@@ -60,8 +60,11 @@ ARTETV_ENDPOINTS = {
     # page_id=SEARCH, HOME...
     'zone':
         '/emac/v4/{lang}/{client}/zones/{zone_id}/content?' +
-        'abv=A&authorizedCountry={lang}&page={page}&pageId={page_id}&' +
+        'abv=A&authorizedCountry={country}&page={page}&pageId={page_id}&' +
         'query={query}&zoneIndexInPage=0',
+    'zonepage':
+        '/emac/v4/{lang}/{client}/zones/{zone_id}/content?' +
+        'authorizedCountry={country}&page={page}',
     # not yet impl.
     # date=2023-01-17
     # 'guide_tv': '/emac/v3/{lang}/{client}/pages/TV_GUIDE/?day={DATE}',
@@ -292,17 +295,18 @@ def get_search_page(lang, zone_id, page_idx, query):
     Navigate in pages of a search identified by zone_id.
     """
     url = _ARTETV_URL + ARTETV_ENDPOINTS['zone'].format(
-        lang=lang, client='tv', zone_id=zone_id, page=page_idx, page_id='SEARCH', query=query)
+        lang=lang, client='tv', zone_id=zone_id, country=lang.upper(), page=page_idx,
+        page_id='SEARCH', query=query)
     return _load_json_full_url('artetv_getsearchpage', url, ARTETV_HEADERS)
 
 
-def get_zone_page(lang, zone_id, page_idx, page_id):
+def get_zone_page(lang, zone_id, page_idx):
     """
     Navigate in pages of a zone identified by zone_id.
     """
-    url = _ARTETV_URL + ARTETV_ENDPOINTS['zone'].format(
-        lang=lang, client='tv', zone_id=zone_id, page=page_idx, page_id=page_id, query='null')
-    return _load_json_full_url('artetv_getsearchpage', url, ARTETV_HEADERS)
+    url = _ARTETV_URL + ARTETV_ENDPOINTS['zonepage'].format(
+        lang=lang, client='tv', zone_id=zone_id, country=lang.upper(), page=page_idx)
+    return _load_json_full_url('artetv_getzonepage', url, ARTETV_HEADERS)
 
 
 def _load_json(request_scope, path, headers=None):

--- a/plugin.video.arteplussept/resources/lib/mapper/artezone.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artezone.py
@@ -47,7 +47,7 @@ class ArteZone(ArteCollection):
         page_id is the type of page e.g. HOME, SEARCH...
         """
         return self._build_menu(
-            api.get_zone_page(self.settings.language, zone_id, page, page_id),
+            api.get_zone_page(self.settings.language, zone_id, page),
             'category_page', zone_id=zone_id, page_id=page_id)
 
     def _get_page_meta(self, json_dict):


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.5.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:

1.5.2 (2026-7-16)
Fix page navigation and keep version in api header user_agent aligned with addon version

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
