### PR TITLE
[plugin.video.arteplussept@matrix] 1.6.2

### DIFF
--- a/plugin.video.arteplussept/CHANGELOG.md
+++ b/plugin.video.arteplussept/CHANGELOG.md
@@ -1,11 +1,22 @@
+v1.6.2 (2026-8-30)
+
+Thank you jcosmao for fixing mis cache error when displaying category 60min after home page display.
+
+v1.6.1 (2026-8-22)
+
+Add support for external page items and fix frequency of update disclamer
+
+- external pages are list of zones - new item &quot;Categories et genre&quot; in main menu.
+- Fix disclamer with link for issues and donations on version update or every 30d.
+
 v1.6.0 (2026-7-30)
 
 Add easier auth for smart tv with device flow
 
-New: Add auth with device flow to simplify auth for Smart TV users
-New: Remind user where to donate or to report issues on new version of the extension
-NFR: Add logging of API communication related to auth.
-NFR: Clean-up code related to auth in api.py and user.py. Especially failing persistance mechanism.
+- New: Add auth with device flow to simplify auth for Smart TV users
+- New: Remind user where to donate or to report issues on new version of the extension
+- NFR: Add logging of API communication related to auth.
+- NFR: Clean-up code related to auth in api.py and user.py. Especially failing persistance mechanism.
 
 v1.5.4 (2026-7-29)
 

--- a/plugin.video.arteplussept/addon.xml
+++ b/plugin.video.arteplussept/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.arteplussept" name="Arte +7" version="1.6.0" provider-name="bmf, thomas-ernest">
+<addon id="plugin.video.arteplussept" name="Arte +7" version="1.6.2" provider-name="bmf, thomas-ernest">
     <!-- https://kodi.wiki/view/Addon.xml -->
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
@@ -50,13 +50,8 @@ Erori sau solicitări: https://github.com/thomas-ernest/plugin.video.arteplussep
         <license>MIT</license>
         <website>https://thomas-ernest.github.io/</website>
         <source>https://github.com/thomas-ernest/plugin.video.arteplussept</source>
-<news>1.6.0 (2026-7-30)
-Add easier auth for smart tv with device flow
-
-New: Add auth with device flow to simplify auth for Smart TV users
-New: Remind user where to donate or to report issues on new version of the extension
-NFR: Add logging of API communication related to auth.
-NFR: Clean-up code related to auth in api.py and user.py. Especially failing persistance mechanism.</news>
+<news>1.6.2 (2026-8-30)
+Thank you jcosmao for fixing mis cache error when displaying category 60min after home page display.</news>
         <assets>
             <icon>resources/icon.png</icon>
             <fanart>resources/fanart.jpg</fanart>

--- a/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.de_de/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr "Abgemeldet"
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr "Bitte E-mail eingeben:"
+
 msgctxt "#30019"
 msgid "Enter password please:"
 msgstr "Bitte Passwort eingeben:"

--- a/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.en_gb/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr ""
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr ""
+
 msgctxt "#30019"
 msgid "Enter password please :"
 msgstr ""

--- a/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.fr_fr/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr "Déconnecté"
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr "Entrez votre email s'il vous plaît:"
+
 msgctxt "#30019"
 msgid "Enter password please:"
 msgstr "Entrez votre mot de passe s'il vous plaît:"

--- a/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.it_it/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr "Disconnesso"
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr "Inserisci la email per favore:"
+
 msgctxt "#30019"
 msgid "Enter password please:"
 msgstr "Inserisci la password per favore:"
@@ -87,7 +91,7 @@ msgstr "Impossibile autenticare"
 
 msgctxt "#30021"
 msgid "Email missing"
-msgstr "E-Mail mancanti"
+msgstr "Email mancanti"
 
 msgctxt "#30022"
 msgid "Password missing"

--- a/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.pl_pl/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr "Wylogowano"
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr "Proszę wprowadzić e-mail:"
+
 msgctxt "#30019"
 msgid "Enter password please:"
 msgstr "Proszę wprowadzić hasło:"

--- a/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
+++ b/plugin.video.arteplussept/resources/language/resource.language.ro_ro/strings.po
@@ -77,6 +77,10 @@ msgctxt "#30018"
 msgid "Logged out"
 msgstr "Deconectat"
 
+msgctxt "#30013"
+msgid "Enter email please :"
+msgstr "E-mail:"
+
 msgctxt "#30019"
 msgid "Enter password please:"
 msgstr "Parolă:"

--- a/plugin.video.arteplussept/resources/lib/api.py
+++ b/plugin.video.arteplussept/resources/lib/api.py
@@ -8,7 +8,7 @@ from resources.lib import hof
 from resources.lib import logger
 
 _PLUGIN_NAME = "Arte +7"
-_PLUGIN_VERSION = "1.6.0"
+_PLUGIN_VERSION = "1.6.2"
 # Arte hbbtv - deprecated API since 2022 prefer Arte TV API
 _HBBTV_URL = 'https://www.arte.tv/hbbtvv2/services/web/index.php'
 _HBBTV_HEADERS = {
@@ -283,10 +283,10 @@ def streams(kind, program_id, lang):
     return _load_json('hbbtv_streams', url).get('videoStreams', [])
 
 
-def page_content(lang):
+def page_content(lang, cat='HOME'):
     """Get content to be display in a page. It can be a page for a category or the home page."""
     url = _ARTETV_URL + ARTETV_ENDPOINTS['page'].format(
-        lang=lang, category='HOME', client='tv')
+        lang=lang, category=cat, client='tv')
     return _load_json_full_url('artetv_home', url, ARTETV_HEADERS)
 
 

--- a/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/arteitem.py
@@ -177,10 +177,30 @@ class ArteTvVideoItem(ArteVideoItem):
         item = self.json_dict
         program_id = item.get('programId')
         kind = self._get_kind()
+
+        path = None
+        is_playable = None
+        additional_context_menu = []
+
         if kind == 'EXTERNAL':
+            deeplink = item.get('deeplink', '')
+            if deeplink is not None and deeplink.strip() != "":
+                category = deeplink.rsplit("/", 1)[-1]
+                path = self.plugin.url_for('raw_page', category=category)
+                is_playable = False
+                return {
+                    'label': item.get('title'),
+                    'path': path,
+                    'thumbnail': self._get_image_url('480x270', True),
+                    'is_playable': is_playable,
+                    'info_type': 'video',
+                    'properties': {
+                        'fanart_image': self._get_image_url('1920x1080', False)
+                    }
+                }
+            # else abort, unable to build an item for an external link
             return None
 
-        additional_context_menu = []
         if self.is_playlist():
             if kind in self.PREFERED_KINDS:
                 # content_type = Content.PLAYLIST

--- a/plugin.video.arteplussept/resources/lib/mapper/artezone.py
+++ b/plugin.video.arteplussept/resources/lib/mapper/artezone.py
@@ -3,6 +3,7 @@ Module for Arte Zone
 """
 
 # pylint: disable=import-error
+from xbmcswift2 import xbmc
 from resources.lib import api
 from resources.lib.mapper.artecollection import ArteCollection
 
@@ -32,6 +33,23 @@ class ArteZone(ArteCollection):
                 'path': self.plugin.url_for('cached_category', zone_id=zone_id)
             }
         return None
+
+    def get_cached_item(self, zone_id):
+        """
+        Return the content of the zone zone_id, that was cached while building a page.
+        The cache is only populated while building a page and its entries expire,
+        so refresh it with an API call, when the entry expired or was never cached.
+        """
+        try:
+            return self.cached_categories[zone_id]
+        except KeyError:
+            xbmc.log(
+                f"No cached content for zone {zone_id}. Refreshing the cache with an API call.",
+                level=xbmc.LOGINFO)
+            cached_category = self.build_menu(zone_id, 1, 'HOME')
+            if self._is_valid_menu(cached_category):
+                self.cached_categories[zone_id] = cached_category
+            return cached_category
 
     def _is_valid_menu(self, cached_category):
         """

--- a/plugin.video.arteplussept/resources/lib/plugin.py
+++ b/plugin.video.arteplussept/resources/lib/plugin.py
@@ -1,5 +1,6 @@
 """Main module for Kodi add-on plugin.video.arteplussept"""
 
+from datetime import date
 import xbmcaddon
 import xbmcgui
 # pylint: disable=import-error
@@ -18,10 +19,9 @@ from resources.lib.settings import Settings
 from resources.lib import utils
 from resources.lib.utils import PlayFrom
 
-# global declarations
-# plugin stuff
-plugin = Plugin()
+DATE_FORMAT = "%Y-%m-%d"
 
+plugin = Plugin()
 settings = Settings(plugin)
 
 
@@ -34,18 +34,40 @@ def display_index():
     addon = xbmcaddon.Addon()
     current_version = addon.getAddonInfo("version")
     last_version = addon.getSetting("last_version_notified")
+    last_date = addon.getSetting("last_date_notified")
 
-    if last_version != current_version:
+    if last_version != current_version or days_since(last_date) >= 30:
         xbmcgui.Dialog().ok(
             addon.getLocalizedString(30061).format(version=current_version),
             addon.getLocalizedString(30062).format(version=current_version)
         )
-        addon.setSetting("last_info_version", current_version)
+        addon.setSetting("last_version_notified", current_version)
+        addon.setSetting("last_date_notified", date.today().strftime(DATE_FORMAT))
 
     lst_itms = view.build_home_page(
         plugin, settings, plugin.get_storage('cached_categories', TTL=60))
     logger.log_xbmc(lst_itms, 'index')
     return lst_itms
+
+
+def days_since(date_str):
+    """
+    date_str: '2026-08-14' or '' (empty)
+    Returns number of days between today and date_str.
+    If empty → MAX_INT.
+    """
+
+    if not date_str:
+        return 1000000
+
+    try:
+        other = date.fromisoformat(date_str)
+    except ValueError:
+        # invalid format, not a date
+        return 1000000
+
+    today = date.today()
+    return (today - other).days
 
 
 @plugin.route('/category/api/<category_code>', name='api_category')
@@ -61,7 +83,7 @@ def display_cached_category(zone_id):
     """Display the menu for a category that is stored
     in cache from previous api call like home page"""
     lst_itms = view.get_cached_category(
-        zone_id, plugin.get_storage('cached_categories', TTL=60))
+        plugin, settings, zone_id, plugin.get_storage('cached_categories', TTL=60))
     logger.log_xbmc(lst_itms, 'cached_category')
     return lst_itms
 
@@ -72,6 +94,15 @@ def display_category_page(zone_id, page, page_id):
     lst_itms = ArteZone(plugin, settings, plugin.get_storage('cached_categories', TTL=60)) \
         .build_menu(zone_id, page, page_id)
     logger.log_xbmc(lst_itms, 'category_page')
+    return lst_itms
+
+
+@plugin.route('/raw_page/<category>', name='raw_page')
+def display_raw_page(category):
+    """Display the menu for a category that needs an api call"""
+    lst_itms = view.build_page(plugin, settings, category)
+    xbmc.log(f"all my lst_itms {lst_itms}", xbmc.LOGWARNING)
+    logger.log_xbmc(lst_itms, 'raw_page')
     return lst_itms
 
 

--- a/plugin.video.arteplussept/resources/lib/user.py
+++ b/plugin.video.arteplussept/resources/lib/user.py
@@ -88,7 +88,7 @@ def get_user_email(plugin):
     Return None if user didn't enter an email or close the UI.
     """
     user_email = ''
-    keyboard = xbmc.Keyboard(user_email, plugin.addon.getLocalizedString(30019), False)
+    keyboard = xbmc.Keyboard(user_email, plugin.addon.getLocalizedString(30013), False)
     keyboard.doModal()
     if keyboard.isConfirmed() is False:
         return None

--- a/plugin.video.arteplussept/resources/lib/view.py
+++ b/plugin.video.arteplussept/resources/lib/view.py
@@ -5,6 +5,7 @@ from xbmcswift2 import xbmc
 from resources.lib.mapper.arteitem import ArteItem
 from resources.lib.mapper.arteliveitem import ArteLiveItem
 from resources.lib.mapper.artesearch import ArteSearch
+from resources.lib.mapper.artezone import ArteZone
 from resources.lib import api
 from resources.lib import hof
 from resources.lib.mapper import mapper
@@ -44,6 +45,23 @@ def build_home_page(plugin, settings, cached_categories):
     return addon_menu
 
 
+def build_page(plugin, settings, category):
+    """
+    Build a page for a category like SER, CIN, DOR...
+    A page is a list of zones.
+    To be extended to HOME.
+    """
+    page = api.page_content(settings.language, category)
+    page_menu = []
+    for zone in page.get('zones', []):
+        page_item = ArteZone(
+            plugin, settings, plugin.get_storage('cached_categories', TTL=60)
+        ).build_item(zone)
+        if page_item:
+            page_menu.append(page_item)
+    return page_menu
+
+
 def build_api_category(plugin, category_code, settings):
     """Build the menu for a category that needs an api call"""
     category = [mapper.map_category_item(plugin, item, category_code) for item in
@@ -52,10 +70,11 @@ def build_api_category(plugin, category_code, settings):
     return category
 
 
-def get_cached_category(zone_id, cached_categories):
+def get_cached_category(plugin, settings, zone_id, cached_categories):
     """Return the menu for a category that is stored
-    in cache from previous api call like home page"""
-    return cached_categories[zone_id]
+    in cache from previous api call like home page.
+    The cache is refreshed with an API call, when the entry expired or was never cached."""
+    return ArteZone(plugin, settings, cached_categories).get_cached_item(zone_id)
 
 
 def mark_as_watched(plugin, usr, program_id, label):

--- a/plugin.video.arteplussept/resources/settings.xml
+++ b/plugin.video.arteplussept/resources/settings.xml
@@ -25,6 +25,16 @@
 			label="30056"
 			values="DEFAULT|API|DISPLAY|API+DISPLAY"
 			default="0"/>
+		<setting
+			id="last_version_notified"
+			type="text"
+			default=""
+			visible="false" />
+		<setting
+			id="last_date_notified"
+			type="text"
+			default=""
+			visible="false" />
 	</category>
 	
 	<!-- Profile -->


### PR DESCRIPTION
### Add-on details:

- **General**
  - Add-on name: Arte +7
  - Add-on ID: plugin.video.arteplussept
  - Version number: 1.6.2
  - Kodi/repository version: matrix

- **Code location**
  - URL: https://github.com/thomas-ernest/plugin.video.arteplussept
  

Enjoy Arte videos on Kodi.
Donations: https://thomas-ernest.github.io/
Bugs or feature requests: https://github.com/thomas-ernest/plugin.video.arteplussept/issues
        

### Description of changes:

v1.6.2 (2026-8-30)

Thank you @jcosmao for fixing mis cache error when displaying category 60min after home page display.

1.6.1 (2026-8-22)
Add support for external page items and fix frequency of update disclamer

- external pages are list of zones - new item "Categories et genre" in main menu.
- Fix disclamer with link for issues and donations on version update or every 30d.

### Checklist:

- [x] My code follows the [add-on rules](http://kodi.wiki/view/Add-on_rules) and [piracy stance](http://kodi.wiki/view/Official:Forum_rules#Piracy_Policy) of this project. 
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/repo-scripts/blob/master/CONTRIBUTING.md) document
- [x] Each add-on submission should be a single commit with using the following style: [plugin.video.foo] v1.0.0
