### PR TITLE
[plugin.video.arteplussept@matrix] 1.5.3

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,3 +1,12 @@
+v1.5.3 (2026-7-18)
+
+Fix next page navigation and error messages for non authenticated users
+
+- Fix next page navigation, when zone_id was made of a duplicated uuid separated with a _.
+Made code compatible with unexpected value returned by Arte TV API.
+- Smarter warning notification instead of error and warning messages for non authenticated users.
+A single warning is displayed, when a user tries to do something requiering auth. Not at start-up and in unconsistent way.
+
 v1.5.2 (2026-7-16)
 
 Fix page navigation and keep version in api header user_agent aligned with addon version

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.5.2" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.5.3" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -55,8 +55,13 @@ https://github.com/thomas-ernest/plugin.video.arteplussept
         <license>MIT</license>
         <website>https://www.arte.tv/fr/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
-<news>1.5.2 (2026-7-16)
-Fix page navigation and keep version in api header user_agent aligned with addon version</news>
+<news>1.5.3 (2026-7-18)
+Fix next page navigation and error messages for non authenticated users
+
+- Fix next page navigation, when zone_id was made of a duplicated uuid separated with a _.
+Made code compatible with unexpected value returned by Arte TV API.
+- Smarter warning notification instead of error and warning messages for non authenticated users.
+A single warning is displayed, when a user tries to do something requiering auth. Not at start-up and in unconsistent way.</news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -8,7 +8,7 @@ from resources.lib import hof
 from resources.lib import logger
 
 _PLUGIN_NAME = "Arte +7"
-_PLUGIN_VERSION = "1.5.2"
+_PLUGIN_VERSION = "1.5.3"
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'https://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
@@ -304,6 +304,11 @@ def get_zone_page(lang, zone_id, page_idx):
     """
     Navigate in pages of a zone identified by zone_id.
     """
+    # fix "bug" in Arte TV API of doubled zone_id. Example of wrong value:
+    # a6f8c6d2-29d8-44e6-95f3-eec44d2fedaa_a6f8c6d2-29d8-44e6-95f3-eec44d2fedaa
+    parts = zone_id.split('_')
+    if len(parts) == 2 and parts[0] == parts[1]:
+        zone_id = parts[0]
     url = _ARTETV_URL + ARTETV_ENDPOINTS['zonepage'].format(
         lang=lang, client='tv', zone_id=zone_id, country=lang.upper(), page=page_idx)
     return _load_json_full_url('artetv_getzonepage', url, ARTETV_HEADERS)
@@ -381,7 +386,7 @@ def authenticate_in_arte(plugin, username='', password='', headers=None):
         'username': username,
         'password': password
     }
-    xbmc.log(f"Try authenticating \"{username}\" to Arte TV")
+    xbmc.log(f"Try authenticating \"{username}\" to Arte TV", level=xbmc.LOGDEBUG)
     error = None
     reply = None
     try:

--- a/plugin.video.arteplussept/resources/lib/mapper/artefavorites.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artefavorites.py
@@ -12,10 +12,6 @@ from resources.lib.mapper.artecollection import ArteCollection
 class ArteFavorites(ArteCollection):
     """Arte favorites is a kind of user bookmark of arte content managed with Arte TV API."""
 
-    def __init__(self, plugin, settings):
-        super().__init__(plugin, settings)
-        self.auth_token = user.get_cached_token(self.plugin, settings.username)
-
     def build_item(self, label):
         """
         Return menu item to access logged-in user's Arte favorites
@@ -24,39 +20,50 @@ class ArteFavorites(ArteCollection):
 
     def build_menu(self, page):
         """Build the menu for user favorites thanks to API call"""
-        return super()._build_menu(
-            api.get_favorites(self.settings.language, self.auth_token, page),
-            'favorites')
+        menu = None
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            menu = super()._build_menu(
+                api.get_favorites(self.settings.language, auth_token, page),
+                'favorites')
+        return menu
 
     def add_favorite(self, program_id, label):
         """Add content program_id to user favorites.
         Notify about completion success or failure with label."""
-        if 200 == api.add_favorite(self.auth_token, program_id, self.settings.language):
-            msg = self.plugin.addon.getLocalizedString(30025).format(label=label)
-            self.plugin.notify(msg=msg, image='info')
-        else:
-            msg = self.plugin.addon.getLocalizedString(30026).format(label=label)
-            self.plugin.notify(msg=msg, image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            if 200 == api.add_favorite(auth_token, program_id, self.settings.language):
+                msg = self.plugin.addon.getLocalizedString(30025).format(label=label)
+                self.plugin.notify(msg=msg, image='info')
+            else:
+                msg = self.plugin.addon.getLocalizedString(30026).format(label=label)
+                self.plugin.notify(msg=msg, image='error')
 
     def remove_favorite(self, program_id, label):
         """Remove content program_id from user favorites.
         Notify about completion success or failure with label."""
-        if 200 == api.remove_favorite(self.auth_token, program_id):
-            msg = self.plugin.addon.getLocalizedString(30027).format(label=label)
-            self.plugin.notify(msg=msg, image='info')
-        else:
-            msg = self.plugin.addon.getLocalizedString(30028).format(label=label)
-            self.plugin.notify(msg=msg, image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            if 200 == api.remove_favorite(auth_token, program_id):
+                msg = self.plugin.addon.getLocalizedString(30027).format(label=label)
+                self.plugin.notify(msg=msg, image='info')
+            else:
+                msg = self.plugin.addon.getLocalizedString(30028).format(label=label)
+                self.plugin.notify(msg=msg, image='error')
 
     def purge(self):
         """Flush user favorites and notify about success or failure"""
-        purge_confirmed = xbmcgui.Dialog().yesno(
-            self.plugin.addon.getLocalizedString(30040),
-            self.plugin.addon.getLocalizedString(30043),
-            autoclose=10000)
-
-        if purge_confirmed:
-            if 200 == api.purge_favorites(self.auth_token):
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30041), image='info')
-            else:
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30042), image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            purge_confirmed = xbmcgui.Dialog().yesno(
+                self.plugin.addon.getLocalizedString(30040),
+                self.plugin.addon.getLocalizedString(30043),
+                autoclose=10000)
+            if purge_confirmed:
+                if 200 == api.purge_favorites(auth_token):
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30041), image='info')
+                else:
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30042), image='error')

--- a/plugin.video.arteplussept/resources/lib/mapper/artehistory.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artehistory.py
@@ -16,10 +16,6 @@ class ArteHistory(ArteCollection):
     It is available with Arte TV APA "last viewed" only.
     """
 
-    def __init__(self, plugin, settings):
-        super().__init__(plugin, settings)
-        self.auth_token = user.get_cached_token(self.plugin, settings.username)
-
     def build_item(self, label):
         """
         Return menu item to access logged-in user's Arte history
@@ -30,19 +26,27 @@ class ArteHistory(ArteCollection):
         """
         Return current page of user's history
         """
-        return super()._build_menu(
-            api.get_last_viewed(self.settings.language, self.auth_token, page),
-            'last_viewed'
-        )
+        menu = None
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            menu = super()._build_menu(
+                api.get_last_viewed(self.settings.language, auth_token, page),
+                'last_viewed'
+            )
+        return menu
 
     def purge(self):
         """Flush user history and notify about success or failure"""
-        purge_confirmed = xbmcgui.Dialog().yesno(
-            self.plugin.addon.getLocalizedString(30030),
-            self.plugin.addon.getLocalizedString(30033),
-            autoclose=10000)
-        if purge_confirmed:
-            if 200 == api.purge_last_viewed(self.auth_token):
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30031), image='info')
-            else:
-                self.plugin.notify(msg=self.plugin.addon.getLocalizedString(30032), image='error')
+        auth_token = user.get_cached_token(self.plugin, self.settings.username)
+        if auth_token:
+            purge_confirmed = xbmcgui.Dialog().yesno(
+                self.plugin.addon.getLocalizedString(30030),
+                self.plugin.addon.getLocalizedString(30033),
+                autoclose=10000)
+            if purge_confirmed:
+                if 200 == api.purge_last_viewed(auth_token):
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30031), image='info')
+                else:
+                    self.plugin.notify(
+                        msg=self.plugin.addon.getLocalizedString(30032), image='error')

--- a/plugin.video.arteplussept/resources/lib/mapper/mapper.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/mapper.py
@@ -159,7 +159,9 @@ def map_zone_to_item(plugin, settings, zone, cached_categories):
     elif zone.get('link'):
         menu_item = map_api_categories_item(plugin, zone)
     else:
-        xbmc.log(f"Zone \"{title}\" will be ignored. No link. No content. id unknown.")
+        xbmc.log(
+            f"Zone \"{title}\" will be ignored. No link. No content. id unknown.",
+            level=xbmc.LOGINFO)
 
     return menu_item
 

--- a/plugin.video.arteplussept/resources/lib/settings.py
+++ b/plugin.video.arteplussept/resources/lib/settings.py
@@ -29,6 +29,8 @@ class Settings:
         # defaults to empty string to return false with if not str
         self.username = plugin.get_setting(
             'username') or ""
+        self.user_mail = plugin.get_setting(
+            'user_email') or ""
         # Enable additional logs managed by plugin : API messages
         self.loglevel = plugin.get_setting(
             'loglevel', choices=loglevel) or loglevel[0]

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -31,11 +31,12 @@ def login(plugin, settings):
         return False
 
     # ensure no user is not logged in
-    loggedin_usr = is_logged_in_as(plugin)
+    loggedin_usr = settings.user_email
     tkn_data = get_cached_token(plugin, usr, True)
     if len(loggedin_usr) > 0 and tkn_data:
         xbmc.log(
-            f"\"{loggedin_usr}\" already authenticated to Arte TV : {tkn_data['access_token']}")
+            f"\"{loggedin_usr}\" already authenticated to Arte TV : {tkn_data['access_token']}",
+            level=xbmc.LOGINFO)
         # notify user that current token might be replaced
         accept_to_replace = xbmcgui.Dialog().yesno(
             plugin.addon.getLocalizedString(30015),
@@ -99,30 +100,20 @@ def logout(plugin, settings):
     return True
 
 
-def update_settings_state(plugin, usr):
+def update_settings_state(plugin, email):
     """Update setting state to know who belong the token to"""
-    message = plugin.addon.getLocalizedString(30017).format(user=usr)
-    if usr is None or len(usr) <= 0:
+    message = plugin.addon.getLocalizedString(30017).format(user=email)
+    if email is None or len(email) <= 0:
         message = plugin.addon.getLocalizedString(30018)
-    return plugin.set_setting('login_acc', message)
-
-
-def is_logged_in_as(plugin):
-    """Extract the logged in user from settings state"""
-    login_acc = plugin.get_setting('login_acc')
-    usr = ''
-    if isinstance(login_acc, str) and len(login_acc) > 1:
-        # remove everything before opening double quote included
-        usr = login_acc[login_acc.find('"')+1:]
-        # remove everything after closing double quote included
-        usr = usr[:usr.rfind('"')]
-    return usr
+    return plugin.set_setting('user_email', email) and plugin.set_setting('login_acc', message)
 
 
 def get_cached_token(plugin, token_idx, silent=False):
     """
     Return cached token for identified user or None.
-    If user logged in and later changed the user email, it returns None
+    If no token is in cache and silent is not True, then it warns user
+    about the need to authenticate.
+    If user logged in and later changed the user email, it returns None.
     """
     cached_token = plugin.get_storage(_STORAGE_KEY, TTL=_TTL)
     if token_idx in cached_token and isinstance(cached_token[token_idx], dict):

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -25,7 +25,8 @@ def build_home_page(plugin, settings, cached_categories):
     except Exception as error:
         xbmc.log("Unable to build live stream item with " +
                  f"lang:{settings.language} quality:{settings.quality} " +
-                 f"because \"{str(error)}\"")
+                 f"because \"{str(error)}\"",
+                 level=xbmc.LOGERROR)
 
     try:
         arte_home = api.page_content(settings.language)
@@ -37,7 +38,8 @@ def build_home_page(plugin, settings, cached_categories):
     except Exception as error:
         xbmc.log("Unable to build home items with " +
                  f"lang:{settings.language} quality:{settings.quality} " +
-                 f"because \"{str(error)}\"")
+                 f"because \"{str(error)}\"",
+                 level=xbmc.LOGERROR)
 
     return addon_menu
 
@@ -62,20 +64,17 @@ def mark_as_watched(plugin, usr, program_id, label):
     in order to mark a program as watched
     """
     status = -1
-    try:
-        program_info = api.player_video(stg.languages[0], program_id)
-        total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
-        status = api.sync_last_viewed(user.get_cached_token(plugin, usr), program_id, total_time)
-    # pylint: disable=broad-exception-caught
-    except Exception as excp:
-        xbmc.log(f" exception caught :{str(excp)}")
-
-    if 200 == status:
-        msg = plugin.addon.getLocalizedString(30036).format(label=label)
-        plugin.notify(msg=msg, image='info')
-    else:
-        msg = plugin.addon.getLocalizedString(30037).format(label=label)
-        plugin.notify(msg=msg, image='error')
+    program_info = api.player_video(stg.languages[0], program_id)
+    total_time = program_info.get('attributes').get('metadata').get('duration').get('seconds')
+    auth_token = user.get_cached_token(plugin, usr)
+    if auth_token:
+        status = api.sync_last_viewed(auth_token, program_id, total_time)
+        if 200 == status:
+            msg = plugin.addon.getLocalizedString(30036).format(label=label)
+            plugin.notify(msg=msg, image='info')
+        else:
+            msg = plugin.addon.getLocalizedString(30037).format(label=label)
+            plugin.notify(msg=msg, image='error')
 
 
 def build_mixed_collection(plugin, kind, collection_id, settings):

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -34,6 +34,11 @@
 			type="text"
 			label="30054" />
 		<setting
+			id="user_email"
+			type="text"
+			default=""
+			visible="false" />
+		<setting
 			type="action"
 			action="RunPlugin(plugin://plugin.video.arteplussept/user/login)"
 			label="30057" />


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.5.3
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Watch videos from Arte +7
For feature requests / issues:
https://github.com/thomas-ernest/plugin.video.arteplussept/issues
Contributions are welcome:
https://github.com/thomas-ernest/plugin.video.arteplussept
        

### Description of changes:

1.5.3 (2026-7-18)
Fix next page navigation and error messages for non authenticated users

- Fix next page navigation, when zone_id was made of a duplicated uuid separated with a _.
Made code compatible with unexpected value returned by Arte TV API.
- Smarter warning notification instead of error and warning messages for non authenticated users.
A single warning is displayed, when a user tries to do something requiering auth. Not at start-up and in unconsistent way.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
