### PR TITLE
[plugin.switchback@nexus] 2.0.1

### DIFF
--- a/plugin.switchback/addon.xml
+++ b/plugin.switchback/addon.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.switchback" name="Switchback" version="2.0.0" provider-name="bossanova808">
+<addon id="plugin.switchback" name="Switchback" version="2.0.1" provider-name="bossanova808">
     <requires>
-        <import addon="xbmc.python" version="3.0.0" />
-        <import addon="script.module.bossanova808" version="1.0.2" />
-        <import addon="script.module.infotagger" version="0.0.7" />
+        <import addon="xbmc.python" version="3.0.1" />
+        <import addon="script.module.bossanova808" version="1.0.4" />
     </requires>
     <!-- The main service entry point, to keep track of playbacks -->
     <extension point="xbmc.service" library="service.py" />
@@ -55,14 +54,14 @@ Tänk dig följande scenario:
         <source>https://github.com/bossanova808/plugin.switchback/</source>
         <forum>https://forum.kodi.tv/showthread.php?tid=379330</forum>
         <email>bossanova808@gmail.com</email>
-        <news>v2.0.0 Re-write!
-- Support addons
-- Support PVR live/recordings
-- (Remove music support)
-- Add context menus (configurable)
-- Better artwork support
-- Better notifications
-- Filter watched items from list (configurable)
+        <news>v2.0.1
+- Playback tracking now uses a shared class from script.module.bossanova808, common with other addons
+- Quick Switchback now resumes PVR live TV and recordings correctly, with proper channel controls
+- On Kodi 22 (Piers) and newer, PVR live TV and recordings now resolve correctly with no workaround needed at all - including full channel controls for the Switchback list too, not just Quick Switchback - thanks to a Kodi core fix (https://github.com/xbmc/xbmc/pull/28893, fixing https://github.com/xbmc/xbmc/issues/28877). Older Kodi versions keep the previous behaviour.
+- Fix a rare crash when saving the Switchback list on Windows
+- Resume notifications now show a timestamp, distinguish live TV/recordings from other video, and note that retuning live TV may take a few seconds
+- Fix duplicate list entries appearing for the same movie/episode/etc across repeated plays (could happen for addon-backed library items, e.g. Jellyfin, where the reported path can differ between plays)
+- Faster list loading: halved the JSON-RPC calls needed to refresh a list of library items, and removed an unnecessary call on every list view
         </news>
         <assets>
             <icon>resources/icon.png</icon>

--- a/plugin.switchback/changelog.txt
+++ b/plugin.switchback/changelog.txt
@@ -1,4 +1,13 @@
-v2.0.0 Re-write!
+v2.0.1 (2026-08-09)
+- Playback tracking now uses a shared class from script.module.bossanova808, common with other addons
+- Quick Switchback now resumes PVR live TV and recordings correctly, with proper channel controls
+- On Kodi 22 (Piers) and newer, PVR live TV and recordings now resolve correctly with no workaround needed at all - including full channel controls for the Switchback list too, not just Quick Switchback - thanks to a Kodi core fix (https://github.com/xbmc/xbmc/pull/28893, fixing https://github.com/xbmc/xbmc/issues/28877). Older Kodi versions keep the previous behaviour.
+- Fix a rare crash when saving the Switchback list on Windows
+- Resume notifications now show a timestamp, distinguish live TV/recordings from other video, and note that retuning live TV may take a few seconds
+- Fix duplicate list entries appearing for the same movie/episode/etc across repeated plays (could happen for addon-backed library items, e.g. Jellyfin, where the reported path can differ between plays)
+- Faster list loading: halved the JSON-RPC calls needed to refresh a list of library items, and removed an unnecessary call on every list view
+
+v2.0.0 Re-write! (2025-10-07)
 - Support addons
 - Support PVR live/recordings
 - (Remove music support)
@@ -7,7 +16,7 @@ v2.0.0 Re-write!
 - Better notifications
 - Filter watched items from list (configurable)
 
-v1.0.0
+v1.0.0 (2024-11-02)
 - Initial Release
 - Supports Episodes, Movies, Songs, PVR channels, Non-library files
 - Does not (yet?) support: addons/PVR recordings

--- a/plugin.switchback/resources/lib/playback.py
+++ b/plugin.switchback/resources/lib/playback.py
@@ -1,334 +1,16 @@
 import os
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from typing import List, Optional
 
-import xbmc
-import xbmcgui
 import xbmcvfs
 
 # noinspection PyPackages
-from bossanova808.utilities import clean_art_url, send_kodi_json, get_resume_point, get_playcount, get_advancedsetting
+from bossanova808.playback import Playback
+# noinspection PyPackages
+from bossanova808.utilities import get_playcount_and_resume_point, get_advancedsetting
 # noinspection PyPackages
 from bossanova808.logger import Logger
-# noinspection PyUnresolvedReferences
-from infotagger.listitem import ListItemInfoTag
-
-@dataclass
-class Playback:
-    """
-    Stores whatever data we can grab about a Kodi Playback so that we can display it nicely in the Switchback list
-    """
-    file: Optional[str] = None
-    path: Optional[str] = None
-    type: Optional[str] = None  # episode, movie, video (per Kodi types) - song is the other type, but Switchback supports video only
-    source: Optional[str] = None  # kodi_library, pvr_live, pvr_recording, addon, file
-    dbid: Optional[int] = None
-    tvshowdbid: Optional[int] = None
-    totalseasons: Optional[int] = None
-    title: Optional[str] = None
-    label: Optional[str] = None
-    label2: Optional[str] = None
-    thumbnail: Optional[str] = None
-    fanart: Optional[str] = None
-    poster: Optional[str] = None
-    icon: Optional[str] = None
-    year: Optional[int] = None
-    showtitle: Optional[str] = None
-    season: Optional[int] = None
-    episode: Optional[int] = None
-    resumetime: Optional[int] = None
-    totaltime: Optional[int] = None
-    duration: Optional[int] = None
-    channelname: Optional[str] = None
-    channelnumberlabel: Optional[str] = None
-    channelgroup: Optional[str] = None
-
-    @property
-    def pluginlabel(self) -> str:
-        """
-        Create a more full label, e.g. Showname (2x03) - Episode title
-
-        :return: The Switchback label for display in the plugin list
-        """
-        label = self.title or self.label or self.channelname or (os.path.basename(self.path) if self.path else None) or "Unknown"
-        if self.showtitle:
-            if (self.season is not None and self.season >= 0) and (self.episode is not None and self.episode >= 0):
-                label = f"{self.showtitle} ({self.season}x{self.episode:02d}) - {self.title or label}"
-            elif self.season is not None and self.season >= 0:
-                label = f"{self.showtitle} ({self.season}x?) - {self.title or label}"
-            else:
-                label = f"{self.showtitle} - {self.title or label}"
-        elif self.channelname:
-            if self.source == "pvr_live":
-                label = f"{self.channelname} (PVR Live)"
-            else:
-                label = f"{label} (PVR Recording {self.channelname})"
-
-        if self.source == "addon":
-            label = f"{label} (* Add-on)"
-        return label
-
-    @property
-    def pluginlabel_short(self) -> str:
-        """
-        Create a shorter label, e.g. Showname (2x03)
-        """
-        label = self.title or self.label or self.channelname or (os.path.basename(self.path) if self.path else None) or "Unknown"
-        if self.showtitle:
-            if (self.season is not None and self.season >= 0) and (self.episode is not None and self.episode >= 0):
-                label = f"{self.showtitle} ({self.season}x{self.episode:02d})"
-            elif self.season is not None and self.season >= 0:
-                label = f"{self.showtitle} ({self.season}x?)"
-            else:
-                label = f"{self.showtitle}"
-
-        return label
-
-    def _is_addon_playback(self) -> bool:
-        """
-        Determine if playback originates from an addon
-
-        :return: True if playback is from an addon, False otherwise
-        """
-        path_lower = (self.path or '').lower()
-
-        # Method 1: Check for plugin:// URLs (most reliable)
-        if path_lower.startswith('plugin://'):
-            return True
-
-        # Method 2: Check ListItem.Path infolabel for plugin URLs
-        listitem_path_lower = xbmc.getInfoLabel('ListItem.Path').lower()
-        if listitem_path_lower.startswith('plugin://'):
-            return True
-
-        # Method 3: Check if an addon ID is associated with the current item
-        addon_id = xbmc.getInfoLabel('ListItem.Property(Addon.ID)')
-        if addon_id:
-            return True
-
-        # Method 4: Check container path (for addon-generated content)
-        container_path_lower = xbmc.getInfoLabel('Container.FolderPath').lower()
-        if container_path_lower.startswith('plugin://'):
-            return True
-
-        # Method 5: Conservative HTTP fallback for local addon proxies only
-        if path_lower.startswith(('http://', 'https://')):
-            # Exclude known WebDAV/cloud storage patterns
-            webdav_patterns = [
-                    '/dav/', 'webdav', '.nextcloud.', 'owncloud', '/remote.php/', 'dropbox', 'googledrive', 'onedrive',
-            ]
-
-            if not any(pattern in path_lower for pattern in webdav_patterns):
-                # Additional check: look for typical addon URL structures
-                if any(indicator in path_lower for indicator in ('plugin', 'addon')):
-                    Logger.debug("Classified as addon via HTTP fallback heuristic", path_lower)
-                    return True
-            # If we still have an Addon.ID or container is a plugin, treat as addon
-            addon_id_http = xbmc.getInfoLabel('ListItem.Property(Addon.ID)')
-            container_path_lower_http = xbmc.getInfoLabel('Container.FolderPath').lower()
-            if addon_id_http or container_path_lower_http.startswith('plugin://'):
-                return True
-            # Accept loopback hosts commonly used by addon proxy/resolvers
-            if any(host in path_lower for host in ('127.0.0.1', 'localhost', '[::1]')):
-                Logger.debug("Classified as addon via localhost HTTP fallback", path_lower)
-                return True
-
-        return False
-
-    def update(self, new_details: dict) -> None:
-        """
-        Update a Playback object with new details
-
-        :param new_details: a dictionary (need not be complete) of the Playback object's new details
-        """
-        for key, value in new_details.items():
-            if hasattr(self, key):
-                setattr(self, key, value)
-            else:
-                Logger.error(f"Playback.update: Unknown key [{key}]")
-
-    def toJson(self) -> str:
-        """
-        Return the Playback object as JSON
-
-        :return: the Playback object as JSON
-        """
-        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
-
-    def update_playback_details(self, file: str, item: xbmcgui.ListItem) -> None:
-        """
-        Update the Playback object with details from a playing Kodi ListItem object and InfoLabels
-
-        :param file: the current file Kodi is playing (from xbmc.Player().getPlayingFile())
-        :param item: the current Kodi playing item (from xbmc.Player().getPlayingItem())
-        """
-
-        self.path = item.getPath()
-        self.file = file
-        self.label = item.getLabel()
-        self.label2 = item.getLabel2()
-
-        # Updated as playback progresses (see switchback_service.py), but initialise here in cast of early exits etc.
-        if self.source != "pvr_live":
-            # Getting from the player directly is more reliable than using item.getVideoInfoTag() etc
-            self.totaltime = self.duration = int(xbmc.Player().getTotalTime())
-            self.resumetime = int(xbmc.Player().getTime())
-
-        # Determine the Playback source - Kodi Library (...get DBID), PVR, Addon, or Non-Library file?
-        dbid_label = xbmc.getInfoLabel('VideoPlayer.DBID')
-        try:
-            self.dbid = int(dbid_label) if dbid_label else None
-        except ValueError:
-            self.dbid = None
-
-        if self.dbid:
-            self.source = "kodi_library"
-        elif xbmc.getCondVisibility('PVR.IsPlayingTV') or xbmc.getCondVisibility('PVR.IsPlayingRadio'):
-            self.source = "pvr_live"
-        elif (self.path or '').lower().startswith('pvr://recordings/'):
-            self.source = "pvr_recording"
-        elif self._is_addon_playback():
-            self.source = "addon"
-        else:
-            Logger.debug("Not from Kodi library, PVR, or addon - treating as a non-library media file")
-            self.source = "file"
-
-        # TITLE
-        if self.source != "pvr_live":
-            self.title = xbmc.getInfoLabel('VideoPlayer.Title')
-        else:
-            self.title = xbmc.getInfoLabel('VideoPlayer.ChannelName')
-
-        # MEDIA TYPE (see also source above, e.g. to distinguish PVR from non library video)
-        # Infotagger/Kodi expect mediatype in {"video","movie","tvshow","season","episode","musicvideo"}.
-        if xbmc.getInfoLabel('VideoPlayer.TVShowTitle'):
-            self.type = "episode"
-            tvshowdbid_label = xbmc.getInfoLabel('VideoPlayer.TvShowDBID')
-            try:
-                self.tvshowdbid = int(tvshowdbid_label) if tvshowdbid_label else None
-            except ValueError:
-                self.tvshowdbid = None
-
-        elif self.dbid:
-            self.type = "movie"
-        elif xbmc.getInfoLabel('VideoPlayer.ChannelName'):
-            self.type = "video"  # use standard mediatype; PVR tracked via self.source
-        else:
-            self.type = "video"
-
-        # ARTWORK - POSTER, FANART THUMBNAIL and ICON
-        self.poster = clean_art_url(xbmc.getInfoLabel('Player.Art(tvshow.poster)') or xbmc.getInfoLabel('Player.Art(poster)') or xbmc.getInfoLabel('Player.Art(thumb)'))
-        self.fanart = clean_art_url(xbmc.getInfoLabel('Player.Art(fanart)'))
-        thumbnail = xbmc.getInfoLabel('Player.Art(thumb)') or (item.getArt('thumb') or '')
-        self.thumbnail = clean_art_url(thumbnail)
-        icon = xbmc.getInfoLabel('Player.Art(icon)') or (item.getArt('icon') or '')
-        self.icon = clean_art_url(icon)
-
-        # OTHER DETAILS
-        # PVR Live/Recordings
-        self.channelname = xbmc.getInfoLabel('VideoPlayer.ChannelName')
-        self.channelnumberlabel = xbmc.getInfoLabel('VideoPlayer.ChannelNumberLabel')
-        self.channelgroup = xbmc.getInfoLabel('VideoPlayer.ChannelGroup')
-        # Episodes & Movies
-        year_label = xbmc.getInfoLabel('VideoPlayer.Year')
-        try:
-            self.year = int(year_label) if year_label else None
-        except ValueError:
-            self.year = None
-        # Episodes
-        self.showtitle = xbmc.getInfoLabel('VideoPlayer.TVShowTitle')
-        season_label = xbmc.getInfoLabel('VideoPlayer.Season')
-        episode_label = xbmc.getInfoLabel('VideoPlayer.Episode')
-        try:
-            self.season = int(season_label) if season_label else None
-        except ValueError:
-            self.season = None
-        try:
-            self.episode = int(episode_label) if episode_label else None
-        except ValueError:
-            self.episode = None
-        # Episodes -> we also want the number of seasons so we can force-browse to the appropriate spot after a Swtichback initiated playback
-        if self.tvshowdbid:
-            json_dict = {
-                    "jsonrpc":"2.0",
-                    "id":"VideoLibrary.GetSeasons",
-                    "method":"VideoLibrary.GetSeasons",
-                    "params":{
-                            "tvshowid":self.tvshowdbid,
-                    },
-            }
-
-            properties_json = send_kodi_json(f'Get seasons details for tv show {self.showtitle}', json_dict)
-            if not properties_json or 'result' not in properties_json:
-                Logger.error("VideoLibrary.GetSeasons returned no result")
-                self.totalseasons = None
-                # Continue without seasons info
-                return
-
-            if 'error' in properties_json:
-                Logger.error("VideoLibrary.GetSeasons returned error:", properties_json['error'])
-                self.totalseasons = None
-                return
-            properties = properties_json['result']
-
-            # {'limits': {'end': 2, 'start': 0, 'total': 2}, 'seasons': [...]}
-            total_limit = properties.get('limits', {}).get('total')
-            self.totalseasons = total_limit if isinstance(total_limit, int) else None
-            if self.totalseasons is None and 'seasons' in properties:
-                self.totalseasons = len(properties['seasons'])
-
-    # noinspection PyMethodMayBeStatic
-    def create_list_item_from_playback(self) -> xbmcgui.ListItem:
-        """
-        Create a Kodi ListItem object from a Playback object
-
-        :return: ListItem: a Kodi ListItem object constructed from the Playback object
-        """
-
-        Logger.debug("Creating list item from playback:", self)
-
-        list_item = xbmcgui.ListItem(label=self.pluginlabel, path=self.file if self.source not in ["addon", "pvr_live"] else self.path)
-        art = {key:value for key, value in {"thumb":self.thumbnail, "poster":self.poster, "fanart":self.fanart, "icon":self.icon}.items() if value}
-        if art:
-            list_item.setArt(art)
-        list_item.setProperty('IsPlayable', 'true')
-
-        # PVR channels are not really videos! See: https://forum.kodi.tv/showthread.php?tid=381623&pid=3232826#pid3232826
-        # So that's all we need to do for PVR playbacks
-        if self.source == "pvr_live":
-            return list_item
-
-        # Otherwise, it's an episode/movie/file etc...set the InfoVideoTag stuff
-        tag = ListItemInfoTag(list_item, "video")
-        duration_seconds = None
-        if self.duration is not None:
-            duration_seconds = self.duration
-        elif self.totaltime is not None:
-            duration_seconds = self.totaltime
-
-        # Infotagger seems the best way to do this currently as is well tested
-        # I found directly setting things on InfoVideoTag to be buggy/inconsistent
-        infolabels = {
-                'mediatype':self.type,
-                'dbid':self.dbid,
-                'title':self.title,
-                'path':self.path,
-                'year':self.year,
-                'tvshowtitle':self.showtitle,
-                'episode':self.episode,
-                'season':self.season,
-                'duration':duration_seconds,
-        }
-        tag.set_info(infolabels)
-
-        # Required, otherwise immediate Switchback mode won't resume properly
-        # These keys are correct, even if CodeRabbit says they are not - see https://github.com/jurialmunkey/script.module.infotagger/blob/f138c1dd7201a8aff7541292fbfc61ed7b3a9aa1/resources/modules/infotagger/listitem.py#L204
-        tag.set_resume_point({'ResumeTime':float(self.resumetime or 0.0), 'TotalTime':float(self.totaltime or 0.0)})
-        if self.tvshowdbid:
-            list_item.setProperty('tvshowdbid', str(self.tvshowdbid))
-
-        return list_item
 
 
 @dataclass
@@ -376,7 +58,7 @@ class PlaybackList:
                     self.init()
                     return
                 for playback in switchback_list_json:
-                    self.list.append(Playback(**playback))
+                    self.list.append(Playback.from_dict(playback))
 
         except FileNotFoundError:
             Logger.warning(f"Could not find: [{self.file}] - creating empty PlaybackList & file")
@@ -387,42 +69,67 @@ class PlaybackList:
 
         list_needs_save = False
 
-        # If the user wants to filter out watched items from the list
-        if self.remove_watched_playbacks:
-            paths_to_remove = []
-            for item in list(self.list):
-                # DB item?  Is it marked as watched in the DB?
-                if item.dbid:
-                    playcount = get_playcount(item.type, item.dbid)
-                    if playcount and playcount > 0:
-                        list_needs_save = True
-                        Logger.debug(f"Filtering watched playback from the list (as playcount > 0 in Kodi DB): [{item.pluginlabel}]")
-                        paths_to_remove.append(item.path)
-
-                # Not a DB item, use a calculation instead and compare to the playcount_minium_percent
-                elif item.resumetime and item.totaltime:
-                    percent_played = (item.resumetime / item.totaltime) * 100
-                    # Use the user set playcount_minium_percent if there is one, or fallback to Kodi default 90 percent
-                    setting = get_advancedsetting('video/playcountminimumpercent')
-                    playcount_minium_percent = float(setting) if setting and setting != 0 else 90.0
-                    if percent_played >= playcount_minium_percent:
-                        list_needs_save = True
-                        Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played over playcount_minium_percent {playcount_minium_percent}%): [{item.pluginlabel}]")
-                        paths_to_remove.append(item.path)
-
-            if paths_to_remove:
-                list_needs_save = True
-                for path in paths_to_remove:
-                    self.remove_playbacks_of_path(path)
-
-        # Update resume points with current data from the Kodi library (consider e.g. shared library scenarios)
+        # Defensively collapse any duplicate entries for the same piece of media - there should only
+        # ever be one entry (the most recent) per movie/episode/etc. Duplicates can end up here from
+        # an older version of the addon that deduplicated on .path alone, which isn't always stable
+        # for the same media across plays (see Playback.identity_key). The list is newest-first, so
+        # keeping the first occurrence of each identity keeps the most recent one.
+        seen_identities = set()
+        deduplicated_list = []
         for item in self.list:
+            identity = item.identity_key
+            if identity in seen_identities:
+                Logger.warning(f"Removing duplicate PlaybackList entry for [{item.pluginlabel}] (identity: {identity})")
+                list_needs_save = True
+                continue
+            seen_identities.add(identity)
+            deduplicated_list.append(item)
+        self.list = deduplicated_list
+
+        # Refresh resume points from the Kodi library (consider e.g. shared library scenarios), and -
+        # if the user wants it - filter out watched items, for every library item in one pass. Both
+        # pieces of data come from the same JSON-RPC call per dbid, rather than two separate
+        # round trips, since a list with several library items otherwise means twice as many
+        # JSON-RPC calls on every single load (e.g. just viewing the Switchback list).
+        paths_to_remove = []
+        for item in list(self.list):
+            # DB item? Refresh its resume point, and its playcount if we care about that here
             if item.dbid:
-                library_resume_point = get_resume_point(item.type, item.dbid)
+                playcount, library_resume_point = get_playcount_and_resume_point(item.type, item.dbid)
+
+                if self.remove_watched_playbacks:
+                    if playcount is None:
+                        Logger.warning(f"dbid {item.dbid} no longer valid in Kodi library for [{item.pluginlabel}] - removing from Switchback list")
+                        paths_to_remove.append(item.path)
+                        list_needs_save = True
+                        continue
+                    elif playcount > 0:
+                        list_needs_save = True
+                        Logger.warning(f"Filtering watched playback from the list (as playcount > 0 in Kodi DB): [{item.pluginlabel}]")
+                        paths_to_remove.append(item.path)
+                        continue
+
                 if library_resume_point != item.resumetime:
                     Logger.debug(f"Retrieved library resume point: {library_resume_point} != existing list resume point {item.resumetime} - updating playback list")
                     list_needs_save = True
                     item.resumetime = library_resume_point
+
+            # Not a DB item - if the user wants watched items filtered, use a calculation instead
+            # and compare to the playcount_minium_percent (there's no library playcount to check)
+            elif self.remove_watched_playbacks and item.resumetime and item.totaltime:
+                percent_played = (item.resumetime / item.totaltime) * 100
+                # Use the user set playcount_minium_percent if there is one, or fallback to Kodi default 90 percent
+                setting = get_advancedsetting('video/playcountminimumpercent')
+                playcount_minium_percent = float(setting) if setting and setting != 0 else 90.0
+                if percent_played >= playcount_minium_percent:
+                    list_needs_save = True
+                    Logger.debug(f"Filtering watched playback from the list (as {percent_played:.1f}% played over playcount_minium_percent {playcount_minium_percent}%): [{item.pluginlabel}]")
+                    paths_to_remove.append(item.path)
+
+        if paths_to_remove:
+            list_needs_save = True
+            for path in paths_to_remove:
+                self.remove_playbacks_of_path(path)
 
         if list_needs_save:
             self.save_to_file()
@@ -433,6 +140,7 @@ class PlaybackList:
         """
         Logger.info(f"Saving PlaybackList to file: {self.file}")
         import tempfile
+        import time
         directory_name = os.path.dirname(self.file)
         temp_dir = None
         if directory_name:
@@ -441,7 +149,24 @@ class PlaybackList:
         with tempfile.NamedTemporaryFile('w', delete=False, encoding='utf-8', dir=temp_dir) as temp_file:
             temp_file.write(self.toJson())
             temporary_name = temp_file.name
-        os.replace(temporary_name, self.file)
+
+        # On Windows, os.replace() can transiently fail with PermissionError if another
+        # Switchback process (the service, or an overlapping plugin invocation) has the
+        # destination file briefly open - retry a few times rather than letting a routine
+        # save crash the caller.
+        last_error = None
+        for attempt in range(5):
+            try:
+                os.replace(temporary_name, self.file)
+                return
+            except PermissionError as e:
+                last_error = e
+                time.sleep(0.1)
+        Logger.error(f"Could not save PlaybackList to file [{self.file}] after retries: {last_error}")
+        try:
+            os.remove(temporary_name)
+        except OSError:
+            pass
 
     def delete_file(self) -> None:
         """
@@ -470,4 +195,25 @@ class PlaybackList:
                 Logger.debug(f"Matched playback to [{playback.path}]")
                 return playback
         Logger.debug(f"No matching playback for [{path}]")
+        return None
+
+    def find_playback_by_identity(self, playback: Playback) -> Optional[Playback]:
+        """
+        Return an existing list entry representing the same piece of media as the given playback
+        (see Playback.identity_key), if found, otherwise None. Unlike find_playback_by_path(), this
+        still recognises the same library movie/episode/etc even if the specific path/file Kodi
+        reports for it differs between plays (e.g. a direct library click vs an addon-triggered
+        Switchback replay of the same item) - which is what actually determines whether a repeat
+        play updates the existing entry or wrongly creates a duplicate.
+
+        :param playback: the Playback to find an existing match for
+        :return: Playback or None: The matching Playback object if found, otherwise None
+        """
+        identity = playback.identity_key
+        Logger.debug(f"find_playback_by_identity: {identity}")
+        for existing in self.list:
+            if existing.identity_key == identity:
+                Logger.debug(f"Matched playback to [{existing.pluginlabel}]")
+                return existing
+        Logger.debug(f"No matching playback for identity [{identity}]")
         return None

--- a/plugin.switchback/resources/lib/player.py
+++ b/plugin.switchback/resources/lib/player.py
@@ -2,6 +2,7 @@ import xbmc
 
 from bossanova808.constants import HOME_WINDOW
 from bossanova808.logger import Logger
+from bossanova808.utilities import get_kodi_setting
 from resources.lib.playback import Playback
 
 from resources.lib.store import Store
@@ -87,21 +88,30 @@ class KodiPlayer(xbmc.Player):
         if Store.episode_force_browse and switchback_playback:
             if Store.current_playback.type == "episode" and Store.current_playback.source == "kodi_library":
                 Logger.info("Force browsing to tvshow/season of just finished playback")
-                Logger.debug(f'flatten tvshows {Store.flatten_tvshows} totalseasons {Store.current_playback.totalseasons} dbid {Store.current_playback.dbid} tvshowdbid {Store.current_playback.tvshowdbid}')
+                # Fetched fresh here rather than cached, since it's a Kodi system setting the user
+                # can change at any time - there's no settings-changed notification we can hook for
+                # it (unlike our own addon settings), so a stale cached value could otherwise persist
+                # for the rest of the Kodi session. This only runs for episodes with force-browse
+                # enabled, so the extra JSON-RPC call here is rare and not worth caching.
+                flatten_tvshows = int(get_kodi_setting('videolibrary.flattentvshows'))
+                Logger.debug(f'flatten tvshows {flatten_tvshows} totalseasons {Store.current_playback.totalseasons} dbid {Store.current_playback.dbid} tvshowdbid {Store.current_playback.tvshowdbid}')
                 # Default: Browse to the show
                 window = f'videodb://tvshows/titles/{Store.current_playback.tvshowdbid}'
                 # 0 = Never flatten → browse to show root
                 # 1 = If only one season → browse to season only when there are multiple seasons
                 # 2 = Always flatten → browse to season
-                if Store.flatten_tvshows == 2:
+                if flatten_tvshows == 2:
                     window += f'/{Store.current_playback.season}'
-                elif Store.flatten_tvshows == 1 and (Store.current_playback.totalseasons or 0) > 1:
+                elif flatten_tvshows == 1 and (Store.current_playback.totalseasons or 0) > 1:
                     window += f'/{Store.current_playback.season}'
                 xbmc.executebuiltin(f'ActivateWindow(Videos,{window},return)')
 
         # This rather long-winded approach is used to keep ALL the details recorded from the original playback
         # (in case they don't make it through when the playback is Switchback initiated - as sometimes seems to be the case)
-        playback_to_remove = Store.switchback.find_playback_by_path(Store.current_playback.path)
+        # Matched by identity (not path) - the path/file Kodi reports for the same library item can
+        # differ between a direct play and a Switchback-triggered replay (see Playback.identity_key),
+        # and matching on path alone would otherwise create a duplicate entry for the same media.
+        playback_to_remove = Store.switchback.find_playback_by_identity(Store.current_playback)
         if playback_to_remove:
             Logger.debug("Updating Playback and list order")
             # Remove it from its current position

--- a/plugin.switchback/resources/lib/store.py
+++ b/plugin.switchback/resources/lib/store.py
@@ -4,7 +4,7 @@ import xbmcvfs
 
 from bossanova808.constants import HOME_WINDOW, PROFILE, ADDON
 from bossanova808.logger import Logger
-from bossanova808.utilities import get_kodi_setting, set_property, clear_property
+from bossanova808.utilities import set_property, clear_property
 from resources.lib.playback import PlaybackList
 
 
@@ -31,16 +31,12 @@ class Store:
     episode_force_browse = ADDON.getSettingBool('episode_force_browse')
     remove_watched_playbacks = ADDON.getSettingBool('remove_watched_playbacks')
 
-    # GUI Settings - to work out how to force browse to a show after a switchback initiated playback
-    flatten_tvshows = None
-
     def __init__(self):
         """
         Load in the addon settings and do basic initialisation stuff
         :return:
         """
         Store.load_config_from_settings()
-        Store.load_config_from_kodi_settings()
         Store.switchback = PlaybackList([], xbmcvfs.translatePath(os.path.join(PROFILE, "switchback.json")), Store.remove_watched_playbacks)
         Store.switchback.load_or_init()
         Store.update_switchback_context_menu()
@@ -63,12 +59,6 @@ class Store:
         Logger.info(f"Remove watched playbacks is: {Store.remove_watched_playbacks}")
         Store.episode_force_browse = ADDON.getSettingBool('episode_force_browse')
         Logger.info(f"Episode force browse is: {Store.episode_force_browse}")
-
-    @staticmethod
-    def load_config_from_kodi_settings():
-        # Note: this is an int, not a bool — 0 = Never, 1 = 'If only one season', 2 = Always
-        Store.flatten_tvshows = int(get_kodi_setting('videolibrary.flattentvshows'))
-        Logger.info(f"Flatten TV Shows is: {Store.flatten_tvshows}")
 
     @staticmethod
     def update_switchback_context_menu():

--- a/plugin.switchback/resources/lib/switchback_plugin.py
+++ b/plugin.switchback/resources/lib/switchback_plugin.py
@@ -7,21 +7,39 @@ import xbmcplugin
 import xbmcgui
 
 from resources.lib.store import Store
-from bossanova808.constants import TRANSLATE
+from bossanova808.constants import TRANSLATE, KODI_MAJOR_VERSION
 from bossanova808.logger import Logger
 from bossanova808.notify import Notify
 
 
 # PVR HACK!
-# Needed to trigger live PVR playback with proper PVR controls.
-# See https://forum.kodi.tv/showthread.php?tid=381623
-def pvr_hack(path):
+# Needed to trigger live PVR playback with proper PVR controls (channel OSD, channel up/down etc)
+# for an *off-screen* resolve - i.e. only for the "switchback" mode below, which plays a specific
+# item with no user click for Kodi to hook into. A directly resolved-item ListItem/setResolvedUrl()
+# gives you basic playback, but never routes through Kodi's PVR-aware
+# CPVRGUIActionsPlayback::SwitchToChannel() path, so Kodi never activates the actual live-TV
+# session. This was a genuine Kodi core bug (not addon-side, and not just an Omega-era thing, as an
+# earlier pass at this assumed) - see https://github.com/xbmc/xbmc/issues/28877, fixed by
+# https://github.com/xbmc/xbmc/pull/28893, landing in Kodi 22 (Piers). So this hack is only used
+# below on Kodi < 22, where the underlying bug is still present.
+# NOT needed for the default list mode further below on any Kodi version - an on-screen click on a
+# pvr:// item there already routes through Kodi's native handling correctly on its own (and, per
+# testing, using this hack there instead causes a hard crash - so don't. See the same issue link
+# above for the crash report/discussion).
+def pvr_hack(path, resume=False):
+    """
+    :param path: the pvr:// channel or recording path to play
+    :param resume: for recordings, pass True to have Kodi apply its own tracked resume position
+        (see bossanova808 script.service.playbackresumer for the full story on why - the short
+        version: a manually-set resume position doesn't work reliably for PVR recordings, but
+        PlayMedia's own "resume" keyword, which asks Kodi to apply whatever position it's already
+        tracking for the item itself, does). Not meaningful for live channels - there's no
+        position to resume to.
+    """
     xbmc.PlayList(xbmc.PLAYLIST_VIDEO).clear()
     # Kodi is jonesing for one of these, so give it the sugar it needs, see: https://forum.kodi.tv/showthread.php?tid=381623&pid=3232778#pid3232778
     xbmcplugin.setResolvedUrl(int(sys.argv[1]), False, xbmcgui.ListItem())
-    # Get the full details from our stored playback
-    # pvr_playback = Store.switchback.find_playback_by_path(path)
-    builtin = f'PlayMedia("{path}")'
+    builtin = f'PlayMedia("{path}", resume)' if resume else f'PlayMedia("{path}")'
     Logger.debug("Work around PVR links not being handled by ListItem/setResolvedUrl - use PlayMedia instead:", builtin)
     # No ListItem to set a property on here, so set on the Home Window instead
     Store.update_home_window_switchback_property(path)
@@ -67,14 +85,32 @@ def run():
         Logger.debug(f"Path: [{switchback_to_play.path}]")
         Logger.debug(f"File: [{switchback_to_play.file}]")
         image = switchback_to_play.poster or switchback_to_play.icon
-        Notify.kodi_notification(f"{switchback_to_play.pluginlabel_short}", 3000, image)
+        at_timestamp = f" at {switchback_to_play.resume_timestamp}" if switchback_to_play.resume_timestamp else ""
+        if switchback_to_play.source == "pvr_live":
+            # Retuning live TV involves Kodi spinning up a full PVR session (buffering etc), which
+            # can take several seconds - call this out so it doesn't read as broken/unresponsive
+            notification_text = f"Re-tuning live TV: {switchback_to_play.pluginlabel_short} (this may take a moment)"
+        elif switchback_to_play.source == "pvr_recording":
+            notification_text = f"Resuming PVR Recording: {switchback_to_play.pluginlabel_short}{at_timestamp}"
+        elif at_timestamp:
+            notification_text = f"Resuming: {switchback_to_play.pluginlabel_short}{at_timestamp}"
+        else:
+            notification_text = switchback_to_play.pluginlabel_short
+        Notify.kodi_notification(notification_text, 3000, image)
 
-        # Short circuit here if PVR, see pvr_hack above.
-        if 'pvr://channels' in switchback_to_play.path:
-            pvr_hack(switchback_to_play.path)
+        # Short circuit here if PVR and we're on a Kodi still needing the PVR hack (see pvr_hack
+        # above). Kodi core PR https://github.com/xbmc/xbmc/pull/28893 (fixing
+        # https://github.com/xbmc/xbmc/issues/28877) resolves this properly from Piers (22) onwards
+        # (confirmed via testing against a pre-release Kodi build with the fix, all 4 PVR
+        # onscreen/offscreen x live/recording combinations working correctly, hack-free), so the
+        # hack is no longer used there, for either live or recordings. Recordings still need the
+        # hack pre-fix (with resume=True) - a directly resolved item doesn't reliably apply the
+        # resume position for a recording off-screen, same issue as live TV's controls.
+        if switchback_to_play.source in ("pvr_live", "pvr_recording") and KODI_MAJOR_VERSION < 22:
+            pvr_hack(switchback_to_play.path, resume=(switchback_to_play.source == "pvr_recording"))
             return
 
-        # Normal path for everything else
+        # Normal path for everything else (and for PVR on Kodi 22+)
         list_item = switchback_to_play.create_list_item_from_playback()
         list_item.setProperty('Switchback', switchback_to_play.path)
         # Store.update_home_window_switchback_property(switchback_to_play.path)
@@ -108,17 +144,6 @@ def run():
         Logger.debug("Force refreshing the container, so Kodi immediately displays the updated Switchback list")
         xbmc.executebuiltin("Container.Refresh")
 
-    # See pvr_hack(path) above
-    elif "pvr_hack" in modes:
-        path_values = parsed_arguments.get('path')
-        if not path_values or not path_values[0]:
-            Logger.error("Missing 'path' parameter for pvr_hack")
-            return
-        path = path_values[0]
-        Logger.debug(f"Triggering PVR Playback hack for {path}")
-        pvr_hack(path)
-        return
-
     # Default mode - show the whole Switchback List (each of which has a context menu option to delete itself)
     else:
         for index, playback in enumerate(Store.switchback.list[0:Store.maximum_list_length]):
@@ -127,20 +152,13 @@ def run():
             list_item.addContextMenuItems([(TRANSLATE(32004), "RunPlugin(plugin://plugin.switchback?mode=delete&index=" + str(index) + ")")])
             # For detecting Switchback playbacks (in player.py)
             list_item.setProperty('Switchback', playback.path)
-            # Use the 'proxy' URL if we're dealing with pvr_live and need to trigger the PVR playback hack
-            if playback.source == "pvr_live":
-                proxy_url = f"plugin://plugin.switchback?mode=pvr_hack&path={playback.path}"
-                Logger.debug(f"Creating directory item with pvr_hack proxy url: {proxy_url}")
-                xbmcplugin.addDirectoryItem(plugin_instance, proxy_url, list_item)
-                # TODO -> not sure if URL encoding needed in some cases?  Maybe CodeRabbit knows?
-                #     args = urlencode({'mode': 'pvr_hack', 'path': self.path})
-                #     proxy_url = f"plugin://plugin.switchback/?{args}"
-
-            # Otherwise use file for all Kodi library playbacks, and path for addons (as those may include tokens etc)
-            else:
-                url = playback.file if playback.source not in ["addon", "pvr_live"] else playback.path
-                # Logger.debug(f"Creating directory item with url: {url}")
-                xbmcplugin.addDirectoryItem(plugin_instance, url, list_item)
+            # No pvr_hack proxy here - an on-screen click on a pvr:// item routes through Kodi's own
+            # native PVR-aware handling correctly (proper controls, no crash) without our help. The
+            # hack is only needed for the "switchback" mode above, which resolves off-screen with no
+            # user click for Kodi to hook into. Use file for all Kodi library playbacks, and path for
+            # addons/PVR (as addon paths may include tokens etc, and PVR only has a path)
+            url = playback.file if playback.source not in ["addon", "pvr_live", "pvr_recording"] else playback.path
+            xbmcplugin.addDirectoryItem(plugin_instance, url, list_item)
 
         xbmcplugin.endOfDirectory(plugin_instance, cacheToDisc=False)
 


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Switchback
  - Add-on ID: plugin.switchback
  - Version number: 2.0.1
  - Kodi/repository version: nexus

- **Code location**
  - URL: https://github.com/bossanova808/plugin.switchback/
  

Kodi utility for fast switching between recently played media.
Keeps a list of recently played videos.
The primary intended use is to make for super easy Switchback between two in progress video. See Wiki for usage notes including how to bind remote/keyboard controls for instant Switchback.
Consider this scenario:
* You're watching 'video A' with your partner. You're interrupted, and your partner needs to tend to the kids/howl at the moon.
* You navigate to 'video B' and watch some of that while you're waiting.
* Your partner comes back.
* You hit your one button 'Switchback' and 'video A' instantly starts playing again - no need for tedious navigation etc.
* You're interrupted, again! The moon really is so very bright tonight. Hit your 'Switchback' button to instantly resume 'video B', again with no tedious navigation.
        

### Description of changes:

v2.0.1
- Playback tracking now uses a shared class from script.module.bossanova808, common with other addons
- Quick Switchback now resumes PVR live TV and recordings correctly, with proper channel controls
- On Kodi 22 (Piers) and newer, PVR live TV and recordings now resolve correctly with no workaround needed at all - including full channel controls for the Switchback list too, not just Quick Switchback - thanks to a Kodi core fix (https://github.com/xbmc/xbmc/pull/28893, fixing https://github.com/xbmc/xbmc/issues/28877). Older Kodi versions keep the previous behaviour.
- Fix a rare crash when saving the Switchback list on Windows
- Resume notifications now show a timestamp, distinguish live TV/recordings from other video, and note that retuning live TV may take a few seconds
- Fix duplicate list entries appearing for the same movie/episode/etc across repeated plays (could happen for addon-backed library items, e.g. Jellyfin, where the reported path can differ between plays)
- Faster list loading: halved the JSON-RPC calls needed to refresh a list of library items, and removed an unnecessary call on every list view
        

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
